### PR TITLE
Add "Execution" to the TypeGroup list.

### DIFF
--- a/controller/work_item_type_group.go
+++ b/controller/work_item_type_group.go
@@ -39,6 +39,7 @@ func (c *WorkItemTypeGroupController) List(ctx *app.ListWorkItemTypeGroupContext
 				ConvertTypeGroup(ctx.RequestData, typegroup.Portfolio0),
 				ConvertTypeGroup(ctx.RequestData, typegroup.Portfolio1),
 				ConvertTypeGroup(ctx.RequestData, typegroup.Requirements0),
+				ConvertTypeGroup(ctx.RequestData, typegroup.Execution0),
 			},
 		},
 		Type: APIWorkItemTypeGroups,

--- a/controller/work_item_type_group_blackbox_test.go
+++ b/controller/work_item_type_group_blackbox_test.go
@@ -60,14 +60,16 @@ func (s *workItemTypeGroupSuite) TestListTypeGroups() {
 	sapcetemplateID := space.SystemSpace // must be valid space ID
 	_, groups := test.ListWorkItemTypeGroupOK(s.T(), nil, s.svc, s.typeGroupCtrl, sapcetemplateID)
 	assert.NotEmpty(s.T(), groups)
-	require.Len(s.T(), groups.Data.Attributes.Hierarchy, 3)
+	require.Len(s.T(), groups.Data.Attributes.Hierarchy, 4)
 	require.Equal(s.T(), typegroup.GroupPortfolio, groups.Data.Attributes.Hierarchy[0].Group)
 	require.Equal(s.T(), typegroup.GroupPortfolio, groups.Data.Attributes.Hierarchy[1].Group)
 	require.Equal(s.T(), typegroup.GroupRequirements, groups.Data.Attributes.Hierarchy[2].Group)
+	require.Equal(s.T(), typegroup.GroupExecution, groups.Data.Attributes.Hierarchy[3].Group)
 
 	assert.Equal(s.T(), typegroup.Portfolio0.WorkItemTypeCollection, groups.Data.Attributes.Hierarchy[0].WitCollection)
 	assert.Equal(s.T(), typegroup.Portfolio1.WorkItemTypeCollection, groups.Data.Attributes.Hierarchy[1].WitCollection)
 	assert.Equal(s.T(), typegroup.Requirements0.WorkItemTypeCollection, groups.Data.Attributes.Hierarchy[2].WitCollection)
+	assert.Equal(s.T(), typegroup.Execution0.WorkItemTypeCollection, groups.Data.Attributes.Hierarchy[3].WitCollection)
 }
 
 func (s *workItemTypeGroupSuite) TestListTypeGroupsNotFound() {

--- a/workitem/typegroup/typegroup.go
+++ b/workitem/typegroup/typegroup.go
@@ -8,6 +8,13 @@ import (
 
 // WorkItemTypeGroup represents the node in the group of work item types
 type WorkItemTypeGroup struct {
+	// Generally Level should look like {0, 0}
+	// First Index defines the nested level of the object in TypeHierarchy.
+	// Second Index defines the child level within that object
+	// e.g> {0, 0} -> object is at 0th level and it is 0th child
+	// e.g> {0, 1} -> Object is at 0th level and it is 1st child
+	// e.g> {1, 0} -> Object is at 1st level and it is 0th child
+	// e.g> {1, 2, 3} -> Object is at 1st level & it is 2nd child's 3rd child
 	Level                  []int
 	Group                  string
 	Name                   string

--- a/workitem/typegroup/typegroup.go
+++ b/workitem/typegroup/typegroup.go
@@ -18,6 +18,7 @@ type WorkItemTypeGroup struct {
 const (
 	GroupPortfolio    = "portfolio"
 	GroupRequirements = "requirements"
+	GroupExecution    = "execution"
 )
 
 // Portfolio0 defines first level of typegroup Portfolio
@@ -52,5 +53,16 @@ var Requirements0 = WorkItemTypeGroup{
 	WorkItemTypeCollection: []uuid.UUID{
 		workitem.SystemFeature,
 		workitem.SystemBug,
+	},
+}
+
+// Execution0 defines first level of typegroup Execution
+// This group has less priority than Requirements
+var Execution0 = WorkItemTypeGroup{
+	Group: GroupExecution,
+	Level: []int{2, 0},
+	Name:  "Execution",
+	WorkItemTypeCollection: []uuid.UUID{
+		workitem.SystemTask,
 	},
 }


### PR DESCRIPTION
TypeGroup should return "Execution" as well.
Now the following object is added to the list.
```
         {
          "group": "execution",
          "level": [
            2,
            0
          ],
          "name": "Execution",
          "wit_collection": [
            "bbf35418-04b6-426c-a60b-7f80beb0b624"
          ]
        }
```

Tests are updated as well.