### PR TITLE
Safe and consistent character encoding for input data in the backend (#1465)

### DIFF
--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -634,8 +634,11 @@ func ConvertWorkItem(request *goa.RequestData, wi workitem.WorkItem, additional 
 			}
 
 		case workitem.SystemTitle:
-			// 'HTML escape' the title to prevent script injection
-			op.Attributes[name] = html.EscapeString(val.(string))
+			if val != nil {
+				op.Attributes[name] = val.(string)
+				// 'HTML escape' the title to prevent script injection
+				op.Attributes[workitem.SystemTitleRendered] = html.EscapeString(val.(string))
+			}
 		case workitem.SystemDescription:
 			description := rendering.NewMarkupContentFromValue(val)
 			if description != nil {

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -1156,7 +1156,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithLegacyDescription() {
 }
 
 // TestWI2SuccessCreateWorkItemWithDescription verifies that the `workitem.SystemDescription` attribute is set, as well as its pair workitem.SystemDescriptionMarkup when the work item description is provided
-func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndMarkup() {
+func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithTitleDescriptionAndMarkup() {
 	// given
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
@@ -1174,6 +1174,26 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndMarkup() 
 	assert.Equal(s.T(), "Description", wi.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), "<p>Description</p>\n", wi.Data.Attributes[workitem.SystemDescriptionRendered])
 	assert.Equal(s.T(), rendering.SystemMarkupMarkdown, wi.Data.Attributes[workitem.SystemDescriptionMarkup])
+}
+
+// TestWI2SuccessCreateWorkItemWithDescription verifies that the `workitem.SystemDescription` attribute is set, as well as its pair workitem.SystemDescriptionMarkup when the work item description is provided
+func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithTitleToEncode() {
+	// given
+	c := minimumRequiredCreatePayload()
+	c.Data.Attributes[workitem.SystemTitle] = "A 'Title' with a &"
+	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
+	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
+
+	// when
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
+	// then
+	require.NotNil(s.T(), wi.Data)
+	require.NotNil(s.T(), wi.Data.Attributes)
+	s.T().Logf("rendered title: %s", wi.Data.Attributes[workitem.SystemTitleRendered])
+	assert.NotNil(s.T(), wi.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), c.Data.Attributes[workitem.SystemTitle], wi.Data.Attributes[workitem.SystemTitle])
+	assert.NotNil(s.T(), wi.Data.Attributes[workitem.SystemTitleRendered])
+	assert.Equal(s.T(), "A &#39;Title&#39; with a &amp;", wi.Data.Attributes[workitem.SystemTitleRendered])
 }
 
 // TestWI2SuccessCreateWorkItemWithDescription verifies that the `workitem.SystemDescription` attribute is set as a MarkupContent element
@@ -2234,7 +2254,9 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithLe
 	// then
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
-	assert.Equal(s.T(), html.EscapeString(title), fetchedWI.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), title, fetchedWI.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), html.EscapeString(title), fetchedWI.Data.Attributes[workitem.SystemTitleRendered])
+	assert.Equal(s.T(), description, fetchedWI.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), html.EscapeString(description), fetchedWI.Data.Attributes[workitem.SystemDescriptionRendered])
 }
 
@@ -2253,7 +2275,9 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithPl
 	// then
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
-	assert.Equal(s.T(), html.EscapeString(title), fetchedWI.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), title, fetchedWI.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), html.EscapeString(title), fetchedWI.Data.Attributes[workitem.SystemTitleRendered])
+	assert.Equal(s.T(), description.Content, fetchedWI.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), html.EscapeString(description.Content), fetchedWI.Data.Attributes[workitem.SystemDescriptionRendered])
 }
 
@@ -2272,7 +2296,9 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithMa
 	// then
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
-	assert.Equal(s.T(), html.EscapeString(title), fetchedWI.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), title, fetchedWI.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), html.EscapeString(title), fetchedWI.Data.Attributes[workitem.SystemTitleRendered])
+	assert.Equal(s.T(), description.Content, fetchedWI.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), "<p>"+html.EscapeString(description.Content)+"</p>\n", fetchedWI.Data.Attributes[workitem.SystemDescriptionRendered])
 }
 

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -21,6 +21,7 @@ const (
 	SystemRemoteItemID        = "system.remote_item_id"
 	SystemNumber              = "system.number"
 	SystemTitle               = "system.title"
+	SystemTitleRendered       = "system.title.rendered"
 	SystemDescription         = "system.description"
 	SystemDescriptionMarkup   = "system.description.markup"
 	SystemDescriptionRendered = "system.description.rendered"


### PR DESCRIPTION
Added a new field in the JSON response: `system.title.rendered`, which contains
the HTML-escaped version of the input title. Also, the `system.title` field now
contains the original (raw) data that the user did input, so both fields can
be used at the UI level:
- `system.title.rendered` when displaying the work item's title
- `system.title` when editing the work item's title

Fixes #1465

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

* Please describe what your change is about.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
* If you are still working on the change please prefix the pull request title with "WIP"
