### PR TITLE
fabric8-wit #1506: Using Async CheStarter API from Codebases and exposing API for starting and getting che server state

### DIFF
--- a/design/codebases.go
+++ b/design/codebases.go
@@ -109,6 +109,17 @@ var workspaceOpen = a.MediaType("application/vnd.workspaceopen+json", func() {
 	})
 })
 
+var cheServerState = a.MediaType("CheServerState", func() {
+	a.TypeName("CheServerState")
+	a.Description(`JSONAPI store Che Server state.  See also http://jsonapi.org/format/#document-resource-object`)
+	a.Attributes(func() {
+		a.Attribute("running", d.Boolean, "Che server state")
+	})
+	a.View("default", func() {
+		a.Attribute("running")
+	})
+})
+
 // new version of "list" for migration
 var _ = a.Resource("codebase", func() {
 	a.BasePath("/codebases")
@@ -177,6 +188,35 @@ var _ = a.Resource("codebase", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+	a.Action("cheState", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("/che/state"),
+		)
+		a.Description("Get che server state.")
+		a.Response(d.OK, func() {
+			a.Media(cheServerState)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+	a.Action("cheStart", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.PATCH("/che/start"),
+		)
+		a.Description("Start che server if not running.")
+		a.Response(d.OK, func() {
+			a.Media(cheServerState)
+		})
+		a.Response(d.Accepted, func() {
+			a.Media(cheServerState)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 })


### PR DESCRIPTION

* Please describe what your change is about.
see the comment - https://github.com/fabric8-services/fabric8-wit/issues/1506

Providing new endpoints for starting che server asyncronously and getting it's state:

`PATCH api/codebases/che/start`
`GET     api/codebases/che/state`

* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
https://github.com/fabric8-services/fabric8-wit/issues/1506
