### PR TITLE
Remove the unused `filter` param in the `filters` endpoint (#1140)

### DIFF
--- a/controller/filters_blackbox_test.go
+++ b/controller/filters_blackbox_test.go
@@ -35,7 +35,7 @@ func (rest *TestFiltersREST) TestListFiltersOK() {
 	svc := goa.New("filterService")
 	ctrl := controller.NewFilterController(svc, rest.Configuration)
 	// when
-	res, filters := test.ListFilterOK(rest.T(), svc.Context, svc, ctrl, nil)
+	res, filters := test.ListFilterOK(rest.T(), svc.Context, svc, ctrl)
 	// then
 	assert.Equal(rest.T(), 5, len(filters.Data))
 	assertResponseHeaders(rest.T(), res)

--- a/design/filters.go
+++ b/design/filters.go
@@ -49,10 +49,7 @@ var _ = a.Resource("filter", func() {
 		a.Routing(
 			a.GET(""),
 		)
-		a.Description("List work items.")
-		a.Params(func() {
-			a.Param("filter", d.String, "a query language expression restricting the set of found work items")
-		})
+		a.Description("List filters.")
 		a.Response(d.OK, func() {
 			a.Media(filterList)
 		})


### PR DESCRIPTION
Was already unused in the controller. Just removed the param in
the design and applied the change in the test.

Fixes #1140

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
