### PR TITLE
Support offline token generation

### DIFF
--- a/controller/login.go
+++ b/controller/login.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -103,6 +104,9 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
 
+	if ctx.Scope != nil {
+		authEndpoint = fmt.Sprintf("%s?scope=%s", authEndpoint, *ctx.Scope) // Offline token
+	}
 	oauth := &oauth2.Config{
 		ClientID:     c.configuration.GetKeycloakClientID(),
 		ClientSecret: c.configuration.GetKeycloakSecret(),

--- a/controller/login_test.go
+++ b/controller/login_test.go
@@ -85,7 +85,20 @@ func (rest *TestLoginREST) TestAuthorizeLoginOK() {
 	resource.Require(t, resource.UnitTest)
 	svc, ctrl := rest.UnSecuredController()
 
-	test.AuthorizeLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil)
+	test.AuthorizeLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil)
+}
+
+func (rest *TestLoginREST) TestOfflineAccessOK() {
+	t := rest.T()
+	resource.Require(t, resource.UnitTest)
+	svc, ctrl := rest.UnSecuredController()
+
+	offline := "offline_access"
+	resp := test.AuthorizeLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, &offline)
+	assert.Contains(t, resp.Header().Get("Location"), "scope=offline_access")
+
+	resp = test.AuthorizeLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil, nil)
+	assert.NotContains(t, resp.Header().Get("Location"), "scope=offline_access")
 }
 
 func (rest *TestLoginREST) TestTestUserTokenObtainedFromKeycloakOK() {

--- a/design/auth.go
+++ b/design/auth.go
@@ -16,7 +16,10 @@ var _ = a.Resource("login", func() {
 		a.Params(func() {
 			a.Param("link", d.Boolean, "If true then link all available Identity Providers to the user account after successful login")
 			a.Param("redirect", d.String, "URL to be redirected to after successful login. If not set then will redirect to the referrer instead.")
-
+			a.Param("scope", d.String, func() {
+				a.Enum("offline_access")
+				a.Description("If scope=offline_access then an offline token will be issued instead of a regular refresh token")
+			})
 		})
 		a.Description("Authorize with the WIT")
 		a.Response(d.Unauthorized, JSONAPIErrors)


### PR DESCRIPTION
If `scope=offline_access` param is added to the authentication request then the offline token will be issued instead of a regular refresh token.

Example: `api.openshift.io/api/login/authorize?scope=offline_access`

Fixes https://github.com/fabric8-services/fabric8-auth/issues/69