### PR TITLE
Enforce data integrity in the `work_item_links` table (#1402)

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -320,7 +320,7 @@ func GetMigrations() Migrations {
 	m = append(m, steps{ExecuteSQLFile("065-workitem-id-unique-per-space.sql")})
 
 	// Version 66
-	m = append(m, steps{ExecuteSQLFile("066-workitem-id-unique-per-space.sql")})
+	m = append(m, steps{ExecuteSQLFile("066-work_item_links_data_integrity.sql")})
 
 	// Version N
 	//

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -316,8 +316,11 @@ func GetMigrations() Migrations {
 	// Version 64
 	m = append(m, steps{ExecuteSQLFile("064-remove-link-combinations.sql")})
 
-	// Version 64
+	// Version 65
 	m = append(m, steps{ExecuteSQLFile("065-workitem-id-unique-per-space.sql")})
+
+	// Version 66
+	m = append(m, steps{ExecuteSQLFile("066-workitem-id-unique-per-space.sql")})
 
 	// Version N
 	//

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -418,10 +418,10 @@ func testMigration66(t *testing.T) {
 	assert.Nil(t, runSQLscript(sqlDB, "066-work_item_links_data_integrity.sql"))
 	// then apply the change
 	migrateToVersion(sqlDB, migrations[:(initialMigratedVersion+22)], (initialMigratedVersion + 22))
-	// verify that some records where removed
+	// verify that the first record was not removed
 	row := sqlDB.QueryRow("select id from work_item_links where id = '00000066-0000-0000-0000-000000000001'")
 	require.NotNil(t, row)
-	// 3 other rows where deleted
+	// verify that the 3 other records where deleted (because of invalid/null data)
 	for id := range []string{"00000066-0000-0000-0000-000000000002", "00000066-0000-0000-0000-000000000003", "00000066-0000-0000-0000-000000000004"} {
 		stmt, err := sqlDB.Prepare("select id from work_item_links where id = $1")
 		require.Nil(t, err)

--- a/migration/sql-files/066-work_item_links_data_integrity.sql
+++ b/migration/sql-files/066-work_item_links_data_integrity.sql
@@ -1,3 +1,6 @@
+--- remove any record in the 'work_item_links' table if the 'link_type_id', 'source_id' and 'target_id' columns contain `NULL` values
+delete from work_item_links where link_type_id IS NULL or source_id IS NULL or target_id IS NULL;
+
 --- make the 'link_type_id', 'source_id' and 'target_id' columns not nullable in the 'work_item_links' table
 alter table work_item_links alter column link_type_id set not null;
 alter table work_item_links alter column source_id set not null;

--- a/migration/sql-files/066-work_item_links_data_integrity.sql
+++ b/migration/sql-files/066-work_item_links_data_integrity.sql
@@ -1,0 +1,4 @@
+--- make the 'link_type_id', 'source_id' and 'target_id' columns not nullable in the 'work_item_links' table
+alter table work_item_links alter column link_type_id set not null;
+alter table work_item_links alter column source_id set not null;
+alter table work_item_links alter column target_id set not null;

--- a/migration/sql-test-files/066-work_item_links_data_integrity.sql
+++ b/migration/sql-test-files/066-work_item_links_data_integrity.sql
@@ -1,0 +1,12 @@
+-- prepare data
+insert into spaces (id, name) values ('00000066-0000-0000-0000-000000000000', 'test space 1');
+insert into work_item_types (id, name, space_id) values ('00000066-0000-0000-0000-000000000000', 'test type 1', '00000066-0000-0000-0000-000000000000');
+insert into work_item_link_types (id, name, topology, forward_name, reverse_name, space_id) 
+    values ('00000066-0000-0000-0000-000000000000', 'foo', 'dependency', 'foo', 'foo', '00000066-0000-0000-0000-000000000000');
+insert into work_items (id, type, space_id) values ('00000066-0000-0000-0000-000000000001', '00000066-0000-0000-0000-000000000000', '00000066-0000-0000-0000-000000000000');
+insert into work_items (id, type, space_id) values ('00000066-0000-0000-0000-000000000002', '00000066-0000-0000-0000-000000000000', '00000066-0000-0000-0000-000000000000');
+-- insert valid and invalid links
+insert into work_item_links (id, link_type_id, source_id, target_id) values ('00000066-0000-0000-0000-000000000001', '00000066-0000-0000-0000-000000000000', '00000066-0000-0000-0000-000000000001', '00000066-0000-0000-0000-000000000002');
+insert into work_item_links (id, link_type_id, source_id, target_id) values ('00000066-0000-0000-0000-000000000002', NULL, '00000066-0000-0000-0000-000000000001', '00000066-0000-0000-0000-000000000002');
+insert into work_item_links (id, link_type_id, source_id, target_id) values ('00000066-0000-0000-0000-000000000003', '00000066-0000-0000-0000-000000000000', NULL, '00000066-0000-0000-0000-000000000002');
+insert into work_item_links (id, link_type_id, source_id, target_id) values ('00000066-0000-0000-0000-000000000004', '00000066-0000-0000-0000-000000000000', '00000066-0000-0000-0000-000000000001', NULL);


### PR DESCRIPTION
make the 'link_type_id', 'source_id' and 'target_id' columns not nullable in the 'work_item_links' table

Fixes #1402

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

