### PR TITLE
fix(space-codebases): panic when stackId is nil

### DIFF
--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -108,7 +108,7 @@ type Codebase struct {
 	SpaceID           uuid.UUID `sql:"type:uuid"`
 	Type              string
 	URL               string
-	StackID           string
+	StackID           *string
 	LastUsedWorkspace string
 }
 

--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -100,7 +100,7 @@ func newCodebase(spaceID uuid.UUID, stackID, lastUsedWorkspace, repotype, url st
 		SpaceID:           spaceID,
 		Type:              repotype,
 		URL:               url,
-		StackID:           stackID,
+		StackID:           &stackID,
 		LastUsedWorkspace: lastUsedWorkspace,
 	}
 }
@@ -169,6 +169,6 @@ func (test *TestCodebaseRepository) TestLoadCodebase() {
 	loadedCodebase, err := repo.Load(context.Background(), codebase.ID)
 	require.Nil(test.T(), err)
 	assert.Equal(test.T(), codebase.ID, loadedCodebase.ID)
-	assert.Equal(test.T(), "golang-default", loadedCodebase.StackID)
+	assert.Equal(test.T(), "golang-default", *loadedCodebase.StackID)
 	assert.Equal(test.T(), "my-used-last-workspace", loadedCodebase.LastUsedWorkspace)
 }

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -136,8 +136,8 @@ func (c *CodebaseController) Create(ctx *app.CreateCodebaseContext) error {
 	}
 	cheClient := che.NewStarterClient(c.config.GetCheStarterURL(), c.config.GetOpenshiftTenantMasterURL(), getNamespace(ctx))
 
-	stackID := cb.StackID
-	if cb.StackID == "" {
+	stackID := *cb.StackID
+	if cb.StackID == nil || *cb.StackID == "" {
 		stackID = "java-centos"
 	}
 	workspace := che.WorkspaceRequest{
@@ -266,7 +266,7 @@ func ConvertCodebase(request *goa.RequestData, codebase *codebase.Codebase, addi
 			CreatedAt:         &codebase.CreatedAt,
 			Type:              &codebase.Type,
 			URL:               &codebase.URL,
-			StackID:           &codebase.StackID,
+			StackID:           codebase.StackID,
 			LastUsedWorkspace: &codebase.LastUsedWorkspace,
 		},
 		Relationships: &app.CodebaseRelations{

--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -91,12 +91,13 @@ func requireSpaceAndCodebase(t *testing.T, db *gormapplication.GormDB, ID, space
 		}
 		_, err := appl.Spaces().Create(context.Background(), s)
 		require.Nil(t, err)
+		stackId := "golang-default"
 		c = &codebase.Codebase{
 			ID:                ID,
 			SpaceID:           spaceID,
 			Type:              "git",
 			URL:               "https://github.com/fabric8-services/fabric8-wit.git",
-			StackID:           "golang-default",
+			StackID:           &stackId,
 			LastUsedWorkspace: "my-last-used-workspace",
 		}
 		err = appl.Codebases().Create(context.Background(), c)

--- a/controller/space_codebases.go
+++ b/controller/space_codebases.go
@@ -54,7 +54,7 @@ func (c *SpaceCodebasesController) Create(ctx *app.CreateSpaceCodebasesContext) 
 			SpaceID: ctx.SpaceID,
 			Type:    *reqIter.Attributes.Type,
 			URL:     *reqIter.Attributes.URL,
-			StackID: *reqIter.Attributes.StackID,
+			StackID: reqIter.Attributes.StackID,
 		}
 		err = appl.Codebases().Create(ctx, &newCodeBase)
 		if err != nil {


### PR DESCRIPTION
* Please describe what your change is about.
Spacecodebases could be created with nil stackId.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
Fixes https://github.com/almighty/almighty-core/issues/1430
* If you are still working on the change please prefix the pull request title with "WIP"
