### PR TITLE
Add control cache max-age for single resources

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -217,17 +217,17 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varCacheControlCollaborators, "max-age=2")
 
 	// Cache control values for a single resource
-	c.v.SetDefault(varCacheControlWorkItem, "private,max-age=120")
+	c.v.SetDefault(varCacheControlWorkItem, "private,max-age=2")
 	c.v.SetDefault(varCacheControlWorkItemType, "private,max-age=120")
 	c.v.SetDefault(varCacheControlWorkItemLink, "private,max-age=120")
 	c.v.SetDefault(varCacheControlWorkItemLinkType, "private,max-age=120")
 	c.v.SetDefault(varCacheControlSpace, "private,max-age=120")
-	c.v.SetDefault(varCacheControlIteration, "private,max-age=120")
+	c.v.SetDefault(varCacheControlIteration, "private,max-age=2")
 	c.v.SetDefault(varCacheControlArea, "private,max-age=120")
 	c.v.SetDefault(varCacheControlComment, "private,max-age=120")
 	// data returned from '/api/user' must not be cached by intermediate proxies,
 	// but can only be kept in the client's local cache.
-	c.v.SetDefault(varCacheControlUser, "private,max-age=2")
+	c.v.SetDefault(varCacheControlUser, "private,max-age=120")
 
 	// Features
 	c.v.SetDefault(varFeatureWorkitemRemote, true)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -72,26 +72,39 @@ const (
 	varTokenPrivateKey                  = "token.privatekey"
 	varAuthNotApprovedRedirect          = "auth.notapproved.redirect"
 	varHeaderMaxLength                  = "header.maxlength"
-	varCacheControlWorkItems            = "cachecontrol.workitems"
-	varCacheControlWorkItemTypes        = "cachecontrol.workitemtypes"
-	varCacheControlWorkItemLinks        = "cachecontrol.workitemLinks"
-	varCacheControlWorkItemLinkTypes    = "cachecontrol.workitemlinktypes"
-	varCacheControlSpaces               = "cachecontrol.spaces"
-	varCacheControlIterations           = "cachecontrol.iterations"
-	varCacheControlAreas                = "cachecontrol.areas"
-	varCacheControlComments             = "cachecontrol.comments"
-	varCacheControlFilters              = "cachecontrol.filters"
-	varCacheControlUsers                = "cachecontrol.users"
-	varCacheControlCollaborators        = "cachecontrol.collaborators"
-	varCacheControlUser                 = "cachecontrol.user"
-	defaultConfigFile                   = "config.yaml"
-	varOpenshiftTenantMasterURL         = "openshift.tenant.masterurl"
-	varCheStarterURL                    = "chestarterurl"
-	varValidRedirectURLs                = "redirect.valid"
-	varLogLevel                         = "log.level"
-	varLogJSON                          = "log.json"
-	varTenantServiceURL                 = "tenant.serviceurl"
-	varNotificationServiceURL           = "notification.serviceurl"
+
+	// cache control settings for a list of resources
+	varCacheControlWorkItems         = "cachecontrol.workitems"
+	varCacheControlWorkItemTypes     = "cachecontrol.workitemtypes"
+	varCacheControlWorkItemLinks     = "cachecontrol.workitemLinks"
+	varCacheControlWorkItemLinkTypes = "cachecontrol.workitemlinktypes"
+	varCacheControlSpaces            = "cachecontrol.spaces"
+	varCacheControlIterations        = "cachecontrol.iterations"
+	varCacheControlAreas             = "cachecontrol.areas"
+	varCacheControlComments          = "cachecontrol.comments"
+	varCacheControlFilters           = "cachecontrol.filters"
+	varCacheControlUsers             = "cachecontrol.users"
+	varCacheControlCollaborators     = "cachecontrol.collaborators"
+
+	// cache control settings for a single resource
+	varCacheControlUser             = "cachecontrol.user"
+	varCacheControlWorkItem         = "cachecontrol.workitem"
+	varCacheControlWorkItemType     = "cachecontrol.workitemtype"
+	varCacheControlWorkItemLink     = "cachecontrol.workitemLink"
+	varCacheControlWorkItemLinkType = "cachecontrol.workitemlinktype"
+	varCacheControlSpace            = "cachecontrol.space"
+	varCacheControlIteration        = "cachecontrol.iteration"
+	varCacheControlArea             = "cachecontrol.area"
+	varCacheControlComment          = "cachecontrol.comment"
+
+	defaultConfigFile           = "config.yaml"
+	varOpenshiftTenantMasterURL = "openshift.tenant.masterurl"
+	varCheStarterURL            = "chestarterurl"
+	varValidRedirectURLs        = "redirect.valid"
+	varLogLevel                 = "log.level"
+	varLogJSON                  = "log.json"
+	varTenantServiceURL         = "tenant.serviceurl"
+	varNotificationServiceURL   = "notification.serviceurl"
 )
 
 // ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
@@ -190,7 +203,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varKeycloakTesUserName, defaultKeycloakTesUserName)
 	c.v.SetDefault(varKeycloakTesUserSecret, defaultKeycloakTesUserSecret)
 
-	// HTTP Cache-Control/max-age default
+	// HTTP Cache-Control/max-age default for a list of resources
 	c.v.SetDefault(varCacheControlWorkItems, "max-age=2") // very short life in cache, to allow for quick, repetitive updates.
 	c.v.SetDefault(varCacheControlWorkItemTypes, "max-age=2")
 	c.v.SetDefault(varCacheControlWorkItemLinks, "max-age=2")
@@ -202,6 +215,16 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varCacheControlFilters, "max-age=86400")
 	c.v.SetDefault(varCacheControlUsers, "max-age=2")
 	c.v.SetDefault(varCacheControlCollaborators, "max-age=2")
+
+	// Cache control values for a single resource
+	c.v.SetDefault(varCacheControlWorkItem, "private,max-age=120")
+	c.v.SetDefault(varCacheControlWorkItemType, "private,max-age=120")
+	c.v.SetDefault(varCacheControlWorkItemLink, "private,max-age=120")
+	c.v.SetDefault(varCacheControlWorkItemLinkType, "private,max-age=120")
+	c.v.SetDefault(varCacheControlSpace, "private,max-age=120")
+	c.v.SetDefault(varCacheControlIteration, "private,max-age=120")
+	c.v.SetDefault(varCacheControlArea, "private,max-age=120")
+	c.v.SetDefault(varCacheControlComment, "private,max-age=120")
 	// data returned from '/api/user' must not be cached by intermediate proxies,
 	// but can only be kept in the client's local cache.
 	c.v.SetDefault(varCacheControlUser, "private,max-age=2")
@@ -316,51 +339,99 @@ func (c *ConfigurationData) IsPostgresDeveloperModeEnabled() bool {
 }
 
 // GetCacheControlWorkItemTypes returns the value to set in the "Cache-Control" HTTP response header
-// when returning a work item type (or a list of).
+// when returning a list of work item types.
 func (c *ConfigurationData) GetCacheControlWorkItemTypes() string {
 	return c.v.GetString(varCacheControlWorkItemTypes)
 }
 
+// GetCacheControlWorkItemType returns the value to set in the "Cache-Control" HTTP response header
+// when returning a work item type.
+func (c *ConfigurationData) GetCacheControlWorkItemType() string {
+	return c.v.GetString(varCacheControlWorkItemType)
+}
+
 // GetCacheControlWorkItemLinkTypes returns the value to set in the "Cache-Control" HTTP response header
-// when returning a work item type (or a list of).
+// when returning a list of work item types.
 func (c *ConfigurationData) GetCacheControlWorkItemLinkTypes() string {
 	return c.v.GetString(varCacheControlWorkItemLinkTypes)
 }
 
+// GetCacheControlWorkItemLinkType returns the value to set in the "Cache-Control" HTTP response header
+// when returning a work item type.
+func (c *ConfigurationData) GetCacheControlWorkItemLinkType() string {
+	return c.v.GetString(varCacheControlWorkItemLinkType)
+}
+
 // GetCacheControlWorkItems returns the value to set in the "Cache-Control" HTTP response header
-// when returning a work item (or a list of).
+// when returning a list of work items.
 func (c *ConfigurationData) GetCacheControlWorkItems() string {
 	return c.v.GetString(varCacheControlWorkItems)
 }
 
+// GetCacheControlWorkItem returns the value to set in the "Cache-Control" HTTP response header
+// when returning a work item.
+func (c *ConfigurationData) GetCacheControlWorkItem() string {
+	return c.v.GetString(varCacheControlWorkItem)
+}
+
 // GetCacheControlWorkItemLinks returns the value to set in the "Cache-Control" HTTP response header
-// when returning a work item (or a list of).
+// when returning a list of work item links.
 func (c *ConfigurationData) GetCacheControlWorkItemLinks() string {
 	return c.v.GetString(varCacheControlWorkItemLinks)
 }
 
+// GetCacheControlWorkItemLink returns the value to set in the "Cache-Control" HTTP response header
+// when returning a work item.
+func (c *ConfigurationData) GetCacheControlWorkItemLink() string {
+	return c.v.GetString(varCacheControlWorkItemLink)
+}
+
 // GetCacheControlAreas returns the value to set in the "Cache-Control" HTTP response header
-// when returning a work item (or a list of).
+// when returning a list of work items.
 func (c *ConfigurationData) GetCacheControlAreas() string {
 	return c.v.GetString(varCacheControlAreas)
 }
 
+// GetCacheControlArea returns the value to set in the "Cache-Control" HTTP response header
+// when returning a work item (or a list of).
+func (c *ConfigurationData) GetCacheControlArea() string {
+	return c.v.GetString(varCacheControlArea)
+}
+
 // GetCacheControlSpaces returns the value to set in the "Cache-Control" HTTP response header
-// when returning spaces.
+// when returning a list of spaces.
 func (c *ConfigurationData) GetCacheControlSpaces() string {
 	return c.v.GetString(varCacheControlSpaces)
 }
 
+// GetCacheControlSpace returns the value to set in the "Cache-Control" HTTP response header
+// when returning a space.
+func (c *ConfigurationData) GetCacheControlSpace() string {
+	return c.v.GetString(varCacheControlSpace)
+}
+
 // GetCacheControlIterations returns the value to set in the "Cache-Control" HTTP response header
-// when returning iterations.
+// when returning a list of iterations.
 func (c *ConfigurationData) GetCacheControlIterations() string {
 	return c.v.GetString(varCacheControlIterations)
 }
 
+// GetCacheControlIteration returns the value to set in the "Cache-Control" HTTP response header
+// when returning an iteration.
+func (c *ConfigurationData) GetCacheControlIteration() string {
+	return c.v.GetString(varCacheControlIteration)
+}
+
 // GetCacheControlComments returns the value to set in the "Cache-Control" HTTP response header
-// when returning comments.
+// when returning a list of comments.
 func (c *ConfigurationData) GetCacheControlComments() string {
 	return c.v.GetString(varCacheControlComments)
+}
+
+// GetCacheControlComment returns the value to set in the "Cache-Control" HTTP response header
+// when returning a comment.
+func (c *ConfigurationData) GetCacheControlComment() string {
+	return c.v.GetString(varCacheControlComment)
 }
 
 // GetCacheControlFilters returns the value to set in the "Cache-Control" HTTP response header

--- a/controller/area.go
+++ b/controller/area.go
@@ -30,6 +30,7 @@ type AreaController struct {
 // AreaControllerConfiguration the configuration for the AreaController
 type AreaControllerConfiguration interface {
 	GetCacheControlAreas() string
+	GetCacheControlArea() string
 }
 
 // NewAreaController creates a area controller.
@@ -129,7 +130,7 @@ func (c *AreaController) Show(ctx *app.ShowAreaContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalRequest(*a, c.config.GetCacheControlAreas, func() error {
+		return ctx.ConditionalRequest(*a, c.config.GetCacheControlArea, func() error {
 			res := &app.AreaSingle{}
 			res.Data = ConvertArea(appl, ctx.RequestData, *a, addResolvedPath)
 			return ctx.OK(res)

--- a/controller/comments.go
+++ b/controller/comments.go
@@ -31,6 +31,7 @@ type CommentsController struct {
 // CommentsControllerConfiguration the configuration for CommentsController
 type CommentsControllerConfiguration interface {
 	GetCacheControlComments() string
+	GetCacheControlComment() string
 }
 
 // NewCommentsController creates a comments controller.
@@ -60,7 +61,7 @@ func (c *CommentsController) Show(ctx *app.ShowCommentsContext) error {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrUnauthorized(err.Error()))
 			return ctx.NotFound(jerrors)
 		}
-		return ctx.ConditionalRequest(*cmt, c.config.GetCacheControlComments, func() error {
+		return ctx.ConditionalRequest(*cmt, c.config.GetCacheControlComment, func() error {
 			res := &app.CommentSingle{}
 			// This code should change if others type of parents than WI are allowed
 			includeParentWorkItem, err := CommentIncludeParentWorkItem(ctx, appl, cmt)

--- a/controller/iteration.go
+++ b/controller/iteration.go
@@ -29,6 +29,7 @@ type IterationController struct {
 
 type IterationControllerConfiguration interface {
 	GetCacheControlIterations() string
+	GetCacheControlIteration() string
 }
 
 // NewIterationController creates a iteration controller.
@@ -119,7 +120,7 @@ func (c *IterationController) Show(ctx *app.ShowIterationContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalRequest(*iter, c.config.GetCacheControlIterations, func() error {
+		return ctx.ConditionalRequest(*iter, c.config.GetCacheControlIteration, func() error {
 			wiCounts, err := appl.WorkItems().GetCountsForIteration(ctx, iter)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/space.go
+++ b/controller/space.go
@@ -37,6 +37,7 @@ type SpaceConfiguration interface {
 	GetKeycloakClientID() string
 	GetKeycloakSecret() string
 	GetCacheControlSpaces() string
+	GetCacheControlSpace() string
 }
 
 // SpaceController implements the space resource.
@@ -255,7 +256,7 @@ func (c *SpaceController) Show(ctx *app.ShowSpaceContext) error {
 			}, "unable to load the space by ID")
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalRequest(*s, c.config.GetCacheControlSpaces, func() error {
+		return ctx.ConditionalRequest(*s, c.config.GetCacheControlSpace, func() error {
 			spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
 			if err != nil {
 				log.Error(ctx, map[string]interface{}{

--- a/controller/test-files/work_item_type/show/not_modified_using_if_modified_since_header.headers.golden.json
+++ b/controller/test-files/work_item_type/show/not_modified_using_if_modified_since_header.headers.golden.json
@@ -1,6 +1,6 @@
 {
   "Cache-Control": [
-    "max-age=2"
+    "private,max-age=120"
   ],
   "Etag": [
     "6/t2yDx7UrWE2j4zZlaehg=="

--- a/controller/test-files/work_item_type/show/not_modified_using_ifnonematch_header.headers.golden.json
+++ b/controller/test-files/work_item_type/show/not_modified_using_ifnonematch_header.headers.golden.json
@@ -1,6 +1,6 @@
 {
   "Cache-Control": [
-    "max-age=2"
+    "private,max-age=120"
   ],
   "Etag": [
     "6/t2yDx7UrWE2j4zZlaehg=="

--- a/controller/test-files/work_item_type/show/ok.headers.golden.json
+++ b/controller/test-files/work_item_type/show/ok.headers.golden.json
@@ -1,6 +1,6 @@
 {
   "Cache-Control": [
-    "max-age=2"
+    "private,max-age=120"
   ],
   "Content-Type": [
     "application/vnd.api+json"

--- a/controller/test-files/work_item_type/show/ok_using_expired_etag_header.headers.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_etag_header.headers.golden.json
@@ -1,6 +1,6 @@
 {
   "Cache-Control": [
-    "max-age=2"
+    "private,max-age=120"
   ],
   "Content-Type": [
     "application/vnd.api+json"

--- a/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.headers.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.headers.golden.json
@@ -1,6 +1,6 @@
 {
   "Cache-Control": [
-    "max-age=2"
+    "private,max-age=120"
   ],
   "Content-Type": [
     "application/vnd.api+json"

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -26,6 +26,7 @@ type WorkItemLinkController struct {
 // WorkItemLinkControllerConfig the config interface for the WorkitemLinkController
 type WorkItemLinkControllerConfig interface {
 	GetCacheControlWorkItemLinks() string
+	GetCacheControlWorkItemLink() string
 }
 
 // NewWorkItemLinkController creates a work-item-link controller.
@@ -322,7 +323,7 @@ func (c *WorkItemLinkController) Show(ctx *app.ShowWorkItemLinkContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalRequest(*modelLink, c.config.GetCacheControlWorkItemLinks, func() error {
+		return ctx.ConditionalRequest(*modelLink, c.config.GetCacheControlWorkItemLink, func() error {
 			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, nil)
 			// convert to rest representation
 			appLink := ConvertLinkFromModel(*modelLink)

--- a/controller/work_item_link_type.go
+++ b/controller/work_item_link_type.go
@@ -25,6 +25,7 @@ type WorkItemLinkTypeController struct {
 // WorkItemLinkTypeControllerConfiguration the configuration for the WorkItemLinkTypeController
 type WorkItemLinkTypeControllerConfiguration interface {
 	GetCacheControlWorkItemLinkTypes() string
+	GetCacheControlWorkItemLinkType() string
 }
 
 // NewWorkItemLinkTypeController creates a work-item-link-type controller.
@@ -225,7 +226,7 @@ func (c *WorkItemLinkTypeController) Show(ctx *app.ShowWorkItemLinkTypeContext) 
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalRequest(*modelLinkType, c.config.GetCacheControlWorkItemLinkTypes, func() error {
+		return ctx.ConditionalRequest(*modelLinkType, c.config.GetCacheControlWorkItemLinkType, func() error {
 			// Convert the created link type entry into a rest representation
 			appLinkType := ConvertWorkItemLinkTypeFromModel(ctx.RequestData, *modelLinkType)
 

--- a/controller/work_item_relationships_links.go
+++ b/controller/work_item_relationships_links.go
@@ -24,6 +24,7 @@ type WorkItemRelationshipsLinksController struct {
 // WorkItemRelationshipsLinksControllerConfig the config interface for the WorkItemRelationshipsLinksController
 type WorkItemRelationshipsLinksControllerConfig interface {
 	GetCacheControlWorkItemLinks() string
+	GetCacheControlWorkItemLink() string
 }
 
 // NewWorkItemRelationshipsLinksController creates a work-item-relationships-links controller.

--- a/controller/work_item_relationships_links.go
+++ b/controller/work_item_relationships_links.go
@@ -24,7 +24,6 @@ type WorkItemRelationshipsLinksController struct {
 // WorkItemRelationshipsLinksControllerConfig the config interface for the WorkItemRelationshipsLinksController
 type WorkItemRelationshipsLinksControllerConfig interface {
 	GetCacheControlWorkItemLinks() string
-	GetCacheControlWorkItemLink() string
 }
 
 // NewWorkItemRelationshipsLinksController creates a work-item-relationships-links controller.

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -46,6 +46,7 @@ type WorkitemController struct {
 // WorkItemControllerConfig the config interface for the WorkitemController
 type WorkItemControllerConfig interface {
 	GetCacheControlWorkItems() string
+	GetCacheControlWorkItem() string
 }
 
 // NewWorkitemController creates a workitem controller.
@@ -148,7 +149,7 @@ func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Fail to load work item with id %v", ctx.WiID)))
 		}
-		return ctx.ConditionalRequest(*wi, c.config.GetCacheControlWorkItems, func() error {
+		return ctx.ConditionalRequest(*wi, c.config.GetCacheControlWorkItem, func() error {
 			comments := workItemIncludeCommentsAndTotal(ctx, c.db, ctx.WiID)
 			hasChildren := workItemIncludeHasChildren(appl, ctx)
 			wi2 := ConvertWorkItem(ctx.RequestData, *wi, comments, hasChildren)

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -32,6 +32,7 @@ type WorkitemtypeController struct {
 
 type WorkItemControllerConfiguration interface {
 	GetCacheControlWorkItemTypes() string
+	GetCacheControlWorkItemType() string
 }
 
 // NewWorkitemtypeController creates a workitemtype controller.
@@ -50,7 +51,7 @@ func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalRequest(*witModel, c.config.GetCacheControlWorkItemTypes, func() error {
+		return ctx.ConditionalRequest(*witModel, c.config.GetCacheControlWorkItemType, func() error {
 			witData := ConvertWorkItemTypeFromModel(ctx.RequestData, witModel)
 			wit := &app.WorkItemTypeSingle{Data: &witData}
 			return ctx.OK(wit)

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -395,7 +395,7 @@ func (s *workItemTypeSuite) TestShow() {
 
 	s.T().Run("not modified - using IfModifiedSince header", func(t *testing.T) {
 		// when
-		lastModified := app.ToHTTPTime(time.Now().Add(1 * time.Second))
+		lastModified := app.ToHTTPTime(time.Now().Add(119 * time.Second))
 		res := test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, &lastModified, nil)
 		// then
 		compareWithGolden(t, filepath.Join(s.testDir, "show", "not_modified_using_if_modified_since_header.headers.golden.json"), res.Header())


### PR DESCRIPTION
Nowadays we set the same max-age for a single resource or a list of resources. Therefore, this PR aims to define a different max-age for a single resource. 
