### PR TITLE
Etag for iterations does not change when number of attached WIs changed (#1587)

### DIFF
--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -51,7 +51,7 @@ func (rest *TestIterationREST) SetupTest() {
 }
 
 func (rest *TestIterationREST) TearDownTest() {
-	rest.clean()
+	// rest.clean()
 }
 
 func (rest *TestIterationREST) SecuredController() (*goa.Service, *IterationController) {
@@ -251,6 +251,133 @@ func (rest *TestIterationREST) TestShowIterationNotModifiedUsingIfNoneMatchHeade
 	// when/then
 	ifNoneMatch := app.GenerateEntityTag(itr)
 	test.ShowIterationNotModified(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), nil, &ifNoneMatch)
+}
+
+func (rest *TestIterationREST) createWorkItem(parentSpace space.Space) workitem.WorkItem {
+	var wi *workitem.WorkItem
+	err := application.Transactional(gormapplication.NewGormDB(rest.DB), func(app application.Application) error {
+		fields := map[string]interface{}{
+			workitem.SystemTitle: "Test Item",
+			workitem.SystemState: "new",
+		}
+		w, err := app.WorkItems().Create(context.Background(), parentSpace.ID, workitem.SystemBug, fields, parentSpace.OwnerId)
+		wi = w
+		return err
+	})
+	require.Nil(rest.T(), err)
+	return *wi
+}
+
+func (rest *TestIterationREST) TestShowIterationModifiedUsingIfModifiedSinceHeaderAfterWorkItemLinking() {
+	// given
+	parentSpace, _, _, _, itr := createSpaceAndRootAreaAndIterations(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	rest.T().Logf("Iteration: %s: updatedAt: %s", itr.ID.String(), itr.UpdatedAt.String())
+	ifModifiedSinceHeader := app.ToHTTPTime(itr.UpdatedAt)
+	testWI := rest.createWorkItem(parentSpace)
+	testWI.Fields[workitem.SystemIteration] = itr.ID.String()
+	// need to wait at least 1s because HTTP date time does not include microseconds, hence `Last-Modified` vs `If-Modified-Since` comparison may fail
+	time.Sleep(1 * time.Second)
+	err := application.Transactional(rest.db, func(app application.Application) error {
+		_, err := app.WorkItems().Save(context.Background(), parentSpace.ID, testWI, parentSpace.OwnerId)
+		return err
+	})
+	require.Nil(rest.T(), err)
+	// when/then
+	test.ShowIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &ifModifiedSinceHeader, nil)
+}
+
+func (rest *TestIterationREST) TestShowIterationModifiedUsingIfModifiedSinceHeaderAfterWorkItemUnlinking() {
+	// given
+	parentSpace, _, _, _, itr := createSpaceAndRootAreaAndIterations(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	rest.T().Logf("Iteration: %s: updatedAt: %s", itr.ID.String(), itr.UpdatedAt.String())
+	testWI := rest.createWorkItem(parentSpace)
+	testWI.Fields[workitem.SystemIteration] = itr.ID.String()
+	// need to wait at least 1s because HTTP date time does not include microseconds, hence `Last-Modified` vs `If-Modified-Since` comparison may fail
+	time.Sleep(1 * time.Second)
+	var updatedWI *workitem.WorkItem
+	err := application.Transactional(rest.db, func(app application.Application) error {
+		w, err := app.WorkItems().Save(context.Background(), parentSpace.ID, testWI, parentSpace.OwnerId)
+		updatedWI = w
+		return err
+	})
+	require.Nil(rest.T(), err)
+	testWI = *updatedWI
+	// read the iteration to compute its current `If-Modified-Since` value
+	var updatedItr *iteration.Iteration
+	err = application.Transactional(rest.db, func(app application.Application) error {
+		i, err := app.Iterations().Load(context.Background(), itr.ID)
+		updatedItr = i
+		return err
+	})
+	ifModifiedSinceHeader := app.ToHTTPTime(updatedItr.GetLastModified())
+	// now, unlink the work item from the iteration
+	// need to wait at least 1s because HTTP date time does not include microseconds, hence `Last-Modified` vs `If-Modified-Since` comparison may fail
+	delete(testWI.Fields, workitem.SystemIteration)
+	time.Sleep(1 * time.Second)
+	err = application.Transactional(rest.db, func(app application.Application) error {
+		_, err := app.WorkItems().Save(context.Background(), parentSpace.ID, testWI, parentSpace.OwnerId)
+		return err
+	})
+	require.Nil(rest.T(), err)
+	// when/then
+	test.ShowIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &ifModifiedSinceHeader, nil)
+}
+
+func (rest *TestIterationREST) TestShowIterationModifiedUsingIfNoneMatchHeaderAfterWorkItemLinking() {
+	// given
+	parentSpace, _, _, _, itr := createSpaceAndRootAreaAndIterations(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	ifNoneMatch := app.GenerateEntityTag(itr)
+	// now, create and attach a work item to the iteration
+	testWI := rest.createWorkItem(parentSpace)
+	testWI.Fields[workitem.SystemIteration] = itr.ID.String()
+	err := application.Transactional(rest.db, func(app application.Application) error {
+		_, err := app.WorkItems().Save(context.Background(), parentSpace.ID, testWI, parentSpace.OwnerId)
+		return err
+	})
+	require.Nil(rest.T(), err)
+	// when/then
+	test.ShowIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), nil, &ifNoneMatch)
+}
+
+func (rest *TestIterationREST) TestShowIterationModifiedUsingIfNoneMatchHeaderAfterWorkItemUnlinking() {
+	// given
+	parentSpace, _, _, _, itr := createSpaceAndRootAreaAndIterations(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	rest.T().Logf("Iteration: %s: updatedAt: %s", itr.ID.String(), itr.UpdatedAt.String())
+	testWI := rest.createWorkItem(parentSpace)
+	testWI.Fields[workitem.SystemIteration] = itr.ID.String()
+	// need to wait at least 1s because HTTP date time does not include microseconds, hence `Last-Modified` vs `If-Modified-Since` comparison may fail
+	time.Sleep(1 * time.Second)
+	var updatedWI *workitem.WorkItem
+	err := application.Transactional(rest.db, func(app application.Application) error {
+		w, err := app.WorkItems().Save(context.Background(), parentSpace.ID, testWI, parentSpace.OwnerId)
+		updatedWI = w
+		return err
+	})
+	require.Nil(rest.T(), err)
+	testWI = *updatedWI
+	// read the iteration to compute its current `If-None-Match` value
+	var updatedItr *iteration.Iteration
+	err = application.Transactional(rest.db, func(app application.Application) error {
+		i, err := app.Iterations().Load(context.Background(), itr.ID)
+		updatedItr = i
+		return err
+	})
+	ifNoneMatch := app.GenerateEntityTag(*updatedItr)
+	// now, unlink the work item from the iteration
+	// need to wait at least 1s because HTTP date time does not include microseconds, hence `Last-Modified` vs `If-Modified-Since` comparison may fail
+	delete(testWI.Fields, workitem.SystemIteration)
+	time.Sleep(1 * time.Second)
+	err = application.Transactional(rest.db, func(app application.Application) error {
+		_, err := app.WorkItems().Save(context.Background(), parentSpace.ID, testWI, parentSpace.OwnerId)
+		return err
+	})
+	require.Nil(rest.T(), err)
+	// when/then
+	test.ShowIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), nil, &ifNoneMatch)
 }
 
 func (rest *TestIterationREST) TestFailShowIterationMissing() {

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -51,7 +51,7 @@ func (rest *TestIterationREST) SetupTest() {
 }
 
 func (rest *TestIterationREST) TearDownTest() {
-	// rest.clean()
+	rest.clean()
 }
 
 func (rest *TestIterationREST) SecuredController() (*goa.Service, *IterationController) {

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -657,7 +657,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			workitem.SystemStateResolved, sprint2.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3+5) // resolved items + items in iteraion2
+		assert.Len(s.T(), result.Data, 3+5) // resolved items + items in iteraion2
 	})
 
 	s.T().Run("state IN resolved, closed", func(t *testing.T) {
@@ -669,7 +669,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			workitem.SystemStateResolved, workitem.SystemStateClosed)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3+5) // state = resolved or state = closed
+		assert.Len(s.T(), result.Data, 3+5) // state = resolved or state = closed
 	})
 
 	s.T().Run("space=ID AND (state=resolved OR iteration=sprint2)", func(t *testing.T) {
@@ -684,7 +684,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemStateResolved, sprint2.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3+5)
+		assert.Len(s.T(), result.Data, 3+5)
 	})
 
 	s.T().Run("space=ID AND (state=resolved OR iteration=sprint2) using EQ", func(t *testing.T) {
@@ -699,7 +699,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemStateResolved, sprint2.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3+5)
+		assert.Len(s.T(), result.Data, 3+5)
 	})
 
 	s.T().Run("space=ID AND (state!=resolved AND iteration=sprint1)", func(t *testing.T) {
@@ -713,7 +713,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			]}`,
 			spaceIDStr, workitem.SystemStateResolved, sprint1.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
-		require.Len(s.T(), result.Data, 0)
+		assert.Len(s.T(), result.Data, 0)
 	})
 
 	s.T().Run("space=ID AND (state!=open AND iteration!=fake-iterationID)", func(t *testing.T) {
@@ -729,7 +729,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemStateOpen, fakeIterationID1)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 8) // all items are other than open state & in other thatn fake itr
+		assert.Len(s.T(), result.Data, 8) // all items are other than open state & in other thatn fake itr
 	})
 
 	s.T().Run("space!=ID AND (state!=open AND iteration!=fake-iterationID)", func(t *testing.T) {
@@ -744,8 +744,8 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			]}`,
 			spaceIDStr, workitem.SystemStateOpen, fakeIterationID1)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
-		require.Empty(s.T(), result.Data)
-		assert.Len(s.T(), result.Data, 0) // all items are other than open state & in other thatn fake itr
+		assert.Empty(s.T(), result.Data) // all items are other than open state & in other thatn fake itr
+		// assert.Len(s.T(), result.Data, 0)
 	})
 
 	s.T().Run("space=ID AND (state!=open AND iteration!=fake-iterationID) using NE", func(t *testing.T) {
@@ -761,7 +761,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemStateOpen, fakeIterationID1)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 8) // all items are other than open state & in other thatn fake itr
+		assert.Len(s.T(), result.Data, 8) // all items are other than open state & in other thatn fake itr
 	})
 
 	s.T().Run("space=FakeID AND state=closed", func(t *testing.T) {
@@ -773,7 +773,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			]}`,
 			fakeSpaceID1, workitem.SystemStateOpen)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &fakeSpaceID1)
-		require.Len(s.T(), result.Data, 0) // we have 5 closed items but they are in different space
+		assert.Len(s.T(), result.Data, 0) // we have 5 closed items but they are in different space
 	})
 
 	s.T().Run("space=spaceID AND state=closed AND assignee=bob", func(t *testing.T) {
@@ -786,7 +786,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, bob.ID, workitem.SystemStateClosed)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 5) // we have 5 closed items assigned to bob
+		assert.Len(s.T(), result.Data, 5) // we have 5 closed items assigned to bob
 	})
 
 	s.T().Run("space=spaceID AND iteration=sprint1 AND assignee=alice", func(t *testing.T) {
@@ -800,7 +800,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, alice.ID, sprint1.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3) // alice worked on 3 issues in sprint1
+		assert.Len(s.T(), result.Data, 3) // alice worked on 3 issues in sprint1
 	})
 
 	s.T().Run("space=spaceID AND state!=closed AND iteration=sprint1 AND assignee=alice", func(t *testing.T) {
@@ -815,7 +815,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, alice.ID, workitem.SystemStateClosed, sprint1.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3)
+		assert.Len(s.T(), result.Data, 3)
 	})
 
 	s.T().Run("space=spaceID AND (state=closed or state=resolved)", func(t *testing.T) {
@@ -831,7 +831,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemStateClosed, workitem.SystemStateResolved)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3+5) //resolved + closed
+		assert.Len(s.T(), result.Data, 3+5) //resolved + closed
 	})
 
 	s.T().Run("space=spaceID AND (type=bug OR type=feature)", func(t *testing.T) {
@@ -847,7 +847,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemBug, workitem.SystemFeature)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3+5) //bugs + features
+		assert.Len(s.T(), result.Data, 3+5) //bugs + features
 	})
 
 	s.T().Run("space=spaceID AND (workitemtype=bug OR workitemtype=feature)", func(t *testing.T) {
@@ -863,7 +863,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemBug, workitem.SystemFeature)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3+5) //bugs + features
+		assert.Len(s.T(), result.Data, 3+5) //bugs + features
 	})
 
 	s.T().Run("space=spaceID AND (type=bug AND state=resolved AND (assignee=bob OR assignee=alice))", func(t *testing.T) {
@@ -879,7 +879,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemBug, workitem.SystemStateResolved, bob.ID, alice.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3) //resolved bugs
+		assert.Len(s.T(), result.Data, 3) //resolved bugs
 	})
 
 	s.T().Run("space=spaceID AND (workitemtype=bug AND state=resolved AND (assignee=bob OR assignee=alice))", func(t *testing.T) {
@@ -895,7 +895,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			spaceIDStr, workitem.SystemBug, workitem.SystemStateResolved, bob.ID, alice.ID)
 		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
 		require.NotEmpty(s.T(), result.Data)
-		require.Len(s.T(), result.Data, 3) //resolved bugs
+		assert.Len(s.T(), result.Data, 3) //resolved bugs
 	})
 
 	s.T().Run("bad expression missing curly brace", func(t *testing.T) {

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/fabric8-services/fabric8-wit/application/repository"
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
@@ -59,7 +58,6 @@ func (m Iteration) GetLastModified() time.Time {
 	if m.RelationShipsChangedAt != nil && m.RelationShipsChangedAt.After(lastModified) {
 		lastModified = *m.RelationShipsChangedAt
 	}
-	logrus.Warnf("Last modification for iteration with id='%s': %s (updated at '%s' / relationships changed at '%s')", m.ID.String(), lastModified.String(), m.UpdatedAt.String(), m.RelationShipsChangedAt.String())
 	return lastModified
 
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -334,6 +334,9 @@ func GetMigrations() Migrations {
 	// Version 70
 	m = append(m, steps{ExecuteSQLFile("070-rename-comment-createdby-to-creator.sql")})
 
+	// Version 71
+	m = append(m, steps{ExecuteSQLFile("071-iteration-related-changes.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -125,6 +125,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration65", testMigration65)
 	t.Run("TestMigration66", testMigration66)
 	t.Run("TestMigration67", testMigration67)
+	t.Run("TestMigration71", testMigration71)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName); err != nil {
@@ -452,6 +453,74 @@ func testMigration67(t *testing.T) {
 	err = stmt.QueryRow("00000067-0000-0000-0000-000000000000").Scan(&parentID)
 	require.Nil(t, err)
 	assert.NotNil(t, parentID)
+}
+
+func testMigration71(t *testing.T) {
+	// migrate to version
+	migrateToVersion(sqlDB, migrations[:72], 72)
+	// fill DB with data
+	assert.Nil(t, runSQLscript(sqlDB, "071-iteration-related-changes.sql"))
+	// verify the data
+	var updatedAt *time.Time
+	var deletedAt *time.Time
+	var relationshipsChangedAt *time.Time
+
+	// verify work item 1 linked to iteration 1
+	stmt, err := sqlDB.Prepare("select updated_at from work_items where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("11111111-7171-0000-0000-000000000000").Scan(&updatedAt)
+	require.Nil(t, err)
+	require.NotNil(t, updatedAt)
+	stmt, err = sqlDB.Prepare("select relationships_changed_at from iterations where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("11111111-7171-0000-0000-000000000000").Scan(&relationshipsChangedAt)
+	require.Nil(t, err)
+	require.NotNil(t, relationshipsChangedAt)
+	assert.Equal(t, *updatedAt, *relationshipsChangedAt)
+	// verify work item 2 linked to iteration 2 then iteration 3
+	stmt, err = sqlDB.Prepare("select updated_at from work_items where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("22222222-7171-0000-0000-000000000000").Scan(&updatedAt)
+	require.Nil(t, err)
+	require.NotNil(t, updatedAt)
+	stmt, err = sqlDB.Prepare("select relationships_changed_at from iterations where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("22222222-7171-0000-0000-000000000000").Scan(&relationshipsChangedAt)
+	require.Nil(t, err)
+	require.NotNil(t, relationshipsChangedAt)
+	assert.Equal(t, *updatedAt, *relationshipsChangedAt)
+	stmt, err = sqlDB.Prepare("select relationships_changed_at from iterations where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("33333333-7171-0000-0000-000000000000").Scan(&relationshipsChangedAt)
+	require.Nil(t, err)
+	require.NotNil(t, relationshipsChangedAt)
+	assert.Equal(t, *updatedAt, *relationshipsChangedAt)
+	// verify work item 3 linked to iteration 4
+	stmt, err = sqlDB.Prepare("select deleted_at from work_items where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("33333333-7171-0000-0000-000000000000").Scan(&deletedAt)
+	require.Nil(t, err)
+	require.NotNil(t, deletedAt)
+	stmt, err = sqlDB.Prepare("select relationships_changed_at from iterations where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("44444444-7171-0000-0000-000000000000").Scan(&relationshipsChangedAt)
+	require.Nil(t, err)
+	require.NotNil(t, relationshipsChangedAt)
+	assert.Equal(t, *deletedAt, *relationshipsChangedAt)
+	// verify work item 4 linked to iteration 5
+	// we will expect 1hr earlier for the last relationship change
+	stmt, err = sqlDB.Prepare("select (updated_at - interval '1 hour') from work_items where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("44444444-7171-0000-0000-000000000000").Scan(&updatedAt)
+	require.Nil(t, err)
+	require.NotNil(t, updatedAt)
+	stmt, err = sqlDB.Prepare("select relationships_changed_at from iterations where id = $1")
+	require.Nil(t, err)
+	err = stmt.QueryRow("55555555-7171-0000-0000-000000000000").Scan(&relationshipsChangedAt)
+	require.Nil(t, err)
+	require.NotNil(t, relationshipsChangedAt)
+	assert.Equal(t, updatedAt.String(), relationshipsChangedAt.String())
+
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/sql-files/071-iteration-related-changes.sql
+++ b/migration/sql-files/071-iteration-related-changes.sql
@@ -1,0 +1,60 @@
+ALTER TABLE iterations ADD COLUMN relationships_changed_at timestamp with time zone;
+COMMENT ON COLUMN iterations.relationships_changed_at IS 'see triggers on the ''work_items'' table''.';
+
+drop trigger if exists workitem_link_iteration_trigger on work_items;
+drop function if exists iteration_set_relationship_timestamp_on_workitem_linking();
+drop trigger if exists workitem_unlink_iteration_trigger on work_items;
+drop function if exists iteration_set_relationship_timestamp_on_workitem_unlinking();
+drop trigger if exists workitem_soft_delete_trigger on work_items;
+drop function if exists iteration_set_relationship_timestamp_on_workitem_deletion();
+
+-- trigger and function when a workitem is linked to an iteration
+CREATE FUNCTION iteration_set_relationship_timestamp_on_workitem_linking() RETURNS trigger AS $$
+    -- trigger to fill the `relationships_changed_at` column when an interation is set
+    BEGIN
+        UPDATE iterations i SET relationships_changed_at = NEW.updated_at WHERE i.id::text = NEW.Fields->>'system.iteration';
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER workitem_link_iteration_trigger AFTER UPDATE ON work_items 
+    FOR EACH ROW
+    WHEN (NEW.deleted_at IS NULL 
+        -- only occurs when the `system.iteration` field changed to a non-null value
+        AND NEW.Fields->>'system.iteration' IS NOT NULL 
+        AND (OLD.Fields->>'system.iteration' IS NULL OR NEW.Fields->>'system.iteration' != OLD.Fields->>'system.iteration'))
+    EXECUTE PROCEDURE iteration_set_relationship_timestamp_on_workitem_linking();
+
+-- trigger and function when an iteration is unset for a workitem 
+CREATE FUNCTION iteration_set_relationship_timestamp_on_workitem_unlinking() RETURNS trigger AS $$
+    -- trigger to fill the `relationships_changed_at` column when an interation is set
+    BEGIN
+        UPDATE iterations i SET relationships_changed_at = NEW.updated_at WHERE i.id::text = OLD.Fields->>'system.iteration';
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER workitem_unlink_iteration_trigger AFTER UPDATE ON work_items 
+    FOR EACH ROW
+    WHEN (OLD.deleted_at IS NULL 
+        -- only occurs when the `system.iteration` field was a non-null value before, and then it changed
+        AND OLD.Fields->>'system.iteration' IS NOT NULL 
+        AND (NEW.Fields->>'system.iteration' IS NULL OR NEW.Fields->>'system.iteration'!= OLD.Fields->>'system.iteration'))
+    EXECUTE PROCEDURE iteration_set_relationship_timestamp_on_workitem_unlinking();
+
+-- trigger and function when a workitem that is soft-deleted was linked to an iteration
+CREATE FUNCTION iteration_set_relationship_timestamp_on_workitem_deletion() RETURNS trigger AS $$
+    -- trigger to fill the `relationships_changed_at` column when an interation is set
+    BEGIN
+        UPDATE iterations i SET relationships_changed_at = NEW.deleted_at WHERE i.id::text = OLD.Fields->>'system.iteration';
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER workitem_soft_delete_trigger AFTER UPDATE ON work_items 
+    FOR EACH ROW
+    WHEN (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
+    EXECUTE PROCEDURE iteration_set_relationship_timestamp_on_workitem_deletion();
+
+

--- a/migration/sql-test-files/071-iteration-related-changes.sql
+++ b/migration/sql-test-files/071-iteration-related-changes.sql
@@ -1,0 +1,27 @@
+insert into spaces (id, name) values ('11111111-7171-0000-0000-000000000000', 'test iteration - relationships changed at');
+delete from work_items;
+insert into work_item_types (id, name, space_id) values ('11111111-7171-0000-0000-000000000000', 'Test WIT','11111111-7171-0000-0000-000000000000');
+insert into work_items (id, created_at, space_id, type, fields) values ('11111111-7171-0000-0000-000000000000', (CURRENT_TIMESTAMP - interval '1 hour'), '11111111-7171-0000-0000-000000000000', '11111111-7171-0000-0000-000000000000', '{"system.title":"Work item 1"}'::json);
+insert into work_items (id, created_at, space_id, type, fields) values ('22222222-7171-0000-0000-000000000000', (CURRENT_TIMESTAMP - interval '1 hour'), '11111111-7171-0000-0000-000000000000', '11111111-7171-0000-0000-000000000000', '{"system.title":"Work item 2"}'::json);
+insert into work_items (id, created_at, space_id, type, fields) values ('33333333-7171-0000-0000-000000000000', (CURRENT_TIMESTAMP - interval '1 hour'), '11111111-7171-0000-0000-000000000000', '11111111-7171-0000-0000-000000000000', '{"system.title":"Work item 3"}'::json);
+insert into work_items (id, created_at, space_id, type, fields) values ('44444444-7171-0000-0000-000000000000', (CURRENT_TIMESTAMP - interval '1 hour'), '11111111-7171-0000-0000-000000000000', '11111111-7171-0000-0000-000000000000', '{"system.title":"Work item 4"}'::json);
+
+delete from iterations;
+insert into iterations (id, name, created_at, space_id) values ('11111111-7171-0000-0000-000000000000', 'iteration 1', CURRENT_TIMESTAMP, '11111111-7171-0000-0000-000000000000');
+insert into iterations (id, name, created_at, space_id) values ('22222222-7171-0000-0000-000000000000', 'iteration 2', CURRENT_TIMESTAMP, '11111111-7171-0000-0000-000000000000');
+insert into iterations (id, name, created_at, space_id) values ('33333333-7171-0000-0000-000000000000', 'iteration 3', CURRENT_TIMESTAMP, '11111111-7171-0000-0000-000000000000');
+insert into iterations (id, name, created_at, space_id) values ('44444444-7171-0000-0000-000000000000', 'iteration 4', CURRENT_TIMESTAMP, '11111111-7171-0000-0000-000000000000');
+insert into iterations (id, name, created_at, space_id) values ('55555555-7171-0000-0000-000000000000', 'iteration 5', CURRENT_TIMESTAMP, '11111111-7171-0000-0000-000000000000');
+
+-- link work item 1 to iteration 1
+update work_items set updated_at = (CURRENT_TIMESTAMP + interval '1 hour'), fields = '{"system.title":"Work item 1", "system.iteration":"11111111-7171-0000-0000-000000000000"}'::json where id = '11111111-7171-0000-0000-000000000000';
+-- link work item 2 to iteration 2 then iteration 3
+update work_items set updated_at = (CURRENT_TIMESTAMP + interval '1 hour'), fields = '{"system.title":"Work item 2", "system.iteration":"22222222-7171-0000-0000-000000000000"}'::json where id = '22222222-7171-0000-0000-000000000000';
+update work_items set updated_at = (CURRENT_TIMESTAMP + interval '2 hour'), fields = '{"system.title":"Work item 2", "system.iteration":"33333333-7171-0000-0000-000000000000"}'::json where id = '22222222-7171-0000-0000-000000000000';
+-- link work item 3 to iteration 4 then soft-delete the work item
+update work_items set fields = '{"system.title":"Work item 3", "system.iteration":"44444444-7171-0000-0000-000000000000"}'::json, updated_at = (CURRENT_TIMESTAMP + interval '1 hour') where id = '33333333-7171-0000-0000-000000000000';
+update work_items set deleted_at = (CURRENT_TIMESTAMP + interval '2 hour') where id = '33333333-7171-0000-0000-000000000000';
+-- link work item 4 to iteration 5 then set another, unrelated field
+update work_items set fields = '{"system.title":"Work item 4", "system.iteration":"55555555-7171-0000-0000-000000000000"}'::json, updated_at = (CURRENT_TIMESTAMP + interval '1 hour') where id = '44444444-7171-0000-0000-000000000000';
+update work_items set fields = '{"system.title":"Work item 4", "system.iteration":"55555555-7171-0000-0000-000000000000", "system.description":"foo"}'::json, updated_at = (CURRENT_TIMESTAMP + interval '2 hour') where id = '44444444-7171-0000-0000-000000000000';
+


### PR DESCRIPTION
Added a `relationships_changed_at` column in the `iterations` table to record
the timestamp of changes in work items when they are linked/unlinked to an
iterations, or soft-deleted.
The filling of the `relationships_changed_at` is performed by a
set of triggers and functions.

Added tests to verify that the `ETag` and `Last-Modified` response headers
change when a work item is added to/removed from an iteration.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

* Please describe what your change is about.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
* If you are still working on the change please prefix the pull request title with "WIP"
