### PR TITLE
ignore the "design" package from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -27,6 +27,7 @@ coverage:
    - "client/*"
    - "swagger/*"
    - "tool/cli/*"
+   - "design/*"
 
 # See http://docs.codecov.io/docs/pull-request-comments-1
 comment:


### PR DESCRIPTION
We are not writing tests to cover the design package.