### PR TITLE
Return 409 errors whenever the item already exists

### DIFF
--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -339,12 +339,12 @@ func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLink() {
 }
 
 // Check if #586 is fixed.
-func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLinkBadRequestDueToUniqueViolation() {
+func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLinkConflictDueToUniqueViolation() {
 	createPayload1 := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
 	_, workItemLink1 := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload1)
 	require.NotNil(s.T(), workItemLink1)
 	createPayload2 := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemLinkBadRequest(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload2)
+	_, _ = test.CreateWorkItemLinkConflict(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload2)
 }
 
 // Same for /api/workitems/:id/relationships/links

--- a/design/work_item_link.go
+++ b/design/work_item_link.go
@@ -187,6 +187,7 @@ func createWorkItemLink() {
 	a.Response(d.InternalServerError, JSONAPIErrors)
 	a.Response(d.Unauthorized, JSONAPIErrors)
 	a.Response(d.NotFound, JSONAPIErrors)
+	a.Response(d.Conflict, JSONAPIErrors)
 }
 
 func deleteWorkItemLink() {

--- a/design/work_item_link_category.go
+++ b/design/work_item_link_category.go
@@ -159,6 +159,7 @@ var _ = a.Resource("work_item_link_category", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 
 	a.Action("delete", func() {

--- a/design/work_item_link_type.go
+++ b/design/work_item_link_type.go
@@ -191,6 +191,7 @@ var _ = a.Resource("work_item_link_type", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 
 	a.Action("delete", func() {

--- a/workitem/link/category_repository.go
+++ b/workitem/link/category_repository.go
@@ -48,7 +48,7 @@ func (r *GormWorkItemLinkCategoryRepository) Create(ctx context.Context, linkCat
 			log.Error(ctx, map[string]interface{}{
 				"err":       db.Error,
 				"wilc_name": linkCat.Name,
-			}, "unable to create work item link category because a category exists with the same name")
+			}, "unable to create work item link category because a category already exists with the same name")
 			return nil, errors.NewDataConflictError(fmt.Sprintf("work item link category already exists with the same name: %s ", linkCat.Name))
 		}
 		return nil, errors.NewInternalError(ctx, db.Error)

--- a/workitem/link/category_repository.go
+++ b/workitem/link/category_repository.go
@@ -2,10 +2,12 @@ package link
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/application/repository"
 	"github.com/fabric8-services/fabric8-wit/errors"
+	"github.com/fabric8-services/fabric8-wit/gormsupport"
 	"github.com/fabric8-services/fabric8-wit/log"
 
 	"github.com/goadesign/goa"
@@ -42,6 +44,13 @@ func (r *GormWorkItemLinkCategoryRepository) Create(ctx context.Context, linkCat
 	}
 	db := r.db.Create(linkCat)
 	if db.Error != nil {
+		if gormsupport.IsUniqueViolation(db.Error, "work_item_link_categories_name_idx") {
+			log.Error(ctx, map[string]interface{}{
+				"err":       db.Error,
+				"wilc_name": linkCat.Name,
+			}, "unable to create work item link category because a category exists with the same name")
+			return nil, errors.NewDataConflictError(fmt.Sprintf("work item link category already exists with the same name: %s ", linkCat.Name))
+		}
 		return nil, errors.NewInternalError(ctx, db.Error)
 	}
 	log.Info(ctx, map[string]interface{}{

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -150,8 +150,11 @@ func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targe
 	db := r.db.Create(link)
 	if db.Error != nil {
 		if gormsupport.IsUniqueViolation(db.Error, "work_item_links_unique_idx") {
-			// TODO(kwk): Make NewBadParameterError a variadic function to avoid this ugliness ;)
-			return nil, errors.NewBadParameterError("data.relationships.source_id + data.relationships.target_id + data.relationships.link_type_id", sourceID).Expected("unique")
+			log.Error(ctx, map[string]interface{}{
+				"err":       db.Error,
+				"source_id": sourceID,
+			}, "unable to create work item link because a link exists with the same source_id, target_id and type_id")
+			return nil, errors.NewDataConflictError(fmt.Sprintf("work item link already exists with data.relationships.source_id: %s; data.relationships.target_id: %s; data.relationships.link_type_id: %s ", sourceID, targetID, linkTypeID))
 		}
 		if gormsupport.IsForeignKeyViolation(db.Error, "work_item_links_source_id_fkey") {
 			return nil, errors.NewNotFoundError("source", sourceID.String())

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -153,7 +153,7 @@ func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targe
 			log.Error(ctx, map[string]interface{}{
 				"err":       db.Error,
 				"source_id": sourceID,
-			}, "unable to create work item link because a link exists with the same source_id, target_id and type_id")
+			}, "unable to create work item link because a link already exists with the same source_id, target_id and type_id")
 			return nil, errors.NewDataConflictError(fmt.Sprintf("work item link already exists with data.relationships.source_id: %s; data.relationships.target_id: %s; data.relationships.link_type_id: %s ", sourceID, targetID, linkTypeID))
 		}
 		if gormsupport.IsForeignKeyViolation(db.Error, "work_item_links_source_id_fkey") {


### PR DESCRIPTION
In addition to the issues https://github.com/fabric8-services/fabric8-wit/issues/1485, we adapted the code in other models to retunr 409 conflicts when an item already exists.