### PR TITLE
Data migration failure because of invalid data (#1476)

### DIFF
--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -124,6 +124,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration63", testMigration63)
 	t.Run("TestMigration65", testMigration65)
 	t.Run("TestMigration66", testMigration66)
+	t.Run("TestMigration67", testMigration67)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName); err != nil {

--- a/migration/sql-files/067-comment-parentid-uuid.sql
+++ b/migration/sql-files/067-comment-parentid-uuid.sql
@@ -5,9 +5,9 @@ UPDATE comments SET parent_id_uuid = parent_id::uuid;
 ALTER TABLE comments DROP COLUMN "parent_id";
 ALTER TABLE comments RENAME COLUMN "parent_id_uuid" TO "parent_id";
 
--- second, we ADD a new COLUMN for the 'parent id' as a UUID in the `comment_revisions` table:
+-- second, we ADD a new COLUMN for the 'parent id' as a UUID in the `comment_revisions` table (after migrating the content of `comment_parent_id`, forgotten in step 65) :
 ALTER TABLE comment_revisions ADD COLUMN "comment_parent_id_uuid" UUID;
-UPDATE comment_revisions SET comment_parent_id_uuid = comment_parent_id::uuid;
+UPDATE comment_revisions SET comment_parent_id_uuid = c.parent_id FROM comments c WHERE c.id = comment_revisions.comment_id;
 -- then drop the old 'parent_id' column and rename the new one to 'parent_id'
 ALTER TABLE comment_revisions DROP COLUMN "comment_parent_id";
 ALTER TABLE comment_revisions RENAME COLUMN "comment_parent_id_uuid" TO "comment_parent_id";

--- a/migration/sql-test-files/067-comment-parentid-uuid.sql
+++ b/migration/sql-test-files/067-comment-parentid-uuid.sql
@@ -1,4 +1,7 @@
+-- need some work items to migrate the comment_revisions table, too
+insert into spaces (id, name) values ('00000067-0000-0000-0000-000000000000', 'test space 67');
+insert into work_item_types (id, name, space_id) values ('00000067-0000-0000-0000-000000000000', 'test type 1', '00000067-0000-0000-0000-000000000000');
+insert into work_items (id, number, type, space_id) values ('00000067-0000-0000-0000-000000000000', 1, '00000067-0000-0000-0000-000000000000', '00000067-0000-0000-0000-000000000000');
 insert into comments (id, parent_id, body) values ('00000067-0000-0000-0000-000000000000', '00000067-0000-0000-0000-000000000000', 'a foo comment');
-
 insert into comment_revisions (id, revision_type, modifier_id, comment_id, comment_parent_id, comment_body) 
-    values ('00000067-0000-0000-0000-000000000000', 1, 'cafebabe-0000-0000-0000-000000000000', '00000067-0000-0000-0000-000000000000',  '00000065-0000-0000-0000-000000000000', 'a foo comment');
+    values ('00000067-0000-0000-0000-000000000000', 1, 'cafebabe-0000-0000-0000-000000000000', '00000067-0000-0000-0000-000000000000',  1, 'a foo comment');


### PR DESCRIPTION
Added an SQL statement to migrate the content of the `comment_revisions.comment_parent_id` column
Added some data in the .sql test file
Added the test in the list of tests to execute (!)

Fixes 1476

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
