### PR TITLE
Added logs in the comparison of objects with the expected golden file

### DIFF
--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -9,6 +9,7 @@ import (
 
 	"path/filepath"
 
+	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	errs "github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -54,8 +55,12 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 	expectedStr := string(expected)
 	actualStr := string(actual)
 	if expectedStr != actualStr {
+		log.Error(nil, nil, "testableCompareWithGolden: expected value %v", expectedStr)
+		log.Error(nil, nil, "testableCompareWithGolden: actual value %v", actualStr)
+
 		dmp := diffmatchpatch.New()
 		diffs := dmp.DiffMain(expectedStr, actualStr, false)
+		log.Error(nil, nil, "testableCompareWithGolden: mismatch of actual output and golden-file %s:\n %s \n", absPath, dmp.DiffPrettyText(diffs))
 		return errs.Errorf("mismatch of actual output and golden-file %s:\n %s \n", absPath, dmp.DiffPrettyText(diffs))
 	}
 	return nil


### PR DESCRIPTION
I added some logs to better trace the source of the problem when comparing a golden file with a generated obj. When trying to debug the reason of some failures in my CI jobs, I couldn't get any error logs explaining what was the problem.

```
=== RUN   TestCreate/ok
panic: test executed panic(nil) or runtime.Goexit

goroutine 4674 [running]:
panic(0xe37600, 0xc420c5bf70)
	/usr/lib/golang/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc4207623c0)
	/usr/lib/golang/src/testing/testing.go:579 +0x25d
runtime.Goexit()
	/usr/lib/golang/src/runtime/panic.go:340 +0xec
testing.(*common).FailNow(0xc420762180)
	/usr/lib/golang/src/testing/testing.go:453 +0x39
testing.(*common).Fatalf(0xc420762180, 0xf54f7a, 0x3, 0xc420d03de8, 0x1, 0x1)
	/usr/lib/golang/src/testing/testing.go:496 +0x83
github.com/fabric8-services/fabric8-wit/controller_test.compareWithGolden(0xc420762180, 0xc420913580, 0x37, 0xe3a4e0, 0xc4205a13b0)
	/tmp/go/src/github.com/fabric8-services/fabric8-wit/controller/golden_files_test.go:31 +0xe9
github.com/fabric8-services/fabric8-wit/controller_test.(*workItemTypeSuite).TestCreate.func1(0xc4207623c0)
	/tmp/go/src/github.com/fabric8-services/fabric8-wit/controller/workitemtype_blackbox_test.go:254 +0x107
testing.tRunner(0xc4207623c0, 0xc420c5a870)
	/usr/lib/golang/src/testing/testing.go:610 +0x81
created by testing.(*T).Run
	/usr/lib/golang/src/testing/testing.go:646 +0x2ec
FAIL	github.com/fabric8-services/fabric8-wit/controller	36.723s
```
