### PR TITLE
small cleanup using gosimple

### DIFF
--- a/account/init_tenant.go
+++ b/account/init_tenant.go
@@ -45,10 +45,8 @@ func InitTenant(ctx context.Context, config tenantConfig) error {
 
 	// Ignore response for now
 	_, err = c.SetupTenant(ctx, tenant.SetupTenantPath())
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
 }
 
 // UpdateTenant creates a new tenant service in oso
@@ -66,8 +64,6 @@ func UpdateTenant(ctx context.Context, config tenantConfig) error {
 
 	// Ignore response for now
 	_, err = c.UpdateTenant(ctx, tenant.SetupTenantPath())
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
 }

--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -75,10 +75,8 @@ func NewCodebaseContent(value map[string]interface{}) (Content, error) {
 		}
 	}
 	err := cb.IsValid()
-	if err != nil {
-		return cb, err
-	}
-	return cb, nil
+
+	return cb, err
 }
 
 // NewCodebaseContentFromValue builds Content from interface{}

--- a/convert/equaler.go
+++ b/convert/equaler.go
@@ -19,8 +19,5 @@ var _ Equaler = (*DummyEqualer)(nil)
 // Equal returns true if the argument is also an DummyEqualer; otherwise false is returned.
 func (d DummyEqualer) Equal(u Equaler) bool {
 	_, ok := u.(DummyEqualer)
-	if !ok {
-		return false
-	}
-	return true
+	return ok
 }

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -710,7 +710,7 @@ func (r *GormWorkItemRepository) getAllIterationWithCounts(ctx context.Context, 
 	// ToDo: Update count query to include non matching rows with 0 values
 	// Following operation can be skipped once above is done
 	for _, i := range allIterations {
-		if _, exists := wiMap[i.String()]; exists == false {
+		if _, exists := wiMap[i.String()]; !exists {
 			wiMap[i.String()] = WICountsPerIteration{
 				IterationID: i.String(),
 				Total:       0,

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -157,10 +157,7 @@ func (wit WorkItemType) Equal(u convert.Equaler) bool {
 			return false
 		}
 	}
-	if wit.SpaceID != other.SpaceID {
-		return false
-	}
-	return true
+	return wit.SpaceID == other.SpaceID
 }
 
 // ConvertWorkItemStorageToModel converts a workItem from the storage/persistence layer into a workItem of the model domain layer


### PR DESCRIPTION
I checked out https://github.com/dominikh/go-tools and I have used `gosimple` on our repo. https://github.com/dominikh/go-tools/tree/master/cmd/gosimple
It shows some minor modifications.

Running this command `for pkg in $(go list -f '{{ join .Deps  "\n"}}' . | grep 'fabric8-wit/[^vendor]'); do gosimple "$pkg"; done` shows all warnings/issues.