### PR TITLE
Fix golint exclude file

### DIFF
--- a/.golint_exclude
+++ b/.golint_exclude
@@ -1,5 +1,5 @@
-bindata_assetfs.go
+bindata_assetfs\.go
 sqlbindata
-/design/.*
+design/.*
 .*exported
 EOF


### PR DESCRIPTION
Before we would exclude not only `bindata_assetfs.go` but also any file that substitutes the dot (`.`) with a different symbol. This is not critical but the exclude file was simply wrong.