### PR TITLE
Forward X-Request-ID to tenant service

### DIFF
--- a/account/init_tenant.go
+++ b/account/init_tenant.go
@@ -44,7 +44,7 @@ func InitTenant(ctx context.Context, config tenantConfig) error {
 	c.SetJWTSigner(goasupport.NewForwardSigner(ctx))
 
 	// Ignore response for now
-	_, err = c.SetupTenant(ctx, tenant.SetupTenantPath())
+	_, err = c.SetupTenant(goasupport.ForwardContextRequestID(ctx), tenant.SetupTenantPath())
 
 	return err
 }
@@ -63,7 +63,7 @@ func UpdateTenant(ctx context.Context, config tenantConfig) error {
 	c.SetJWTSigner(goasupport.NewForwardSigner(ctx))
 
 	// Ignore response for now
-	_, err = c.UpdateTenant(ctx, tenant.SetupTenantPath())
+	_, err = c.UpdateTenant(goasupport.ForwardContextRequestID(ctx), tenant.SetupTenantPath())
 
 	return err
 }

--- a/goasupport/forward_requestid.go
+++ b/goasupport/forward_requestid.go
@@ -1,0 +1,16 @@
+package goasupport
+
+import (
+	"context"
+
+	"github.com/goadesign/goa/client"
+	"github.com/goadesign/goa/middleware"
+)
+
+func ForwardContextRequestID(ctx context.Context) context.Context {
+	reqID := middleware.ContextRequestID(ctx)
+	if reqID != "" {
+		return client.SetContextRequestID(ctx, reqID)
+	}
+	return ctx
+}

--- a/goasupport/forward_requestid_test.go
+++ b/goasupport/forward_requestid_test.go
@@ -1,0 +1,39 @@
+package goasupport
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"net/http/httptest"
+
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/client"
+	"github.com/goadesign/goa/middleware"
+	"github.com/goadesign/goa/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForwardRequest(t *testing.T) {
+
+	reqID := uuid.NewV4().String()
+	ctx := context.Background()
+
+	service := goa.New("test")
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/goo", nil)
+	req.Header.Set(middleware.RequestIDHeader, reqID)
+
+	var newCtx context.Context
+	h := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		newCtx = ctx
+		return service.Send(ctx, 200, "ok")
+	}
+	rg := middleware.RequestID()(h)
+	rg(ctx, rw, req)
+
+	assert.Equal(t, middleware.ContextRequestID(newCtx), reqID)
+
+	clientCtx := ForwardContextRequestID(newCtx)
+	assert.Equal(t, client.ContextRequestID(clientCtx), reqID)
+}


### PR DESCRIPTION
Fixes lack of log coordination between tenant service and core.

client.ContextRequestID != middleware.ContextRequestID as they are stored
under different local keys.