### PR TITLE
Added logs to space controller/repo to log internal or unknown error details

### DIFF
--- a/controller/space.go
+++ b/controller/space.go
@@ -263,11 +263,18 @@ func (c *SpaceController) Show(ctx *app.ShowSpaceContext) error {
 			return nil
 		})
 		if entityErr != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err": entityErr,
+			}, "unable to convert space from model")
 			return entityErr
 		}
 		return nil
 	})
 	if txnErr != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":      txnErr,
+			"space_id": ctx.SpaceID,
+		}, "unable to show the space by ID")
 		return jsonapi.JSONErrorResponse(ctx, txnErr)
 	}
 	return ctx.OK(&result)

--- a/controller/space.go
+++ b/controller/space.go
@@ -264,7 +264,8 @@ func (c *SpaceController) Show(ctx *app.ShowSpaceContext) error {
 		})
 		if entityErr != nil {
 			log.Error(ctx, map[string]interface{}{
-				"err": entityErr,
+				"space_id": ctx.SpaceID,
+				"err":      entityErr,
 			}, "unable to convert space from model")
 			return entityErr
 		}

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -34,7 +34,7 @@ func ErrorToJSONAPIError(err error) (app.JSONAPIError, int) {
 	var title, code string
 	var statusCode int
 	var id *string
-	log.Info(nil, map[string]interface{}{"err": cause, "error_message": cause.Error()}, "an error occurred in our api")
+	log.Error(nil, map[string]interface{}{"err": cause, "error_message": cause.Error()}, "an error occurred in our api")
 	switch cause.(type) {
 	case errors.NotFoundError:
 		code = ErrorCodeNotFound

--- a/space/space.go
+++ b/space/space.go
@@ -113,6 +113,9 @@ func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*Space, error)
 		return nil, errors.NewNotFoundError("space", ID.String())
 	}
 	if tx.Error != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": tx.Error,
+		}, "unable to load the space by ID")
 		return nil, errors.NewInternalError(ctx, tx.Error)
 	}
 	return &res, nil
@@ -166,6 +169,9 @@ func (r *GormRepository) Save(ctx context.Context, p *Space) (*Space, error) {
 		return nil, errors.NewNotFoundError("space", p.ID.String())
 	}
 	if err := tx.Error; err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": tx.Error,
+		}, "unable to find the space by ID")
 		return nil, errors.NewInternalError(ctx, err)
 	}
 	tx = tx.Where("Version = ?", oldVersion).Save(p)
@@ -176,6 +182,9 @@ func (r *GormRepository) Save(ctx context.Context, p *Space) (*Space, error) {
 		if gormsupport.IsUniqueViolation(tx.Error, "spaces_name_idx") {
 			return nil, errors.NewBadParameterError("Name", p.Name).Expected("unique")
 		}
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "unable to find the space by version")
 		return nil, errors.NewInternalError(ctx, err)
 	}
 	if tx.RowsAffected == 0 {
@@ -249,6 +258,9 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, q *string, userID 
 	result := []Space{}
 	columns, err := rows.Columns()
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "unable to load spaces")
 		return nil, 0, errors.NewInternalError(ctx, err)
 	}
 
@@ -269,6 +281,9 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, q *string, userID 
 		if first {
 			first = false
 			if err = rows.Scan(columnValues...); err != nil {
+				log.Error(ctx, map[string]interface{}{
+					"err": err,
+				}, "unable to load spaces")
 				return nil, 0, errors.NewInternalError(ctx, err)
 			}
 		}
@@ -333,6 +348,9 @@ func (r *GormRepository) LoadByOwnerAndName(ctx context.Context, userID *uuid.UU
 		return nil, errors.NewNotFoundError("space", *spaceName)
 	}
 	if tx.Error != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": tx.Error,
+		}, "unable to load space by owner and name")
 		return nil, errors.NewInternalError(ctx, tx.Error)
 	}
 	return &res, nil

--- a/space/space.go
+++ b/space/space.go
@@ -114,7 +114,8 @@ func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*Space, error)
 	}
 	if tx.Error != nil {
 		log.Error(ctx, map[string]interface{}{
-			"err": tx.Error,
+			"err":      tx.Error,
+			"space_id": ID.String(),
 		}, "unable to load the space by ID")
 		return nil, errors.NewInternalError(ctx, tx.Error)
 	}
@@ -170,7 +171,8 @@ func (r *GormRepository) Save(ctx context.Context, p *Space) (*Space, error) {
 	}
 	if err := tx.Error; err != nil {
 		log.Error(ctx, map[string]interface{}{
-			"err": tx.Error,
+			"err":      tx.Error,
+			"space_id": p.ID,
 		}, "unable to find the space by ID")
 		return nil, errors.NewInternalError(ctx, err)
 	}
@@ -183,7 +185,9 @@ func (r *GormRepository) Save(ctx context.Context, p *Space) (*Space, error) {
 			return nil, errors.NewBadParameterError("Name", p.Name).Expected("unique")
 		}
 		log.Error(ctx, map[string]interface{}{
-			"err": err,
+			"err":      err,
+			"version":  oldVersion,
+			"space_id": p.ID,
 		}, "unable to find the space by version")
 		return nil, errors.NewInternalError(ctx, err)
 	}
@@ -259,7 +263,8 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, q *string, userID 
 	columns, err := rows.Columns()
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
-			"err": err,
+			"err":   err,
+			"query": q,
 		}, "unable to load spaces")
 		return nil, 0, errors.NewInternalError(ctx, err)
 	}
@@ -349,7 +354,9 @@ func (r *GormRepository) LoadByOwnerAndName(ctx context.Context, userID *uuid.UU
 	}
 	if tx.Error != nil {
 		log.Error(ctx, map[string]interface{}{
-			"err": tx.Error,
+			"err":        tx.Error,
+			"space_name": *spaceName,
+			"user_id":    *userID,
 		}, "unable to load space by owner and name")
 		return nil, errors.NewInternalError(ctx, tx.Error)
 	}


### PR DESCRIPTION
We're tracking one issue that we saw in the SpaceController for the Show operation. The following output is what we got in the logs.

```
July 1st 2017, 19:11:13.209    {"err":"http: request method or response status code does not allow body","fields.msg":{"errors":[{"code":"unknown_error","detail":"http: request method or response status code does not allow body","status":"500","title":"Unknown error"}]},"file":"/tmp/go/src/github.com/fabric8-services/fabric8-wit/jsonapi/error_handler.go","func":"github.com/fabric8-services/fabric8-wit/jsonapi.ErrorHandler.func1.1","level":"error","line":66,"msg":"uncaught error detected in ErrorHandler","pid":1,"pkg":"jsonapi.ErrorHandler.func1","req_id":"c9b5c63b-dce7-4cca-8f9d-91c407796819","time":"2017-07-01 17:11:13"}
c9b5c63b-dce7-4cca-8f9d-91c407796819
July 1st 2017, 19:11:13.209    {"action":"Show","bytes":167,"ctrl":"SpaceController","fields.time":"6.839027ms","level":"info","msg":"completed","pkg":"log.LogRequest.func1","req_id":"c9b5c63b-dce7-4cca-8f9d-91c407796819","status":500,"time":"2017-07-01 17:11:13"}
c9b5c63b-dce7-4cca-8f9d-91c407796819
July 1st 2017, 19:11:13.203    {"GET":"/api/spaces/79144bd1-90ea-49ac-b04c-33a586df6fd7","action":"Show","ctrl":"SpaceController","from":"173.95.170.232","level":"info","msg":"request started","pkg":"log.LogRequest.func1","req_id":"c9b5c63b-dce7-4cca-8f9d-91c407796819","time":"2017-07-01 17:11:13"}
```

 This is clearly insufficient to determine the source of the problem.

The idea is to add these logs to extract more info. If this helps we could add them to the rest of internal server errors to improve traceability.