### PR TITLE
Temporarily disable remote tests

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -62,7 +62,8 @@ function run_tests_without_coverage() {
 
   make docker-test-migration
   make docker-test-integration-no-coverage
-  make docker-test-remote-no-coverage
+  # Temporarily disabled. See https://github.com/almighty/keycloak/issues/47
+  #make docker-test-remote-no-coverage
   echo "CICO: ran tests without coverage"
 }
 
@@ -89,7 +90,8 @@ function run_tests_with_coverage() {
   make docker-test-integration
 
   # Run the remote tests that generate coverage information
-  make docker-test-remote
+  # Temporarily disabled. See https://github.com/almighty/keycloak/issues/47
+  #make docker-test-remote
 
   # Output coverage
   make docker-coverage-all


### PR DESCRIPTION
KC in prod-preview cluster is currently super slow because of issues with distributed cache in KC cluster.
See https://github.com/almighty/keycloak/issues/47 and https://github.com/almighty/keycloak/issues/52

This PR is temporarily disabling the remote tests until we fix the problem with KC in prod-preview.
