### PR TITLE
Restore removed test (#1453)

### DIFF
--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -1719,6 +1719,10 @@ func assertResponseHeaders(t *testing.T, res http.ResponseWriter) (string, strin
 }
 
 // Temporarly disabled, See https://github.com/fabric8-services/fabric8-wit/issues/1036
+func (s *WorkItem2Suite) TestWI2FailShowMissing() {
+	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, uuid.NewV4(), nil, nil)
+}
+
 func (s *WorkItem2Suite) TestWI2FailOnDelete() {
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -1718,7 +1718,6 @@ func assertResponseHeaders(t *testing.T, res http.ResponseWriter) (string, strin
 	return etag[0], lastModified[0], cacheControl[0]
 }
 
-// Temporarly disabled, See https://github.com/fabric8-services/fabric8-wit/issues/1036
 func (s *WorkItem2Suite) TestWI2FailShowMissing() {
 	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, uuid.NewV4(), nil, nil)
 }

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -299,7 +299,7 @@ func (s *TrackerItemRepositorySuite) TestConvertGithubIssue() {
 	// when
 	workItemGithub, err := convertToWorkItemModel(s.ctx, s.DB, int(s.trackerQuery.ID), remoteItemDataGithub, ProviderGithub, s.trackerQuery.SpaceID)
 	// then
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), "map flatten : test case : with assignee", workItemGithub.Fields[workitem.SystemTitle])
 	assert.Equal(s.T(), identity.ID.String(), workItemGithub.Fields[workitem.SystemCreator])
 	assert.Equal(s.T(), identity.ID.String(), workItemGithub.Fields[workitem.SystemAssignees].([]interface{})[0])


### PR DESCRIPTION
Also replace a `assert.Nil` with `require.Nil` in another test.

Fixes #1453

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

