### PR TITLE
Keep old structure around until clients are updated.

### DIFF
--- a/controller/comments.go
+++ b/controller/comments.go
@@ -244,6 +244,15 @@ func ConvertComment(request *goa.RequestData, comment comment.Comment, additiona
 					},
 				},
 			},
+			CreatedBy: &app.CommentCreatedBy{ // Keep old API style until all cients are updated
+				Data: &app.IdentityRelationData{
+					Type: userType,
+					ID:   &comment.Creator,
+				},
+				Links: &app.GenericLinks{
+					Related: &relatedCreatorLink,
+				},
+			},
 		},
 		Links: &app.GenericLinks{
 			Self:    &relatedURL,

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -209,6 +209,17 @@ func convertCommentToModel(c app.CommentSingle) comment.Comment {
 	}
 }
 
+func (s *CommentsSuite) TestShowCommentWithBackwardSupport() {
+	// given
+	wiID := s.createWorkItem(s.testIdentity)
+	c := s.createWorkItemComment(s.testIdentity, wiID, "body", &markdownMarkup)
+	// when
+	userSvc, commentsCtrl := s.unsecuredController()
+	_, result := test.ShowCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, *c.Data.ID, nil, nil)
+	// then
+	assert.Equal(s.T(), *result.Data.Relationships.Creator.Data.ID, result.Data.Relationships.CreatedBy.Data.ID.String())
+}
+
 func (s *CommentsSuite) TestShowCommentWithoutAuthOK() {
 	// given
 	wiID := s.createWorkItem(s.testIdentity)

--- a/design/comments.go
+++ b/design/comments.go
@@ -61,7 +61,14 @@ var createCommentAttributes = a.Type("CreateCommentAttributes", func() {
 
 var commentRelationships = a.Type("CommentRelations", func() {
 	a.Attribute("creator", relationGeneric, "This defines the creator of the comment")
+	a.Attribute("created-by", commentCreatedBy, "DEPRECATED. This defines the creator of the comment.")
 	a.Attribute("parent", relationGeneric, "This defines the owning resource of the comment")
+})
+
+var commentCreatedBy = a.Type("CommentCreatedBy", func() {
+	a.Attribute("data", identityRelationData)
+	a.Required("data")
+	a.Attribute("links", genericLinks)
 })
 
 var identityRelationData = a.Type("IdentityRelationData", func() {


### PR DESCRIPTION
Breaking changes block Core from being pushed to prod.

Related to #1380

Note: @kwk @DhritiShikhar 