### PR TITLE
WIP : Return RPT token in response whenever it is generated from SSO server

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -10,12 +10,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/workitem"
-
-<<<<<<< HEAD
-=======
-	"context"
-
->>>>>>> 72a6d9b... add token to response and start using limit
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"

--- a/account/user.go
+++ b/account/user.go
@@ -11,6 +11,11 @@ import (
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 
+<<<<<<< HEAD
+=======
+	"context"
+
+>>>>>>> 72a6d9b... add token to response and start using limit
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -206,4 +211,9 @@ func UserFilterByEmail(email string) func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("email = ?", email)
 	}
+}
+
+// GetRecentUserSpaces returns the list of spaces recently accessed by the user
+func GetRecentUserSpaces(userID uuid.UUID) *[]uuid.UUID {
+	return nil
 }

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -143,7 +143,12 @@ type UserInfo struct {
 
 // EntitlementResource represents a payload for obtaining entitlement for specific resource
 type EntitlementResource struct {
-	Permissions []ResourceSet `json:"permissions"`
+	Permissions     []ResourceSet   `json:"permissions"`
+	MetaInformation EntitlementMeta `json:"metadata"`
+}
+
+type EntitlementMeta struct {
+	Limit string `json:"limit"`
 }
 
 // ResourceSet represents a resource set for Entitlement payload
@@ -177,8 +182,12 @@ type Permissions struct {
 func VerifyResourceUser(ctx context.Context, token string, resourceName string, entitlementEndpoint string) (bool, error) {
 	resource := EntitlementResource{
 		Permissions: []ResourceSet{{Name: resourceName}},
+		MetaInformation: EntitlementMeta{
+			Limit: "5",
+		},
 	}
 	ent, err := GetEntitlement(ctx, entitlementEndpoint, &resource, token)
+
 	if err != nil {
 		return false, err
 	}
@@ -645,6 +654,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 	var reqErr error
 	if entitlementResource != nil {
 		b, err := json.Marshal(entitlementResource)
+		fmt.Println(string(b))
 		if err != nil {
 			log.Error(ctx, map[string]interface{}{
 				"entitlement_resource": entitlementResource,

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -208,8 +208,6 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 		}, "unable to marshal keycloak resource struct")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to marshal keycloak resource struct"))
 	}
-	fmt.Println(string(b))
-	fmt.Println(authzEndpoint)
 
 	req, err := http.NewRequest("POST", authzEndpoint, strings.NewReader(string(b)))
 	if err != nil {
@@ -268,7 +266,6 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
-	fmt.Println(clientsEndpoint)
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -312,7 +309,6 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 // CreatePolicy creates a Keycloak policy
 func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, policy KeycloakPolicy, protectionAPIToken string) (string, error) {
 	b, err := json.Marshal(policy)
-	fmt.Println(string(b))
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"policy": policy,
@@ -320,7 +316,6 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		}, "unable to marshal keycloak policy struct")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to marshal keycloak policy struct"))
 	}
-	fmt.Println(clientsEndpoint + "/" + clientID + "/authz/resource-server/policy")
 	req, err := http.NewRequest("POST", clientsEndpoint+"/"+clientID+"/authz/resource-server/policy", strings.NewReader(string(b)))
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -654,7 +649,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 	var reqErr error
 	if entitlementResource != nil {
 		b, err := json.Marshal(entitlementResource)
-		fmt.Println(string(b))
+		fmt.Println(string(b)) //temporary
 		if err != nil {
 			log.Error(ctx, map[string]interface{}{
 				"entitlement_resource": entitlementResource,

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -199,6 +199,8 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 		}, "unable to marshal keycloak resource struct")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to marshal keycloak resource struct"))
 	}
+	fmt.Println(string(b))
+	fmt.Println(authzEndpoint)
 
 	req, err := http.NewRequest("POST", authzEndpoint, strings.NewReader(string(b)))
 	if err != nil {
@@ -257,6 +259,7 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
+	fmt.Println(clientsEndpoint)
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -300,6 +303,7 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 // CreatePolicy creates a Keycloak policy
 func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, policy KeycloakPolicy, protectionAPIToken string) (string, error) {
 	b, err := json.Marshal(policy)
+	fmt.Println(string(b))
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"policy": policy,
@@ -307,7 +311,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		}, "unable to marshal keycloak policy struct")
 		return "", errors.NewInternalError(ctx, errs.Wrap(err, "unable to marshal keycloak policy struct"))
 	}
-
+	fmt.Println(clientsEndpoint + "/" + clientID + "/authz/resource-server/policy")
 	req, err := http.NewRequest("POST", clientsEndpoint+"/"+clientID+"/authz/resource-server/policy", strings.NewReader(string(b)))
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -694,19 +694,19 @@ OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
 	// RSAPublicKey for verifying JWT Tokens
 	// openssl rsa -in alm_rsa -pubout -out alm_rsa.pub
 	defaultTokenPublicKey = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvQ8p+HsTMrgcsuIMoOR1
-LXRhynL9YAU0qoDON6PLKCpdBv0Xy/jnsPjo5DrtUOijuJcID8CR7E0hYpY9MgK5
-H5pDFwC4lbUVENquHEVS/E0pQSKCIzSmORcIhjYW2+wKfDOVjeudZwdFBIxJ6KpI
-ty/aF78hlUJZuvghFVqoHQYTq/DZOmKjS+PAVLw8FKE3wa/3WU0EkpP+iovRMCkl
-lzxqrcLPIvx+T2gkwe0bn0kTvdMOhTLTN2tuvKrFpVUxVi8RM/V8PtgdKroxnES7
-SyUqK8rLO830jKJzAYrByQL+sdGuSqInIY/geahQHEGTwMI0CLj6zfhpjSgCflst
-vwIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzDvrcYlz8SQFY2Y6OKHN
+im3pMinvY46rem8eWm/SYGdG4gpkx7UjVD3JTI65gSfKO0L+OTGK1xTIUO3tA3ji
+H4NB1RtEGLGJMCtafeyZ3x0UnCKiw0YW4b8jYm/XtrX39aoSyUuLlPU0o3Jdn/0f
+cv/kM0+fElCKwjtdftvROlW6wCj3+k6Z7PiJpKGIBnOZ40gwjRj79pGvCGFk2CYc
+F1WC2Bu9qtVcZXGfhdpgBBvAw5slH8iztEiMBTm9xTs7S+lG5FeMxas6uzKXAGBL
+R6WowwXkce3+vHsVpwgy62RFlSV0StNggt06+oVqGotwZdnZU43qdRWyDpsfdR8F
+5wIDAQAB
 -----END PUBLIC KEY-----`
 
 	defaultLogLevel = "info"
 
 	defaultKeycloakClientID = "fabric8-online-platform"
-	defaultKeycloakSecret   = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"
+	defaultKeycloakSecret   = "cd382c22-5445-48f7-9c5f-78752963cdfa"
 
 	defaultKeycloakDomainPrefix = "sso"
 	defaultKeycloakRealm        = "fabric8"
@@ -720,8 +720,8 @@ vwIDAQAB
 	defaultKeycloakTesUser2Secret = "testuser2"
 
 	// Keycloak vars to be used in dev mode. Can be overridden by setting up keycloak.url & keycloak.realm
-	devModeKeycloakURL   = "https://sso.prod-preview.openshift.io"
-	devModeKeycloakRealm = "fabric8-test"
+	devModeKeycloakURL   = "http://keycloak-keycloak3-2.dev.rdu2c.fabric8.io"
+	devModeKeycloakRealm = "fabric8"
 
 	defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
 	defaultCheStarterURL            = "che-server"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -706,7 +706,7 @@ R6WowwXkce3+vHsVpwgy62RFlSV0StNggt06+oVqGotwZdnZU43qdRWyDpsfdR8F
 	defaultLogLevel = "info"
 
 	defaultKeycloakClientID = "fabric8-online-platform"
-	defaultKeycloakSecret   = "cd382c22-5445-48f7-9c5f-78752963cdfa"
+	defaultKeycloakSecret   = "4c4346a0-d9a9-4d54-a74c-18e892e59f58"
 
 	defaultKeycloakDomainPrefix = "sso"
 	defaultKeycloakRealm        = "fabric8"

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -122,10 +122,17 @@ func (c *CollaboratorsController) Add(ctx *app.AddCollaboratorsContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	response := app.UserList{
-		Meta: &app.UserListMeta{TotalCount: 0, Token: &rptToken},
+
+	// Convert the token string to a nice object for marshal<->unmarshal
+	tokenPayload, err := auth.ConvertRPTStringToTokenPayload(ctx, rptToken)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	return ctx.OK(&response)
+
+	// Convert to the exposed AuthToken format.
+	appAuthToken := convertRPT(*tokenPayload, rptToken)
+
+	return ctx.OK(appAuthToken)
 }
 
 // AddMany adds user's identities to the list of space collaborators.
@@ -139,10 +146,16 @@ func (c *CollaboratorsController) AddMany(ctx *app.AddManyCollaboratorsContext) 
 		}
 	}
 
-	response := app.UserList{
-		Meta: &app.UserListMeta{TotalCount: 0, Token: &rptToken},
+	// Convert the token string to a nice object for marshal<->unmarshal
+	tokenPayload, err := auth.ConvertRPTStringToTokenPayload(ctx, rptToken)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	return ctx.OK(&response)
+
+	// Convert to the exposed AuthToken format.
+	appAuthToken := convertRPT(*tokenPayload, rptToken)
+
+	return ctx.OK(appAuthToken)
 }
 
 // Remove user from the list of space collaborators.
@@ -160,10 +173,16 @@ func (c *CollaboratorsController) Remove(ctx *app.RemoveCollaboratorsContext) er
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	response := app.UserList{
-		Meta: &app.UserListMeta{TotalCount: 0, Token: &rptToken},
+	// Convert the token string to a nice object for marshal<->unmarshal
+	tokenPayload, err := auth.ConvertRPTStringToTokenPayload(ctx, rptToken)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	return ctx.OK(&response)
+
+	// Convert to the exposed AuthToken format.
+	appAuthToken := convertRPT(*tokenPayload, rptToken)
+
+	return ctx.OK(appAuthToken)
 }
 
 // RemoveMany removes users from the list of space collaborators.
@@ -185,10 +204,16 @@ func (c *CollaboratorsController) RemoveMany(ctx *app.RemoveManyCollaboratorsCon
 		}
 	}
 
-	response := app.UserList{
-		Meta: &app.UserListMeta{TotalCount: 0, Token: &rptToken},
+	// Convert the token string to a nice object for marshal<->unmarshal
+	tokenPayload, err := auth.ConvertRPTStringToTokenPayload(ctx, rptToken)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	return ctx.OK(&response)
+
+	// Convert to the exposed AuthToken format.
+	appAuthToken := convertRPT(*tokenPayload, rptToken)
+
+	return ctx.OK(appAuthToken)
 }
 
 func (c *CollaboratorsController) checkSpaceOwner(ctx context.Context, spaceID uuid.UUID, identityID string) error {
@@ -319,3 +344,22 @@ func (c *CollaboratorsController) getPolicy(ctx collaboratorContext, req *goa.Re
 	}
 	return policy, pat, nil
 }
+
+/*
+func useRPT(ctx collaboratorContext, rpt *string) *jwt.Token {
+	jwttoken := goajwt.ContextJWT(ctx)
+	tokenWithClaims, err := jwt.ParseWithClaims(jwttoken.Raw, &auth.TokenPayload{}, func(t *jwt.Token) (interface{}, error) {
+		return tm.(token.Manager).PublicKey(), nil
+	})
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"space-id": spaceID,
+			"err":      err,
+		}, "unable to parse the rpt token")
+		return false, errors.NewInternalError(ctx, errs.Wrap(err, "unable to parse the rpt token"))
+	}
+	claims := tokenWithClaims.Claims.(*auth.TokenPayload)
+
+	return jwttoken
+}
+*/

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -41,7 +41,7 @@ type DummySpaceAuthzService struct {
 	rest *TestCollaboratorsREST
 }
 
-func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (bool, error) {
+func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string, rptToken *string) (bool, error) {
 	jwtToken := goajwt.ContextJWT(ctx)
 	if jwtToken == nil {
 		return false, errors.NewUnauthorizedError("Missing token")
@@ -565,7 +565,7 @@ type TestSpaceAuthzService struct {
 	owner account.Identity
 }
 
-func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (bool, error) {
+func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string, rptToken *string) (bool, error) {
 	jwtToken := goajwt.ContextJWT(ctx)
 	if jwtToken == nil {
 		return false, errors.NewUnauthorizedError("Missing token")

--- a/controller/comments.go
+++ b/controller/comments.go
@@ -102,7 +102,8 @@ func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
 		return c.performUpdate(ctx, cm, identityID)
 	}
 
-	authorized, err := authz.Authorize(ctx, wi.SpaceID.String())
+	var rptToken string
+	authorized, err := authz.Authorize(ctx, wi.SpaceID.String(), &rptToken)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -171,7 +172,8 @@ func (c *CommentsController) Delete(ctx *app.DeleteCommentsContext) error {
 		return c.performDelete(ctx, cm, identityID)
 	}
 
-	authorized, err := authz.Authorize(ctx, wi.SpaceID.String())
+	var rptToken string
+	authorized, err := authz.Authorize(ctx, wi.SpaceID.String(), &rptToken)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}

--- a/controller/login.go
+++ b/controller/login.go
@@ -189,6 +189,16 @@ func convertToken(token auth.Token) *app.AuthToken {
 	}}
 }
 
+func convertRPT(token auth.TokenPayload, rawRPT string) *app.AuthToken {
+
+	return &app.AuthToken{Token: &app.TokenData{
+		ExpiresIn:        token.ExpiresAt,
+		RefreshExpiresIn: token.ExpiresAt, // temporary, this needs to be set from access token
+		AccessToken:      &rawRPT,
+		NotBeforePolicy:  token.NotBefore,
+	}}
+}
+
 // Link links identity provider(s) to the user's account
 func (c *LoginController) Link(ctx *app.LinkLoginContext) error {
 	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.RequestData)

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -140,7 +140,8 @@ func authorizeWorkitemEditor(ctx context.Context, db application.DB, spaceID uui
 	if editorID == creatorID {
 		return true, nil
 	}
-	authorized, err := authz.Authorize(ctx, spaceID.String())
+	var rptToken string
+	authorized, err := authz.Authorize(ctx, spaceID.String(), &rptToken)
 	if err != nil {
 		return false, errors.NewUnauthorizedError(err.Error())
 	}
@@ -212,7 +213,9 @@ func (c *WorkitemController) Reorder(ctx *app.ReorderWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	authorized, err := authz.Authorize(ctx, ctx.SpaceID.String())
+
+	var rptToken string
+	authorized, err := authz.Authorize(ctx, ctx.SpaceID.String(), &rptToken)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -339,7 +342,8 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	authorized, err := authz.Authorize(ctx, ctx.SpaceID.String())
+	var rptToken string
+	authorized, err := authz.Authorize(ctx, ctx.SpaceID.String(), &rptToken)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}

--- a/design/account.go
+++ b/design/account.go
@@ -63,6 +63,7 @@ var userArray = a.MediaType("application/vnd.user-array+json", func() {
 
 var userListMeta = a.Type("UserListMeta", func() {
 	a.Attribute("totalCount", d.Integer)
+	a.Attribute("token", d.String)
 	a.Required("totalCount")
 })
 

--- a/design/collaborators.go
+++ b/design/collaborators.go
@@ -32,7 +32,7 @@ var _ = a.Resource("collaborators", func() {
 			a.POST(""),
 		)
 		a.Description("Add users to the list of space collaborators.")
-		a.Response(d.OK, userList)
+		a.Response(d.OK, AuthToken)
 		a.Payload(updateUserIDList)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -46,7 +46,7 @@ var _ = a.Resource("collaborators", func() {
 			a.POST("/:identityID"),
 		)
 		a.Description("Add a user to the list of space collaborators.")
-		a.Response(d.OK, userList)
+		a.Response(d.OK, AuthToken)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
@@ -59,7 +59,7 @@ var _ = a.Resource("collaborators", func() {
 			a.DELETE(""),
 		)
 		a.Description("Remove users form the list of space collaborators.")
-		a.Response(d.OK, userList)
+		a.Response(d.OK, AuthToken)
 		a.Payload(updateUserIDList)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -73,7 +73,7 @@ var _ = a.Resource("collaborators", func() {
 			a.DELETE("/:identityID"),
 		)
 		a.Description("Remove a user from the list of space collaborators.")
-		a.Response(d.OK, userList)
+		a.Response(d.OK, AuthToken)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)

--- a/design/collaborators.go
+++ b/design/collaborators.go
@@ -32,7 +32,7 @@ var _ = a.Resource("collaborators", func() {
 			a.POST(""),
 		)
 		a.Description("Add users to the list of space collaborators.")
-		a.Response(d.OK)
+		a.Response(d.OK, userList)
 		a.Payload(updateUserIDList)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -46,7 +46,7 @@ var _ = a.Resource("collaborators", func() {
 			a.POST("/:identityID"),
 		)
 		a.Description("Add a user to the list of space collaborators.")
-		a.Response(d.OK)
+		a.Response(d.OK, userList)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
@@ -59,7 +59,7 @@ var _ = a.Resource("collaborators", func() {
 			a.DELETE(""),
 		)
 		a.Description("Remove users form the list of space collaborators.")
-		a.Response(d.OK)
+		a.Response(d.OK, userList)
 		a.Payload(updateUserIDList)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -73,7 +73,7 @@ var _ = a.Resource("collaborators", func() {
 			a.DELETE("/:identityID"),
 		)
 		a.Description("Remove a user from the list of space collaborators.")
-		a.Response(d.OK)
+		a.Response(d.OK, userList)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)

--- a/login/service.go
+++ b/login/service.go
@@ -82,7 +82,7 @@ type keycloakTokenClaims struct {
 	jwt.StandardClaims
 }
 
-var allProvidersToLink = []string{"github", "openshift-v3"}
+var allProvidersToLink = []string{"github"} //, "openshift-v3"}
 
 const (
 	initiateLinkingParam = "initlinking"

--- a/login/service.go
+++ b/login/service.go
@@ -82,7 +82,7 @@ type keycloakTokenClaims struct {
 	jwt.StandardClaims
 }
 
-var allProvidersToLink = []string{"github"} //, "openshift-v3"}
+var allProvidersToLink = []string{"github", "openshift-v3"}
 
 const (
 	initiateLinkingParam = "initlinking"

--- a/space/authz/authz.go
+++ b/space/authz/authz.go
@@ -130,7 +130,7 @@ func (s *KeycloakAuthzService) Authorize(ctx context.Context, entitlementEndpoin
 	for _, permission := range permissions {
 		name := permission.ResourceSetName
 		if name != nil && spaceID == *name {
-			return false, nil
+			return true, nil
 		}
 	}
 	return false, nil

--- a/space/authz/authz.go
+++ b/space/authz/authz.go
@@ -25,7 +25,7 @@ import (
 
 // AuthzService represents a space authorization service
 type AuthzService interface {
-	Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (bool, error)
+	Authorize(ctx context.Context, entitlementEndpoint string, spaceID string, entitlementToken *string) (bool, error)
 	Configuration() AuthzConfiguration
 }
 
@@ -73,8 +73,10 @@ func (s *KeycloakAuthzService) Configuration() AuthzConfiguration {
 }
 
 // Authorize returns true and the corresponding Requesting Party Token if the current user is among the space collaborators
-func (s *KeycloakAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (bool, error) {
+func (s *KeycloakAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string, entitlementToken *string) (bool, error) {
 	jwttoken := goajwt.ContextJWT(ctx)
+	var rpttoken string
+
 	if jwttoken == nil {
 		return false, errors.NewUnauthorizedError("missing token")
 	}
@@ -103,7 +105,10 @@ func (s *KeycloakAuthzService) Authorize(ctx context.Context, entitlementEndpoin
 		log.Warn(ctx, map[string]interface{}{
 			"space-id": spaceID,
 		}, "no authorization found in the token; this is an access token (not a RPT token)")
-		return s.checkEntitlementForSpace(ctx, *jwttoken, entitlementEndpoint, spaceID)
+
+		isEntitled, err := s.checkEntitlementForSpace(ctx, &rpttoken, *jwttoken, entitlementEndpoint, spaceID)
+		*entitlementToken = rpttoken
+		return isEntitled, err
 	}
 
 	// Check if the token was issued before the space resouces changed the last time.
@@ -113,7 +118,9 @@ func (s *KeycloakAuthzService) Authorize(ctx context.Context, entitlementEndpoin
 		return false, err
 	}
 	if outdated {
-		return s.checkEntitlementForSpace(ctx, *jwttoken, entitlementEndpoint, spaceID)
+		isEntitled, err := s.checkEntitlementForSpace(ctx, &rpttoken, *jwttoken, entitlementEndpoint, spaceID)
+		*entitlementToken = rpttoken
+		return isEntitled, err
 	}
 
 	permissions := claims.Authorization.Permissions
@@ -123,17 +130,28 @@ func (s *KeycloakAuthzService) Authorize(ctx context.Context, entitlementEndpoin
 	for _, permission := range permissions {
 		name := permission.ResourceSetName
 		if name != nil && spaceID == *name {
-			return true, nil
+			return false, nil
 		}
 	}
 	return false, nil
 }
 
-func (s *KeycloakAuthzService) checkEntitlementForSpace(ctx context.Context, token jwt.Token, entitlementEndpoint string, spaceID string) (bool, error) {
+func (s *KeycloakAuthzService) checkEntitlementForSpace(ctx context.Context, rpttoken *string, token jwt.Token, entitlementEndpoint string, spaceID string) (bool, error) {
 	resource := auth.EntitlementResource{
 		Permissions: []auth.ResourceSet{{Name: spaceID}},
+		MetaInformation: auth.EntitlementMeta{
+			Limit: "2",
+		},
 	}
+
 	ent, err := auth.GetEntitlement(ctx, entitlementEndpoint, &resource, token.Raw)
+
+	// bubble up the rpt token
+	*rpttoken = ""
+	if ent != nil {
+		*rpttoken = *ent
+	}
+
 	if err != nil {
 		return false, err
 	}
@@ -183,8 +201,9 @@ func InjectAuthzService(service AuthzService) goa.Middleware {
 }
 
 // Authorize returns true and the corresponding Requesting Party Token if the current user is among the space collaborators
-func Authorize(ctx context.Context, spaceID string) (bool, error) {
+func Authorize(ctx context.Context, spaceID string, rptToken *string) (bool, error) {
 	srv := tokencontext.ReadSpaceAuthzServiceFromContext(ctx)
+	var generatedToken string
 	if srv == nil {
 		log.Error(ctx, map[string]interface{}{
 			"space-id": spaceID,
@@ -193,5 +212,7 @@ func Authorize(ctx context.Context, spaceID string) (bool, error) {
 		return false, errs.New("missing space authz service")
 	}
 	manager := srv.(AuthzServiceManager)
-	return manager.AuthzService().Authorize(ctx, manager.EntitlementEndpoint(), spaceID)
+	isAuthorized, err := manager.AuthzService().Authorize(ctx, manager.EntitlementEndpoint(), spaceID, &generatedToken)
+	*rptToken = generatedToken
+	return isAuthorized, err
 }

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -52,7 +52,8 @@ func (s *TestAuthzSuite) SetupSuite() {
 func (s *TestAuthzSuite) TestFailsIfNoTokenInContext() {
 	ctx := context.Background()
 	spaceID := ""
-	_, err := s.authzService.Authorize(ctx, "", spaceID)
+	var rptToken string
+	_, err := s.authzService.Authorize(ctx, "", spaceID, &rptToken)
 	require.NotNil(s.T(), err)
 }
 
@@ -78,8 +79,8 @@ func (s *TestAuthzSuite) checkPermissions(authzPayload auth.AuthorizationPayload
 	testIdentity := testsupport.TestIdentity
 	svc := testsupport.ServiceAsUserWithAuthz("SpaceAuthz-Service", almtoken.NewManagerWithPrivateKey(priv), priv, testIdentity, authzPayload)
 	resource.UpdatedAt = time.Now()
-
-	ok, err := authzService.Authorize(svc.Context, "", spaceID)
+	var rptToken string
+	ok, err := authzService.Authorize(svc.Context, "", spaceID, &rptToken)
 	require.Nil(s.T(), err)
 	return ok
 }

--- a/test/login.go
+++ b/test/login.go
@@ -19,7 +19,7 @@ import (
 type dummySpaceAuthzService struct {
 }
 
-func (s *dummySpaceAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (bool, error) {
+func (s *dummySpaceAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string, token *string) (bool, error) {
 	return true, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/fabric8-services/fabric8-wit/issues/1300

**Do not merge**
- This PR uses a different keycloak ( https://github.com/fabric8-services/keycloak/pull/88 )  and hence the values have been changed in the `configuration.go` for the time-being. ( I should have used env vars but had a hard time setting the public key )
- `comments` and `workitems` needs more refactoring.
- No tests have been added yet.

**This PR has the following changes**

1. For every request which accesses the entitlement endpoint to fetch an RPT token, the freshly retrieved RPT token is returned in the response. ( This would eventually be consumed as a UI for subsequent token-associated calls to the API )


**Usage / Example**


1. Returning the RPT in a 200OK response  ( for eventual consumption by UI )

```
$ ./bin/alm-cli add collaborators --key $ALM_TOKEN --spaceID "7dab0b6a-26ab-4b83-ad8c-555080487d3d"  --identityID "0bd9034e-f14b-44db-8061-5616e10fc580"  -H localhost:8080 --pp
2017/06/29 14:28:43 [INFO] started id=h2f2VS9e POST=http://localhost:8080/api/spaces/7dab0b6a-26ab-4b83-ad8c-555080487d3d/collaborators/0bd9034e-f14b-44db-8061-5616e10fc580

2017/06/29 14:28:46 [INFO] completed id=h2f2VS9e status=200 time=2.773866432s
{
    "token": {
        "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZMk55WC0zSEZVOHBoUW1DbFZsYUZQSmJoYkNrc0NfTGdmd0xFNW5GMzVzIn0.eyJqdGkiOiJmN2UwOTFjYi0yNWMxLTRmMTYtODc1NS1mN2U1Njk2N2Y4NzkiLCJleHAiOjE1MDEyMzcxMzUsIm5iZiI6MCwiaWF0IjoxNDk4NjQ1MTM1LCJpc3MiOiJodHRwOi8va2V5Y2xvYWsta2V5Y2xvYWszLTIuZGV2LnJkdTJjLmZhYnJpYzguaW8vYXV0aC9yZWFsbXMvZmFicmljOCIsImF1ZCI6ImZhYnJpYzgtb25saW5lLXBsYXRmb3JtIiwic3ViIjoiYTk5NmE1NGItMzc0Mi00NjAxLTg4NWEtMjI2NWJmN2UyMTgzIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJhdXRoX3RpbWUiOjAsInNlc3Npb25fc3RhdGUiOiIwNzViMTYxMC1kMzQyLTQ3NDEtODY2ZS1iZGQ3NmU1YWNlZTYiLCJuYW1lIjoidGVzdHVzZXIyIHRlc3R1c2VyMiIsImdpdmVuX25hbWUiOiJ0ZXN0dXNlcjIiLCJmYW1pbHlfbmFtZSI6InRlc3R1c2VyMiIsInByZWZlcnJlZF91c2VybmFtZSI6InRlc3R1c2VyMiIsImVtYWlsIjoidGVzdHVzZXIyQHRlc3R1c2VyMi5jb20iLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbIioiXSwicmVzb3VyY2VfYWNjZXNzIjp7ImZhYnJpYzgtb25saW5lLXBsYXRmb3JtIjp7InJvbGVzIjpbInVtYV9wcm90ZWN0aW9uIl19LCJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJhdXRob3JpemF0aW9uIjp7InBlcm1pc3Npb25zIjpbeyJzY29wZXMiOlsicmVhZDpzcGFjZSIsImFkbWluOnNwYWNlIl0sInJlc291cmNlX3NldF9pZCI6ImY4ZWRhODg4LThiNWYtNDExZS05ZmEwLTg4MWM5MTg2YmZiMCIsInJlc291cmNlX3NldF9uYW1lIjoiN2RhYjBiNmEtMjZhYi00YjgzLWFkOGMtNTU1MDgwNDg3ZDNkIn1dfX0.F9rQwA_GoHzEP3GR_jv3oUIfpgCIESr4h1EaKMlK6kz3fomdx274Cndkr-js62g6GJbdXAD--YU0KiyoYXPdPWuIBUDnrKHtToet6AbjNH8XAYIBUFa_ety-LFeajPQHuFt9xTLoWIzxIbg-pe6rxfsjPEKGQUwL8Icr2i7mKG7q7ECIiH5d1D77nyQsUrTUxK8q_Rbps9Ex-ht8It8Xk_mmKgUGXQmpqciyTk15SCPI50ofX5av42ZlwPe85B4232Tjp-FgDrAqzE-0mNK04h7QONX1oSNHqwbBmxRoeinks2-VagB9z7UiVYYKCxz3Au1u2tEAJyD7on1txljMmg",
        "expires_in": 1.501237135e+09,
        "not-before-policy": 0,
        "refresh_expires_in": 1.501237135e+09
    }
}
```




