### PR TITLE
Add DataConflictError & return HTTP 409 when creating duplicate areas

### DIFF
--- a/area/area.go
+++ b/area/area.go
@@ -77,10 +77,10 @@ func (m *GormAreaRepository) Create(ctx context.Context, u *Area) error {
 		// ( name, spaceID ,path ) needs to be unique
 		if gormsupport.IsUniqueViolation(err, "areas_name_space_id_path_unique") {
 			log.Error(ctx, map[string]interface{}{
-				"err":   err,
-				"name":  u.Name,
-				"path":  u.Path,
-				"space": u.SpaceID,
+				"err":      err,
+				"name":     u.Name,
+				"path":     u.Path,
+				"space_id": u.SpaceID,
 			}, "unable to create child area because an area in the same path already exists")
 			return errors.NewDataConflictError(fmt.Sprintf("area already exists with name = %s , space_id = %s , path = %s ", u.Name, u.SpaceID.String(), u.Path.String()))
 		}

--- a/area/area.go
+++ b/area/area.go
@@ -10,6 +10,8 @@ import (
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/path"
 
+	"fmt"
+
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -74,7 +76,13 @@ func (m *GormAreaRepository) Create(ctx context.Context, u *Area) error {
 	if err != nil {
 		// ( name, spaceID ,path ) needs to be unique
 		if gormsupport.IsUniqueViolation(err, "areas_name_space_id_path_unique") {
-			return errors.NewBadParameterError("name & space_id & path", u.Name+" & "+u.SpaceID.String()+" & "+u.Path.String()).Expected("unique")
+			log.Error(ctx, map[string]interface{}{
+				"err":   err,
+				"name":  u.Name,
+				"path":  u.Path,
+				"space": u.SpaceID,
+			}, "unable to create child area because an area in the same path already exists")
+			return errors.NewDataConflictError(fmt.Sprintf("area already exists with name = %s , space_id = %s , path = %s ", u.Name, u.SpaceID.String(), u.Path.String()))
 		}
 		log.Error(ctx, map[string]interface{}{}, "error adding Area: %s", err.Error())
 		return err

--- a/area/area_blackbox_test.go
+++ b/area/area_blackbox_test.go
@@ -72,8 +72,8 @@ func (s *TestAreaRepository) TestCreateAreaWithSameNameFail() {
 	err = repo.Create(context.Background(), &anotherAreaWithSameName)
 	// then
 	require.NotNil(s.T(), err)
-	// In case of unique constrain error, a BadParameterError is returned.
-	_, ok := errors.Cause(err).(errs.BadParameterError)
+	// In case of unique constrain error, a DataConflictError is returned.
+	_, ok := errors.Cause(err).(errs.DataConflictError)
 	assert.True(s.T(), ok)
 }
 

--- a/design/areas.go
+++ b/design/areas.go
@@ -108,6 +108,7 @@ var _ = a.Resource("area", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.Forbidden, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 })
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -100,6 +100,26 @@ func NewVersionConflictError(msg string) VersionConflictError {
 	return VersionConflictError{simpleError{msg}}
 }
 
+// DataConflictError means that the version was not as expected in an update operation
+type DataConflictError struct {
+	simpleError
+}
+
+// IsDataConflictError returns true if the cause of the given error can be
+// converted to an IsDataConflictError, which is returned as the second result.
+func IsDataConflictError(err error) (bool, error) {
+	e, ok := errs.Cause(err).(DataConflictError)
+	if !ok {
+		return false, nil
+	}
+	return true, e
+}
+
+// NewDataConflictError returns the custom defined error of type NewDataConflictError.
+func NewDataConflictError(msg string) DataConflictError {
+	return DataConflictError{simpleError{msg}}
+}
+
 // IsVersionConflictError returns true if the cause of the given error can be
 // converted to an VersionConflictError, which is returned as the second result.
 func IsVersionConflictError(err error) (bool, error) {

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -22,7 +22,7 @@ const (
 	ErrorCodeUnauthorizedError = "unauthorized_error"
 	ErrorCodeForbiddenError    = "forbidden_error"
 	ErrorCodeJWTSecurityError  = "jwt_security_error"
-	ErrorCodeDataConflict      = "data_conflict"
+	ErrorCodeDataConflict      = "data_conflict_error"
 )
 
 // ErrorToJSONAPIError returns the JSONAPI representation

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -22,6 +22,7 @@ const (
 	ErrorCodeUnauthorizedError = "unauthorized_error"
 	ErrorCodeForbiddenError    = "forbidden_error"
 	ErrorCodeJWTSecurityError  = "jwt_security_error"
+	ErrorCodeDataConflict      = "data_conflict"
 )
 
 // ErrorToJSONAPIError returns the JSONAPI representation
@@ -51,6 +52,10 @@ func ErrorToJSONAPIError(err error) (app.JSONAPIError, int) {
 	case errors.VersionConflictError:
 		code = ErrorCodeVersionConflict
 		title = "Version conflict error"
+		statusCode = http.StatusConflict
+	case errors.DataConflictError:
+		code = ErrorCodeDataConflict
+		title = "Data conflict error"
 		statusCode = http.StatusConflict
 	case errors.InternalError:
 		code = ErrorCodeInternalError


### PR DESCRIPTION
Fixes https://github.com/fabric8-services/fabric8-wit/issues/1484

When an area creation with the same name in the same space/path is attempted, return an HTTP 409, instead of HTTP 400 which was earlier being mapped from `BadParameterError`. In this PR, a new `Error` type `DataConflictError` is returned and mapped into a HTTP 409 . 

Note, HTTP 409 is returned for `VersionConflictError` as well.

Error in logs:

```
ERRO[2017-07-17 23:36:31] unable to create child area because an area in the same path already exists  err="pq: duplicate key value violates unique constraint \"areas_name_space_id_path_unique\"" file="/Users/shoubhikbose/dev/alm-core-sbose/src/github.com/fabric8-services/fabric8-wit/area/area.go" func="github.com/fabric8-services/fabric8-wit/area.(*GormAreaRepository).Create" identity_id=5af0439a-47fb-4832-a060-47d654567b02 line=84 name=myspace path=/de129c08-655a-44f6-8ee9-0b7d90b6f935 pid=56198 pkg=area req_id=3a959a6d-d5fd-4aef-84b1-a099b994b607 space=11412d5c-ecf3-4fd4-8b84-2b609fdb62d7

(pq: duplicate key value violates unique constraint "areas_name_space_id_path_unique") 
[2017-07-17 23:36:31]  
ERRO[2017-07-17 23:36:31] an error occurred in our api                  err="area already exists with name = myspace & space_id = 11412d5c-ecf3-4fd4-8b84-2b609fdb62d7 & path = /de129c08-655a-44f6-8ee9-0b7d90b6f935 " error_message="area already exists with name = myspace & space_id = 11412d5c-ecf3-4fd4-8b84-2b609fdb62d7 & path = /de129c08-655a-44f6-8ee9-0b7d90b6f935 " file="/Users/shoubhikbose/dev/alm-core-sbose/src/github.com/fabric8-services/fabric8-wit/jsonapi/jsonapi_utility.go" func="github.com/fabric8-services/fabric8-wit/jsonapi.ErrorToJSONAPIError" line=38 pid=56198 pkg=jsonapi
```


Response

```
Request URL:http://localhost:8080/api/areas/de129c08-655a-44f6-8ee9-0b7d90b6f935
Request Method:POST
Status Code:409 Conflict
Remote Address:[::1]:8080
Referrer Policy:no-referrer-when-downgrade
```

Response body:
```{"errors":[{"code":"data_conflict","detail":"area already exists with name = myspace \u0026 space_id = 11412d5c-ecf3-4fd4-8b84-2b609fdb62d7 \u0026 path = /de129c08-655a-44f6-8ee9-0b7d90b6f935 ","status":"409","title":"Data conflict error"}]}```
