### PR TITLE
WIP : Support creation of user/identity in WIT , when requested from AUTH service

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -494,6 +494,12 @@ func (c *ConfigurationData) GetAuthEndpointSpaces(req *goa.RequestData) (string,
 	return c.getAuthEndpoint(req, "api/spaces")
 }
 
+// GetAuthEndpointUserProfile returns the endpoint of the remote auth service responsible for user profile
+// updation.
+func (c *ConfigurationData) GetAuthEndpointUserProfile(req *goa.RequestData) (string, error) {
+	return c.getAuthEndpoint(req, "api/users")
+}
+
 func (c *ConfigurationData) getAuthEndpoint(req *goa.RequestData, pathSufix string) (string, error) {
 	return c.getServiceEndpoint(req, varAuthURL, devModeAuthURL, c.GetAuthDomainPrefix(), pathSufix)
 }

--- a/controller/users.go
+++ b/controller/users.go
@@ -3,24 +3,19 @@ package controller
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
-	"github.com/fabric8-services/fabric8-wit/auth/authservice"
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/goasupport"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/login"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/goadesign/goa"
-	goaclient "github.com/goadesign/goa/client"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -382,49 +377,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			}
 		}
 	}
-	if !isDelegated(ctx) {
-		// if the control entered here because of delegation from auth service,
-		// then we ensure there is no loop.
-		c.notifyAuthService(ctx, ctx.RequestData) // TODO: Dont ignore error
-	}
 	return returnResponse
-}
-
-func (c *UsersController) notifyAuthService(ctx *app.UpdateUsersContext, request *goa.RequestData) error {
-	remoteAuthClient, err := c.createRemoteAuthClient(ctx.Context, request)
-	if err != nil {
-		return err
-	}
-	updateUserPayload := &authservice.UpdateUsersPayload{
-		Data: &authservice.UpdateUserData{
-			Attributes: &authservice.UpdateIdentityDataAttributes{
-				Bio:                   ctx.Payload.Data.Attributes.Bio,
-				Company:               ctx.Payload.Data.Attributes.Company,
-				ContextInformation:    ctx.Payload.Data.Attributes.ContextInformation,
-				Email:                 ctx.Payload.Data.Attributes.Email,
-				FullName:              ctx.Payload.Data.Attributes.FullName,
-				ImageURL:              ctx.Payload.Data.Attributes.ImageURL,
-				RegistrationCompleted: ctx.Payload.Data.Attributes.RegistrationCompleted,
-				URL:      ctx.Payload.Data.Attributes.URL,
-				Username: ctx.Payload.Data.Attributes.Username,
-			},
-			Type: ctx.Payload.Data.Type,
-			Links: &authservice.GenericLinks{
-				Self:    ctx.Payload.Data.Links.Self,
-				Related: ctx.Payload.Data.Links.Related,
-				Meta:    ctx.Payload.Data.Links.Meta,
-			},
-		},
-	}
-	_, err = remoteAuthClient.UpdateUsers(goasupport.ForwardContextRequestID(ctx), "", updateUserPayload)
-	return err
-}
-
-// addDelegationFlag adds information for Auth service to know that
-// this was forwarded from WIT
-func addDelegationFlag(ctx context.Context) context.Context {
-	ctx = context.WithValue(ctx, DelegationFlag, true)
-	return ctx
 }
 
 // isDelegated checks if the request is coming from Auth.
@@ -438,23 +391,6 @@ func isDelegated(ctx context.Context) bool {
 		}
 	}
 	return false
-}
-
-func (c *UsersController) createRemoteAuthClient(ctx context.Context, request *goa.RequestData) (*authservice.Client, error) {
-	authUserProfileEndpoint, err := c.config.GetAuthEndpointUserProfile(request)
-	if err != nil {
-		return nil, err
-	}
-
-	u, err := url.Parse(authUserProfileEndpoint)
-	if err != nil {
-		return nil, err
-	}
-	authClient := authservice.New(goaclient.HTTPClientDoer(http.DefaultClient))
-	authClient.Host = u.Host
-	authClient.Scheme = u.Scheme
-	authClient.SetJWTSigner(goasupport.NewForwardSigner(ctx))
-	return authClient, nil
 }
 
 func isEmailValid(email string) bool {

--- a/controller/users.go
+++ b/controller/users.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	usersEndpoint = "/api/users"
+	usersEndpoint  = "/api/users"
+	DelegationFlag = "isRequestDelegated"
 )
 
 // UsersController implements the users resource.
@@ -406,8 +407,16 @@ func (c *UsersController) notifyAuthService(ctx *app.UpdateUsersContext, request
 	return err
 }
 
+// addDelegationFlag adds information for Auth service to know that
+// this was forwarded from WIT
+func addDelegationFlag(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, DelegationFlag, true)
+	return ctx
+}
+
+// isDelegated checks if the request is coming from Auth.
 func isDelegated(ctx context.Context) bool {
-	ctxValue := ctx.Value("isRequestDelegated")
+	ctxValue := ctx.Value(DelegationFlag)
 	if ctxValue != nil {
 		isDelegated := ctxValue.(bool)
 		if isDelegated {

--- a/controller/users.go
+++ b/controller/users.go
@@ -36,9 +36,10 @@ const (
 // UsersController implements the users resource.
 type UsersController struct {
 	*goa.Controller
-	db                 application.DB
-	config             UsersControllerConfiguration
-	userProfileService login.UserProfileService
+	db                   application.DB
+	config               UsersControllerConfiguration
+	userProfileService   login.UserProfileService
+	KeycloakOAuthService login.KeycloakOAuthService
 }
 
 // UsersControllerConfiguration the configuration for the UsersController
@@ -50,12 +51,13 @@ type UsersControllerConfiguration interface {
 }
 
 // NewUsersController creates a users controller.
-func NewUsersController(service *goa.Service, db application.DB, config UsersControllerConfiguration, userProfileService login.UserProfileService) *UsersController {
+func NewUsersController(service *goa.Service, db application.DB, config UsersControllerConfiguration, userProfileService login.UserProfileService, loginService login.KeycloakOAuthService) *UsersController {
 	return &UsersController{
-		Controller:         service.NewController("UsersController"),
-		db:                 db,
-		config:             config,
-		userProfileService: userProfileService,
+		Controller:           service.NewController("UsersController"),
+		db:                   db,
+		config:               config,
+		userProfileService:   userProfileService,
+		KeycloakOAuthService: loginService,
 	}
 }
 
@@ -181,16 +183,27 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 
 	returnResponse := application.Transactional(c.db, func(appl application.Application) error {
 		identity, err := appl.Identities().Load(ctx, *id)
+		var user *account.User
+
 		if err != nil || identity == nil {
 			log.Error(ctx, map[string]interface{}{
 				"identity_id": id,
 			}, "auth token contains id %s of unknown Identity", *id)
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrUnauthorized(fmt.Sprintf("Auth token contains id %s of unknown Identity\n", *id)))
-			return ctx.Unauthorized(jerrors)
+
+			// If the request was delegated, then we shall allow addition of the identity/user.
+			// This use case is for post-login where AUTH informs WIT about the new/existing user/identity.
+			if isDelegated(ctx) {
+				identity, user, err = c.KeycloakOAuthService.CreateOrUpdateKeycloakUser(tokenString, ctx, accountAPIEndpoint)
+				if err != nil {
+					return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("error adding new user/identity while calling user profile update endpoint")))
+				}
+			} else {
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrUnauthorized(fmt.Sprintf("Auth token contains id %s of unknown Identity\n", *id)))
+				return ctx.Unauthorized(jerrors)
+			}
 		}
 
-		var user *account.User
-		if identity.UserID.Valid {
+		if identity.UserID.Valid && user == nil {
 			user, err = appl.Users().Load(ctx.Context, identity.UserID.UUID)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Can't load user with id %s", identity.UserID.UUID)))
@@ -416,6 +429,7 @@ func addDelegationFlag(ctx context.Context) context.Context {
 
 // isDelegated checks if the request is coming from Auth.
 func isDelegated(ctx context.Context) bool {
+	// TODO: Add validation of source ( from whom is the request coming ? )
 	ctxValue := ctx.Value(DelegationFlag)
 	if ctxValue != nil {
 		isDelegated := ctxValue.(bool)

--- a/main.go
+++ b/main.go
@@ -293,7 +293,7 @@ func main() {
 
 	// Mount "users" controller
 	keycloakProfileService := login.NewKeycloakUserProfileClient()
-	usersCtrl := controller.NewUsersController(service, appDB, configuration, keycloakProfileService)
+	usersCtrl := controller.NewUsersController(service, appDB, configuration, keycloakProfileService, loginService)
 	app.MountUsersController(service, usersCtrl)
 
 	// Mount "iterations" controller


### PR DESCRIPTION
As part of fabric8-services/fabric8-auth#26

- Accept delegated identity/user updates *from* auth ( Scenario: This would happen after login in Autj ,as part of the workflow #1599  ). 


- If the incoming request from Auth corresponds to a user whose data is not present in the WIT DB, it would be added using the existing method "CreateOrUpdateKeycloakUser".
```
if identityNotFoundInDB {
   if isDelegated(ctx)  {
 	// Do a CreateOrUpdateKeycloakUser(tokenString, ctx, accountAPIEndpoint)        
   } else  {
       // Throw error, as we've been doing currently
   }
}
```

- A context property would be used to verify if the request is coming from Auth is a delegated request.
```
        ctxValue := ctx.Value(DelegationFlag)
	if ctxValue != nil {
		isDelegated := ctxValue.(bool)
		if isDelegated {
			return true
		}
	}
```