### PR TITLE
Replace `goa.RequestData` with `http.Request` where applicable (#1606)

### DIFF
--- a/auth/authz_blackbox_test.go
+++ b/auth/authz_blackbox_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	wittoken "github.com/fabric8-services/fabric8-wit/token"
-	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,9 +62,7 @@ func (s *TestAuthSuite) TearDownSuite() {
 }
 
 func (s *TestAuthSuite) TestCreateAndDeleteResourceOK() {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	ctx := context.Background()
 	authzEndpoint, err := configuration.GetKeycloakEndpointAuthzResourceset(r)
 	require.Nil(s.T(), err)
@@ -76,12 +73,8 @@ func (s *TestAuthSuite) TestCreateAndDeleteResourceOK() {
 }
 
 func (s *TestAuthSuite) TestDeleteNonexistingResourceFails() {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
-
+	r := &http.Request{Host: "domain.io"}
 	ctx := context.Background()
-
 	authzEndpoint, err := configuration.GetKeycloakEndpointAuthzResourceset(r)
 	require.Nil(s.T(), err)
 	pat := getProtectedAPITokenOK(s.T())
@@ -122,9 +115,7 @@ func (s *TestAuthSuite) TestDeletePolicyOK() {
 }
 
 func (s *TestAuthSuite) TestCreateAndDeletePermissionOK() {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	authzEndpoint, err := configuration.GetKeycloakEndpointAuthzResourceset(r)
 	require.Nil(s.T(), err)
 
@@ -156,12 +147,8 @@ func (s *TestAuthSuite) TestCreateAndDeletePermissionOK() {
 }
 
 func (s *TestAuthSuite) TestDeleteNonexistingPolicyAndPermissionFails() {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
-
+	r := &http.Request{Host: "domain.io"}
 	ctx := context.Background()
-
 	clientsEndpoint, err := configuration.GetKeycloakEndpointClients(r)
 	require.Nil(s.T(), err)
 	pat := getProtectedAPITokenOK(s.T())
@@ -174,9 +161,7 @@ func (s *TestAuthSuite) TestDeleteNonexistingPolicyAndPermissionFails() {
 }
 
 func (s *TestAuthSuite) TestGetEntitlement() {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	authzEndpoint, err := configuration.GetKeycloakEndpointAuthzResourceset(r)
 	require.Nil(s.T(), err)
 
@@ -369,9 +354,7 @@ type policyRequestResultPayload struct {
 }
 
 func cleanKeycloakResources(t *testing.T) {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	ctx := context.Background()
 	authzEndpoint, err := configuration.GetKeycloakEndpointAuthzResourceset(r)
 	require.Nil(t, err)
@@ -414,9 +397,7 @@ func cleanKeycloakResources(t *testing.T) {
 }
 
 func createResource(t *testing.T, ctx context.Context, pat string) (string, string) {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	uri := "testResourceURI"
 	kcResource := auth.KeycloakResource{
 		Name:   "test-" + uuid.NewV4().String(),
@@ -476,10 +457,7 @@ func validatePolicy(t *testing.T, ctx context.Context, clientsEndpoint string, c
 }
 
 func getUserID(t *testing.T, username string, usersecret string) string {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
-
+	r := &http.Request{Host: "domain.io"}
 	tokenEndpoint, err := configuration.GetKeycloakEndpointToken(r)
 	require.Nil(t, err)
 	userinfoEndpoint, err := configuration.GetKeycloakEndpointUserInfo(r)
@@ -503,9 +481,7 @@ func getUserID(t *testing.T, username string, usersecret string) string {
 }
 
 func getClientIDAndEndpoint(t *testing.T) (string, string) {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	clientsEndpoint, err := configuration.GetKeycloakEndpointClients(r)
 	require.Nil(t, err)
 	publicClientID := configuration.GetKeycloakClientID()
@@ -518,10 +494,7 @@ func getClientIDAndEndpoint(t *testing.T) (string, string) {
 }
 
 func getProtectedAPITokenOK(t *testing.T) string {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "demo.api.openshift.io"},
-	}
-
+	r := &http.Request{Host: "demo.api.openshift.io"}
 	endpoint, err := configuration.GetKeycloakEndpointToken(r)
 	require.Nil(t, err)
 	token, err := auth.GetProtectedAPIToken(context.Background(), endpoint, configuration.GetKeycloakClientID(), configuration.GetKeycloakSecret())

--- a/auth/policy.go
+++ b/auth/policy.go
@@ -2,25 +2,24 @@ package auth
 
 import (
 	"context"
-
-	"github.com/goadesign/goa"
+	"net/http"
 )
 
 // KeycloakConfiguration represents a keycloak configuration
 type KeycloakConfiguration interface {
-	GetKeycloakEndpointAuthzResourceset(*goa.RequestData) (string, error)
-	GetKeycloakEndpointToken(*goa.RequestData) (string, error)
-	GetKeycloakEndpointClients(*goa.RequestData) (string, error)
-	GetKeycloakEndpointAdmin(*goa.RequestData) (string, error)
-	GetKeycloakEndpointEntitlement(*goa.RequestData) (string, error)
+	GetKeycloakEndpointAuthzResourceset(*http.Request) (string, error)
+	GetKeycloakEndpointToken(*http.Request) (string, error)
+	GetKeycloakEndpointClients(*http.Request) (string, error)
+	GetKeycloakEndpointAdmin(*http.Request) (string, error)
+	GetKeycloakEndpointEntitlement(*http.Request) (string, error)
 	GetKeycloakClientID() string
 	GetKeycloakSecret() string
 }
 
 // AuthzPolicyManager represents a space collaborators policy manager
 type AuthzPolicyManager interface {
-	GetPolicy(ctx context.Context, request *goa.RequestData, policyID string) (*KeycloakPolicy, *string, error)
-	UpdatePolicy(ctx context.Context, request *goa.RequestData, policy KeycloakPolicy, pat string) error
+	GetPolicy(ctx context.Context, request *http.Request, policyID string) (*KeycloakPolicy, *string, error)
+	UpdatePolicy(ctx context.Context, request *http.Request, policy KeycloakPolicy, pat string) error
 	AddUserToPolicy(p *KeycloakPolicy, userID string) bool
 	RemoveUserFromPolicy(p *KeycloakPolicy, userID string) bool
 }
@@ -46,7 +45,7 @@ func (m *KeycloakPolicyManager) RemoveUserFromPolicy(p *KeycloakPolicy, userID s
 }
 
 // GetPolicy obtains the space collaborators policy
-func (m *KeycloakPolicyManager) GetPolicy(ctx context.Context, request *goa.RequestData, policyID string) (*KeycloakPolicy, *string, error) {
+func (m *KeycloakPolicyManager) GetPolicy(ctx context.Context, request *http.Request, policyID string) (*KeycloakPolicy, *string, error) {
 	clientsEndpoint, err := m.configuration.GetKeycloakEndpointClients(request)
 	if err != nil {
 		return nil, nil, err
@@ -70,7 +69,7 @@ func (m *KeycloakPolicyManager) GetPolicy(ctx context.Context, request *goa.Requ
 }
 
 // UpdatePolicy updates the space collaborators policy
-func (m *KeycloakPolicyManager) UpdatePolicy(ctx context.Context, request *goa.RequestData, policy KeycloakPolicy, pat string) error {
+func (m *KeycloakPolicyManager) UpdatePolicy(ctx context.Context, request *http.Request, policy KeycloakPolicy, pat string) error {
 	clientsEndpoint, err := m.configuration.GetKeycloakEndpointClients(request)
 	if err != nil {
 		return err
@@ -84,7 +83,7 @@ func (m *KeycloakPolicyManager) UpdatePolicy(ctx context.Context, request *goa.R
 	return UpdatePolicy(ctx, clientsEndpoint, clientID, policy, pat)
 }
 
-func getPat(ctx context.Context, requestData *goa.RequestData, config KeycloakConfiguration) (string, error) {
+func getPat(ctx context.Context, requestData *http.Request, config KeycloakConfiguration) (string, error) {
 	endpoint, err := config.GetKeycloakEndpointToken(requestData)
 	if err != nil {
 		return "", err

--- a/auth/policy_blackbox_test.go
+++ b/auth/policy_blackbox_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/auth"
 	"github.com/fabric8-services/fabric8-wit/resource"
-	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -39,9 +38,7 @@ func (s *TestPolicySuite) TearDownSuite() {
 func (s *TestPolicySuite) TestGetPolicyOK() {
 	policy, policyID := createPermissionWithPolicy(s)
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	obtainedPolicy, newPat, err := s.policyManager.GetPolicy(context.Background(), r, policyID)
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), obtainedPolicy)
@@ -58,9 +55,7 @@ func (s *TestPolicySuite) TestUpdatePolicyOK() {
 	secondTestUserID := getUserID(s.T(), configuration.GetKeycloakTestUser2Name(), configuration.GetKeycloakTestUser2Secret())
 	policy.RemoveUserFromPolicy(secondTestUserID)
 	policy.ID = &policyID
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.io"},
-	}
+	r := &http.Request{Host: "domain.io"}
 	pat := getProtectedAPITokenOK(s.T())
 	err := s.policyManager.UpdatePolicy(context.Background(), r, *policy, pat)
 	require.Nil(s.T(), err)

--- a/auth/resource.go
+++ b/auth/resource.go
@@ -9,7 +9,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/goasupport"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/rest"
-	"github.com/goadesign/goa"
 	goaclient "github.com/goadesign/goa/client"
 	goauuid "github.com/goadesign/goa/uuid"
 	errs "github.com/pkg/errors"
@@ -18,8 +17,8 @@ import (
 
 // ResourceManager represents a space resource manager
 type ResourceManager interface {
-	CreateSpace(ctx context.Context, request *goa.RequestData, spaceID string) (*authservice.SpaceResource, error)
-	DeleteSpace(ctx context.Context, request *goa.RequestData, spaceID string) error
+	CreateSpace(ctx context.Context, request *http.Request, spaceID string) (*authservice.SpaceResource, error)
+	DeleteSpace(ctx context.Context, request *http.Request, spaceID string) error
 }
 
 // AuthzResourceManager implements ResourceManager interface
@@ -29,7 +28,7 @@ type AuthzResourceManager struct {
 
 // AuthServiceConfiguration represents auth service configuration
 type AuthServiceConfiguration interface {
-	GetAuthEndpointSpaces(*goa.RequestData) (string, error)
+	GetAuthEndpointSpaces(*http.Request) (string, error)
 	IsAuthorizationEnabled() bool
 }
 
@@ -39,7 +38,7 @@ func NewAuthzResourceManager(config AuthServiceConfiguration) *AuthzResourceMana
 }
 
 // CreateSpace calls auth service to create a keycloak resource associated with the space
-func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *goa.RequestData, spaceID string) (*authservice.SpaceResource, error) {
+func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *http.Request, spaceID string) (*authservice.SpaceResource, error) {
 	if !m.configuration.IsAuthorizationEnabled() {
 		// Keycloak authorization is disabled by default in Developer Mode
 		log.Warn(ctx, map[string]interface{}{
@@ -97,7 +96,7 @@ func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *goa.Req
 }
 
 // DeleteSpace calls auth service to delete the keycloak resource associated with the space
-func (m *AuthzResourceManager) DeleteSpace(ctx context.Context, request *goa.RequestData, spaceID string) error {
+func (m *AuthzResourceManager) DeleteSpace(ctx context.Context, request *http.Request, spaceID string) error {
 	if !m.configuration.IsAuthorizationEnabled() {
 		// Keycloak authorization is disabled by default in Developer Mode
 		log.Warn(ctx, map[string]interface{}{
@@ -138,7 +137,7 @@ func (m *AuthzResourceManager) DeleteSpace(ctx context.Context, request *goa.Req
 	return nil
 }
 
-func (m *AuthzResourceManager) createClient(ctx context.Context, request *goa.RequestData) (*authservice.Client, error) {
+func (m *AuthzResourceManager) createClient(ctx context.Context, request *http.Request) (*authservice.Client, error) {
 	authSpacesEndpoint, err := m.configuration.GetAuthEndpointSpaces(request)
 	if err != nil {
 		return nil, err

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/fabric8-services/fabric8-wit/rest"
-	"github.com/goadesign/goa"
 	"github.com/spf13/viper"
 )
 
@@ -490,15 +490,15 @@ func (c *ConfigurationData) GetAuthDomainPrefix() string {
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> auth.service.domain.org
 // or api.domain.org -> auth.domain.org
-func (c *ConfigurationData) GetAuthEndpointSpaces(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetAuthEndpointSpaces(req *http.Request) (string, error) {
 	return c.getAuthEndpoint(req, "api/spaces")
 }
 
-func (c *ConfigurationData) getAuthEndpoint(req *goa.RequestData, pathSufix string) (string, error) {
+func (c *ConfigurationData) getAuthEndpoint(req *http.Request, pathSufix string) (string, error) {
 	return c.getServiceEndpoint(req, varAuthURL, devModeAuthURL, c.GetAuthDomainPrefix(), pathSufix)
 }
 
-func (c *ConfigurationData) getServiceEndpoint(req *goa.RequestData, varServiceURL string, devModeURL string, serviceDomainPrefix string, pathSufix string) (string, error) {
+func (c *ConfigurationData) getServiceEndpoint(req *http.Request, varServiceURL string, devModeURL string, serviceDomainPrefix string, pathSufix string) (string, error) {
 	var endpoint string
 	var err error
 	if c.v.IsSet(varServiceURL) {
@@ -583,7 +583,7 @@ func (c *ConfigurationData) GetKeycloakTestUser2Secret() string {
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointAuth(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointAuth(req *http.Request) (string, error) {
 	return c.getKeycloakOpenIDConnectEndpoint(req, "auth")
 }
 
@@ -592,7 +592,7 @@ func (c *ConfigurationData) GetKeycloakEndpointAuth(req *goa.RequestData) (strin
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointToken(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointToken(req *http.Request) (string, error) {
 	return c.getKeycloakOpenIDConnectEndpoint(req, "token")
 }
 
@@ -601,7 +601,7 @@ func (c *ConfigurationData) GetKeycloakEndpointToken(req *goa.RequestData) (stri
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointUserInfo(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointUserInfo(req *http.Request) (string, error) {
 	return c.getKeycloakOpenIDConnectEndpoint(req, "userinfo")
 }
 
@@ -611,7 +611,7 @@ func (c *ConfigurationData) GetKeycloakEndpointUserInfo(req *goa.RequestData) (s
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointAdmin(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointAdmin(req *http.Request) (string, error) {
 	return c.getKeycloakEndpoint(req, "auth/admin/realms/"+c.GetKeycloakRealm())
 }
 
@@ -621,7 +621,7 @@ func (c *ConfigurationData) GetKeycloakEndpointAdmin(req *goa.RequestData) (stri
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointAuthzResourceset(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointAuthzResourceset(req *http.Request) (string, error) {
 	return c.getKeycloakEndpoint(req, "auth/realms/"+c.GetKeycloakRealm()+"/authz/protection/resource_set")
 }
 
@@ -631,7 +631,7 @@ func (c *ConfigurationData) GetKeycloakEndpointAuthzResourceset(req *goa.Request
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointClients(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointClients(req *http.Request) (string, error) {
 	return c.getKeycloakEndpoint(req, "auth/admin/realms/"+c.GetKeycloakRealm()+"/clients")
 }
 
@@ -641,7 +641,7 @@ func (c *ConfigurationData) GetKeycloakEndpointClients(req *goa.RequestData) (st
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointEntitlement(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointEntitlement(req *http.Request) (string, error) {
 	return c.getKeycloakEndpoint(req, "auth/realms/"+c.GetKeycloakRealm()+"/authz/entitlement/"+c.GetKeycloakClientID())
 }
 
@@ -651,12 +651,12 @@ func (c *ConfigurationData) GetKeycloakEndpointEntitlement(req *goa.RequestData)
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointBroker(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointBroker(req *http.Request) (string, error) {
 	return c.getKeycloakEndpoint(req, "auth/realms/"+c.GetKeycloakRealm()+"/broker")
 }
 
 // GetKeycloakAccountEndpoint returns the API URL for Read and Update on Keycloak User Accounts.
-func (c *ConfigurationData) GetKeycloakAccountEndpoint(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakAccountEndpoint(req *http.Request) (string, error) {
 	return c.getKeycloakEndpoint(req, "auth/realms/"+c.GetKeycloakRealm()+"/account")
 }
 
@@ -665,7 +665,7 @@ func (c *ConfigurationData) GetKeycloakAccountEndpoint(req *goa.RequestData) (st
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func (c *ConfigurationData) GetKeycloakEndpointLogout(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetKeycloakEndpointLogout(req *http.Request) (string, error) {
 	return c.getKeycloakOpenIDConnectEndpoint(req, "logout")
 }
 
@@ -674,11 +674,11 @@ func (c *ConfigurationData) GetKeycloakDevModeURL() string {
 	return devModeKeycloakURL
 }
 
-func (c *ConfigurationData) getKeycloakOpenIDConnectEndpoint(req *goa.RequestData, pathSufix string) (string, error) {
+func (c *ConfigurationData) getKeycloakOpenIDConnectEndpoint(req *http.Request, pathSufix string) (string, error) {
 	return c.getKeycloakEndpoint(req, c.openIDConnectPath(pathSufix))
 }
 
-func (c *ConfigurationData) getKeycloakEndpoint(req *goa.RequestData, pathSufix string) (string, error) {
+func (c *ConfigurationData) getKeycloakEndpoint(req *http.Request, pathSufix string) (string, error) {
 	return c.getServiceEndpoint(req, varKeycloakURL, devModeKeycloakURL, c.GetKeycloakDomainPrefix(), pathSufix)
 }
 
@@ -686,7 +686,7 @@ func (c *ConfigurationData) openIDConnectPath(suffix string) string {
 	return "auth/realms/" + c.GetKeycloakRealm() + "/protocol/openid-connect/" + suffix
 }
 
-func (c *ConfigurationData) getServiceURL(req *goa.RequestData, serviceDomainPrefix string, path string) (string, error) {
+func (c *ConfigurationData) getServiceURL(req *http.Request, serviceDomainPrefix string, path string) (string, error) {
 	scheme := "http"
 	if req.URL != nil && req.URL.Scheme == "https" { // isHTTPS
 		scheme = "https"
@@ -734,7 +734,7 @@ func (c *ConfigurationData) IsLogJSON() bool {
 // GetValidRedirectURLs returns the RegEx of valid redirect URLs for auth requests
 // If the F8_REDIRECT_VALID env var is not set then in Dev Mode all redirects allowed - *
 // In prod mode the default regex will be returned
-func (c *ConfigurationData) GetValidRedirectURLs(req *goa.RequestData) (string, error) {
+func (c *ConfigurationData) GetValidRedirectURLs(req *http.Request) (string, error) {
 	if c.v.IsSet(varValidRedirectURLs) {
 		return c.v.GetString(varValidRedirectURLs), nil
 	}
@@ -744,11 +744,11 @@ func (c *ConfigurationData) GetValidRedirectURLs(req *goa.RequestData) (string, 
 	return c.checkLocalhostRedirectException(req)
 }
 
-func (c *ConfigurationData) checkLocalhostRedirectException(req *goa.RequestData) (string, error) {
-	if req.Request == nil || req.Request.URL == nil {
+func (c *ConfigurationData) checkLocalhostRedirectException(req *http.Request) (string, error) {
+	if req.URL == nil {
 		return DefaultValidRedirectURLs, nil
 	}
-	matched, err := regexp.MatchString(localhostRedirectException, req.Request.URL.String())
+	matched, err := regexp.MatchString(localhostRedirectException, req.URL.String())
 	if err != nil {
 		return "", err
 	}

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -14,7 +14,6 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-wit/configuration"
 	"github.com/fabric8-services/fabric8-wit/resource"
-	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,19 +26,15 @@ const (
 	defaultValuesConfigFilePath = "" // when the code defaults are to be used, the path to config file is ""
 )
 
-var reqLong *goa.RequestData
-var reqShort *goa.RequestData
+var reqLong *http.Request
+var reqShort *http.Request
 var config *configuration.ConfigurationData
 
 func TestMain(m *testing.M) {
 	resetConfiguration(defaultConfigFilePath)
 
-	reqLong = &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
-	reqShort = &goa.RequestData{
-		Request: &http.Request{Host: "api.domain.org"},
-	}
+	reqLong = &http.Request{Host: "api.service.domain.org"}
+	reqShort = &http.Request{Host: "api.domain.org"}
 	os.Exit(m.Run())
 }
 
@@ -175,7 +170,7 @@ func TestGetKeycloakUserInfoEndpointOK(t *testing.T) {
 	checkGetServiceEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/account", config.GetKeycloakAccountEndpoint)
 }
 
-func checkGetServiceEndpointOK(t *testing.T, expectedEndpoint string, getEndpoint func(req *goa.RequestData) (string, error)) {
+func checkGetServiceEndpointOK(t *testing.T, expectedEndpoint string, getEndpoint func(req *http.Request) (string, error)) {
 	url, err := getEndpoint(reqLong)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
@@ -261,7 +256,7 @@ func generateEnvKey(yamlKey string) string {
 	return "F8_" + strings.ToUpper(strings.Replace(yamlKey, ".", "_", -1))
 }
 
-func checkGetKeycloakEndpointSetByEnvVaribaleOK(t *testing.T, envName string, getEndpoint func(req *goa.RequestData) (string, error)) {
+func checkGetKeycloakEndpointSetByEnvVaribaleOK(t *testing.T, envName string, getEndpoint func(req *http.Request) (string, error)) {
 	envValue := uuid.NewV4().String()
 	env := os.Getenv(envName)
 	defer func() {

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -9,24 +9,18 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/resource"
-	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var reqLong *goa.RequestData
-var reqShort *goa.RequestData
+var reqLong *http.Request
+var reqShort *http.Request
 var config *ConfigurationData
 
 func init() {
-
 	// ensure that the content here is executed only once.
-	reqLong = &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
-	reqShort = &goa.RequestData{
-		Request: &http.Request{Host: "api.domain.org"},
-	}
+	reqLong = &http.Request{Host: "api.service.domain.org"}
+	reqShort = &http.Request{Host: "api.domain.org"}
 	resetConfiguration()
 }
 
@@ -65,11 +59,7 @@ func TestGetKeycloakHttpsURLOK(t *testing.T) {
 
 	r, err := http.NewRequest("", "https://sso.domain.org", nil)
 	require.Nil(t, err)
-	req := &goa.RequestData{
-		Request: r,
-	}
-
-	url, err := config.getServiceURL(req, config.GetKeycloakDomainPrefix(), "somepath")
+	url, err := config.getServiceURL(r, config.GetKeycloakDomainPrefix(), "somepath")
 	assert.Nil(t, err)
 	assert.Equal(t, "https://sso.domain.org/somepath", url)
 }
@@ -77,10 +67,7 @@ func TestGetKeycloakHttpsURLOK(t *testing.T) {
 func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "org"},
-	}
+	r := &http.Request{Host: "org"}
 	_, err := config.getServiceURL(r, config.GetKeycloakDomainPrefix(), "somepath")
 	assert.NotNil(t, err)
 }
@@ -186,11 +173,7 @@ func TestRedirectURLsForLocalhostRequestAreExcepted(t *testing.T) {
 func validateRedirectURL(t *testing.T, request string, redirect string) bool {
 	r, err := http.NewRequest("", request, nil)
 	require.Nil(t, err)
-	req := &goa.RequestData{
-		Request: r,
-	}
-
-	whitelist, err := config.checkLocalhostRedirectException(req)
+	whitelist, err := config.checkLocalhostRedirectException(r)
 	require.Nil(t, err)
 
 	matched, err := regexp.MatchString(whitelist, redirect)

--- a/controller/area.go
+++ b/controller/area.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
 
 	"context"
 
@@ -59,7 +60,7 @@ func (c *AreaController) ShowChildren(ctx *app.ShowChildrenAreaContext) error {
 		}
 		return ctx.ConditionalEntities(children, c.config.GetCacheControlAreas, func() error {
 			res := &app.AreaList{}
-			res.Data = ConvertAreas(appl, ctx.RequestData, children, addResolvedPath)
+			res.Data = ConvertAreas(appl, ctx.Request, children, addResolvedPath)
 			return ctx.OK(res)
 		})
 	})
@@ -111,9 +112,9 @@ func (c *AreaController) CreateChild(ctx *app.CreateChildAreaContext) error {
 		}
 
 		res := &app.AreaSingle{
-			Data: ConvertArea(appl, ctx.RequestData, newArea, addResolvedPath),
+			Data: ConvertArea(appl, ctx.Request, newArea, addResolvedPath),
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.AreaHref(res.Data.ID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.AreaHref(res.Data.ID)))
 		return ctx.Created(res)
 	})
 }
@@ -132,14 +133,14 @@ func (c *AreaController) Show(ctx *app.ShowAreaContext) error {
 		}
 		return ctx.ConditionalRequest(*a, c.config.GetCacheControlArea, func() error {
 			res := &app.AreaSingle{}
-			res.Data = ConvertArea(appl, ctx.RequestData, *a, addResolvedPath)
+			res.Data = ConvertArea(appl, ctx.Request, *a, addResolvedPath)
 			return ctx.OK(res)
 		})
 	})
 }
 
 // addResolvedPath resolves the path in the form of /area1/area2/area3
-func addResolvedPath(appl application.Application, req *goa.RequestData, mArea *area.Area, sArea *app.Area) error {
+func addResolvedPath(appl application.Application, req *http.Request, mArea *area.Area, sArea *app.Area) error {
 	pathResolved, error := getResolvePath(appl, mArea)
 	sArea.Attributes.ParentPathResolved = pathResolved
 	return error
@@ -178,10 +179,10 @@ func getAreaByID(id uuid.UUID, areas []area.Area) *area.Area {
 
 // AreaConvertFunc is a open ended function to add additional links/data/relations to a area during
 // convertion from internal to API
-type AreaConvertFunc func(application.Application, *goa.RequestData, *area.Area, *app.Area) error
+type AreaConvertFunc func(application.Application, *http.Request, *area.Area, *app.Area) error
 
 // ConvertAreas converts between internal and external REST representation
-func ConvertAreas(appl application.Application, request *goa.RequestData, areas []area.Area, additional ...AreaConvertFunc) []*app.Area {
+func ConvertAreas(appl application.Application, request *http.Request, areas []area.Area, additional ...AreaConvertFunc) []*app.Area {
 	var is = []*app.Area{}
 	for _, i := range areas {
 		is = append(is, ConvertArea(appl, request, i, additional...))
@@ -190,7 +191,7 @@ func ConvertAreas(appl application.Application, request *goa.RequestData, areas 
 }
 
 // ConvertArea converts between internal and external REST representation
-func ConvertArea(appl application.Application, request *goa.RequestData, ar area.Area, additional ...AreaConvertFunc) *app.Area {
+func ConvertArea(appl application.Application, request *http.Request, ar area.Area, additional ...AreaConvertFunc) *app.Area {
 	areaType := area.APIStringTypeAreas
 	spaceID := ar.SpaceID.String()
 	relatedURL := rest.AbsoluteURL(request, app.AreaHref(ar.ID))
@@ -255,7 +256,7 @@ func ConvertArea(appl application.Application, request *goa.RequestData, ar area
 }
 
 // ConvertAreaSimple converts a simple area ID into a Generic Reletionship
-func ConvertAreaSimple(request *goa.RequestData, id interface{}) *app.GenericData {
+func ConvertAreaSimple(request *http.Request, id interface{}) *app.GenericData {
 	t := area.APIStringTypeAreas
 	i := fmt.Sprint(id)
 	return &app.GenericData{
@@ -265,7 +266,7 @@ func ConvertAreaSimple(request *goa.RequestData, id interface{}) *app.GenericDat
 	}
 }
 
-func createAreaLinks(request *goa.RequestData, id interface{}) *app.GenericLinks {
+func createAreaLinks(request *http.Request, id interface{}) *app.GenericLinks {
 	relatedURL := rest.AbsoluteURL(request, app.AreaHref(id))
 	return &app.GenericLinks{
 		Self:    &relatedURL,

--- a/controller/area.go
+++ b/controller/area.go
@@ -114,7 +114,7 @@ func (c *AreaController) CreateChild(ctx *app.CreateChildAreaContext) error {
 		res := &app.AreaSingle{
 			Data: ConvertArea(appl, ctx.Request, newArea, addResolvedPath),
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.AreaHref(res.Data.ID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.Request, app.AreaHref(res.Data.ID)))
 		return ctx.Created(res)
 	})
 }

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -94,7 +94,7 @@ func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
 
 	var existingWorkspaces []*app.Workspace
 	for _, workspace := range workspaces {
-		openLink := rest.AbsoluteURL(ctx.RequestData.Request, fmt.Sprintf(app.CodebaseHref(cb.ID)+"/open/%v", workspace.Config.Name))
+		openLink := rest.AbsoluteURL(ctx.Request, fmt.Sprintf(app.CodebaseHref(cb.ID)+"/open/%v", workspace.Config.Name))
 		existingWorkspaces = append(existingWorkspaces, &app.Workspace{
 			Attributes: &app.WorkspaceAttributes{
 				Name:        &workspace.Config.Name,
@@ -107,7 +107,7 @@ func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
 		})
 	}
 
-	createLink := rest.AbsoluteURL(ctx.RequestData.Request, app.CodebaseHref(cb.ID)+"/create")
+	createLink := rest.AbsoluteURL(ctx.Request, app.CodebaseHref(cb.ID)+"/create")
 	resp := &app.WorkspaceList{
 		Data: existingWorkspaces,
 		Links: &app.WorkspaceEditLinks{

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/fabric8-services/fabric8-wit/account/tenant"
 	"github.com/fabric8-services/fabric8-wit/app"
@@ -52,7 +53,7 @@ func (c *CodebaseController) Show(ctx *app.ShowCodebaseContext) error {
 		}
 
 		res := &app.CodebaseSingle{}
-		res.Data = ConvertCodebase(ctx.RequestData, c)
+		res.Data = ConvertCodebase(ctx.Request, c)
 
 		return ctx.OK(res)
 	})
@@ -93,7 +94,7 @@ func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
 
 	var existingWorkspaces []*app.Workspace
 	for _, workspace := range workspaces {
-		openLink := rest.AbsoluteURL(ctx.RequestData, fmt.Sprintf(app.CodebaseHref(cb.ID)+"/open/%v", workspace.Config.Name))
+		openLink := rest.AbsoluteURL(ctx.RequestData.Request, fmt.Sprintf(app.CodebaseHref(cb.ID)+"/open/%v", workspace.Config.Name))
 		existingWorkspaces = append(existingWorkspaces, &app.Workspace{
 			Attributes: &app.WorkspaceAttributes{
 				Name:        &workspace.Config.Name,
@@ -106,7 +107,7 @@ func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
 		})
 	}
 
-	createLink := rest.AbsoluteURL(ctx.RequestData, app.CodebaseHref(cb.ID)+"/create")
+	createLink := rest.AbsoluteURL(ctx.RequestData.Request, app.CodebaseHref(cb.ID)+"/create")
 	resp := &app.WorkspaceList{
 		Data: existingWorkspaces,
 		Links: &app.WorkspaceEditLinks{
@@ -252,10 +253,10 @@ func (c *CodebaseController) Open(ctx *app.OpenCodebaseContext) error {
 
 // CodebaseConvertFunc is a open ended function to add additional links/data/relations to a Codebase during
 // convertion from internal to API
-type CodebaseConvertFunc func(*goa.RequestData, *codebase.Codebase, *app.Codebase)
+type CodebaseConvertFunc func(*http.Request, *codebase.Codebase, *app.Codebase)
 
 // ConvertCodebases converts between internal and external REST representation
-func ConvertCodebases(request *goa.RequestData, codebases []*codebase.Codebase, additional ...CodebaseConvertFunc) []*app.Codebase {
+func ConvertCodebases(request *http.Request, codebases []*codebase.Codebase, additional ...CodebaseConvertFunc) []*app.Codebase {
 	var is = []*app.Codebase{}
 	for _, i := range codebases {
 		is = append(is, ConvertCodebase(request, i, additional...))
@@ -264,7 +265,7 @@ func ConvertCodebases(request *goa.RequestData, codebases []*codebase.Codebase, 
 }
 
 // ConvertCodebase converts between internal and external REST representation
-func ConvertCodebase(request *goa.RequestData, codebase *codebase.Codebase, additional ...CodebaseConvertFunc) *app.Codebase {
+func ConvertCodebase(request *http.Request, codebase *codebase.Codebase, additional ...CodebaseConvertFunc) *app.Codebase {
 	codebaseType := APIStringTypeCodebase
 	spaceType := APIStringTypeSpace
 

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -55,12 +56,12 @@ func (s *DummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
 	return nil
 }
 
-func (m *DummyPolicyManager) GetPolicy(ctx context.Context, request *goa.RequestData, policyID string) (*auth.KeycloakPolicy, *string, error) {
+func (m *DummyPolicyManager) GetPolicy(ctx context.Context, request *http.Request, policyID string) (*auth.KeycloakPolicy, *string, error) {
 	pat := ""
 	return m.rest.policy, &pat, nil
 }
 
-func (m *DummyPolicyManager) UpdatePolicy(ctx context.Context, request *goa.RequestData, policy auth.KeycloakPolicy, pat string) error {
+func (m *DummyPolicyManager) UpdatePolicy(ctx context.Context, request *http.Request, policy auth.KeycloakPolicy, pat string) error {
 	return nil
 }
 
@@ -76,7 +77,7 @@ type dummyCollaboratorsConfiguration struct {
 	configuration *config.ConfigurationData
 }
 
-func (c *dummyCollaboratorsConfiguration) GetKeycloakEndpointEntitlement(*goa.RequestData) (string, error) {
+func (c *dummyCollaboratorsConfiguration) GetKeycloakEndpointEntitlement(*http.Request) (string, error) {
 	return "", nil
 }
 

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -97,12 +97,8 @@ func (s *CommentsSuite) securedControllers(identity account.Identity) (*goa.Serv
 
 // createWorkItem creates a workitem that will be used to perform the comment operations during the tests.
 func (s *CommentsSuite) createWorkItem(identity account.Identity) uuid.UUID {
-	spaceRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(space.SystemSpace.String()))
-	witRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.WorkitemtypeHref(space.SystemSpace.String(), workitem.SystemBug.String()))
+	spaceRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
+	witRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.WorkitemtypeHref(space.SystemSpace.String(), workitem.SystemBug.String()))
 	createWorkitemPayload := app.CreateWorkitemsPayload{
 		Data: &app.WorkItem{
 			Type: APIStringTypeWorkItem,

--- a/controller/filter.go
+++ b/controller/filter.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/app"
@@ -95,7 +96,7 @@ func (c *FilterController) List(ctx *app.ListFilterContext) error {
 	return ctx.OK(result)
 }
 
-func addFilterLinks(links *app.PagingLinks, request *goa.RequestData) {
+func addFilterLinks(links *app.PagingLinks, request *http.Request) {
 	filter := rest.AbsoluteURL(request, app.FilterHref())
 	links.Filters = &filter
 }

--- a/controller/iteration.go
+++ b/controller/iteration.go
@@ -113,7 +113,7 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 		res := &app.IterationSingle{
 			Data: responseData,
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.IterationHref(res.Data.ID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.Request, app.IterationHref(res.Data.ID)))
 		return ctx.Created(res)
 	})
 }

--- a/controller/login.go
+++ b/controller/login.go
@@ -112,7 +112,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		ClientSecret: c.configuration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
 		Endpoint:     oauth2.Endpoint{AuthURL: authEndpoint, TokenURL: tokenEndpoint},
-		RedirectURL:  rest.AbsoluteURL(ctx.RequestData.Request, "/api/login/authorize"),
+		RedirectURL:  rest.AbsoluteURL(ctx.Request, "/api/login/authorize"),
 	}
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")

--- a/controller/login.go
+++ b/controller/login.go
@@ -26,11 +26,11 @@ import (
 )
 
 type loginConfiguration interface {
-	GetKeycloakEndpointAuth(*goa.RequestData) (string, error)
-	GetKeycloakEndpointToken(*goa.RequestData) (string, error)
-	GetKeycloakAccountEndpoint(req *goa.RequestData) (string, error)
-	GetKeycloakEndpointBroker(*goa.RequestData) (string, error)
-	GetKeycloakEndpointEntitlement(*goa.RequestData) (string, error)
+	GetKeycloakEndpointAuth(*http.Request) (string, error)
+	GetKeycloakEndpointToken(*http.Request) (string, error)
+	GetKeycloakAccountEndpoint(req *http.Request) (string, error)
+	GetKeycloakEndpointBroker(*http.Request) (string, error)
+	GetKeycloakEndpointEntitlement(*http.Request) (string, error)
 	GetKeycloakClientID() string
 	GetKeycloakSecret() string
 	IsPostgresDeveloperModeEnabled() bool
@@ -38,7 +38,7 @@ type loginConfiguration interface {
 	GetKeycloakTestUserSecret() string
 	GetKeycloakTestUser2Name() string
 	GetKeycloakTestUser2Secret() string
-	GetValidRedirectURLs(*goa.RequestData) (string, error)
+	GetValidRedirectURLs(*http.Request) (string, error)
 	GetHeaderMaxLength() int64
 	GetAuthNotApprovedRedirect() string
 }
@@ -61,7 +61,7 @@ func NewLoginController(service *goa.Service, auth *login.KeycloakOAuthProvider,
 
 // Authorize runs the authorize action.
 func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
-	authEndpoint, err := c.configuration.GetKeycloakEndpointAuth(ctx.RequestData)
+	authEndpoint, err := c.configuration.GetKeycloakEndpointAuth(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -69,7 +69,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak auth endpoint URL")))
 	}
 
-	tokenEndpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	tokenEndpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -77,7 +77,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak token endpoint URL")))
 	}
 
-	entitlementEndpoint, err := c.configuration.GetKeycloakEndpointEntitlement(ctx.RequestData)
+	entitlementEndpoint, err := c.configuration.GetKeycloakEndpointEntitlement(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -85,21 +85,21 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak entitlement endpoint URL")))
 	}
 
-	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.RequestData)
+	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get Keycloak broker endpoint URL")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
-	profileEndpoint, err := c.configuration.GetKeycloakAccountEndpoint(ctx.RequestData)
+	profileEndpoint, err := c.configuration.GetKeycloakAccountEndpoint(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get Keycloak account endpoint URL")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
-	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
+	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.Request)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
@@ -112,7 +112,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		ClientSecret: c.configuration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
 		Endpoint:     oauth2.Endpoint{AuthURL: authEndpoint, TokenURL: tokenEndpoint},
-		RedirectURL:  rest.AbsoluteURL(ctx.RequestData, "/api/login/authorize"),
+		RedirectURL:  rest.AbsoluteURL(ctx.RequestData.Request, "/api/login/authorize"),
 	}
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
@@ -193,7 +193,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	endpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	endpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -226,7 +226,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	entitlementEndpoint, err := c.configuration.GetKeycloakEndpointEntitlement(ctx.RequestData)
+	entitlementEndpoint, err := c.configuration.GetKeycloakEndpointEntitlement(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -275,7 +275,7 @@ func convertToken(token auth.Token) *app.AuthToken {
 
 // Link links identity provider(s) to the user's account
 func (c *LoginController) Link(ctx *app.LinkLoginContext) error {
-	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.RequestData)
+	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -283,7 +283,7 @@ func (c *LoginController) Link(ctx *app.LinkLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
 	clientID := c.configuration.GetKeycloakClientID()
-	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
+	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.Request)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
@@ -294,7 +294,7 @@ func (c *LoginController) Link(ctx *app.LinkLoginContext) error {
 
 // Linksession links identity provider(s) to the user's account
 func (c *LoginController) Linksession(ctx *app.LinksessionLoginContext) error {
-	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.RequestData)
+	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -302,7 +302,7 @@ func (c *LoginController) Linksession(ctx *app.LinksessionLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
 	clientID := c.configuration.GetKeycloakClientID()
-	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
+	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.Request)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
@@ -313,7 +313,7 @@ func (c *LoginController) Linksession(ctx *app.LinksessionLoginContext) error {
 
 // Linkcallback redirects to original referel when Identity Provider account are linked to the user account
 func (c *LoginController) Linkcallback(ctx *app.LinkcallbackLoginContext) error {
-	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.RequestData)
+	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -330,7 +330,7 @@ func (c *LoginController) Linkcallback(ctx *app.LinkcallbackLoginContext) error 
 func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 	var tokens app.AuthTokenCollection
 
-	tokenEndpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	tokenEndpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -347,7 +347,7 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to generate test token ")))
 	}
 	// Creates the testuser user and identity if they don't yet exist
-	profileEndpoint, err := c.configuration.GetKeycloakAccountEndpoint(ctx.RequestData)
+	profileEndpoint, err := c.configuration.GetKeycloakAccountEndpoint(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,

--- a/controller/login_recent_spaces_test.go
+++ b/controller/login_recent_spaces_test.go
@@ -94,9 +94,7 @@ func (rest *TestRecentSpacesREST) TestResourceRequestPayload() {
 	service, controller := rest.SecuredController()
 
 	// Generate an access token for a test identity
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.example.org"},
-	}
+	r := &http.Request{Host: "api.example.org"}
 	tokenEndpoint, err := rest.configuration.GetKeycloakEndpointToken(r)
 	require.Nil(t, err)
 

--- a/controller/logout.go
+++ b/controller/logout.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"net/http"
+
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
@@ -11,8 +13,8 @@ import (
 )
 
 type logoutConfiguration interface {
-	GetKeycloakEndpointLogout(*goa.RequestData) (string, error)
-	GetValidRedirectURLs(*goa.RequestData) (string, error)
+	GetKeycloakEndpointLogout(*http.Request) (string, error)
+	GetValidRedirectURLs(*http.Request) (string, error)
 }
 
 // LogoutController implements the logout resource.
@@ -29,14 +31,14 @@ func NewLogoutController(service *goa.Service, logoutService *login.KeycloakLogo
 
 // Logout runs the logout action.
 func (c *LogoutController) Logout(ctx *app.LogoutLogoutContext) error {
-	logoutEndpoint, err := c.configuration.GetKeycloakEndpointLogout(ctx.RequestData)
+	logoutEndpoint, err := c.configuration.GetKeycloakEndpointLogout(ctx.Request)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak logout endpoint URL")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.Wrap(err, "unable to get Keycloak logout endpoint URL")))
 	}
-	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
+	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.Request)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}

--- a/controller/named_work_items.go
+++ b/controller/named_work_items.go
@@ -30,7 +30,7 @@ func (c *NamedWorkItemsController) Show(ctx *app.ShowNamedWorkItemsContext) erro
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "Fail to load work item with number %v in %s/%s", ctx.WiNumber, ctx.UserName, ctx.SpaceName))
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.WorkitemHref(wiID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.WorkitemHref(wiID)))
 		return ctx.MovedPermanently()
 	})
 }

--- a/controller/named_work_items.go
+++ b/controller/named_work_items.go
@@ -30,7 +30,7 @@ func (c *NamedWorkItemsController) Show(ctx *app.ShowNamedWorkItemsContext) erro
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "Fail to load work item with number %v in %s/%s", ctx.WiNumber, ctx.UserName, ctx.SpaceName))
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.WorkitemHref(wiID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.Request, app.WorkitemHref(wiID)))
 		return ctx.MovedPermanently()
 	})
 }

--- a/controller/namedspaces.go
+++ b/controller/namedspaces.go
@@ -43,7 +43,7 @@ func (c *NamedspacesController) Show(ctx *app.ShowNamedspacesContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 
-		spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
+		spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.Request, *s)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -72,7 +72,7 @@ func (c *NamedspacesController) List(ctx *app.ListNamedspacesContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 
-		spaceData, err := ConvertSpacesFromModel(ctx.Context, c.db, ctx.RequestData, spaces)
+		spaceData, err := ConvertSpacesFromModel(ctx.Context, c.db, ctx.Request, spaces)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -81,7 +81,7 @@ func (c *NamedspacesController) List(ctx *app.ListNamedspacesContext) error {
 			Meta:  &app.SpaceListMeta{TotalCount: count},
 			Data:  spaceData,
 		}
-		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(spaces), offset, limit, count)
+		setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(spaces), offset, limit, count)
 
 		return ctx.OK(&response)
 	})

--- a/controller/paging.go
+++ b/controller/paging.go
@@ -4,12 +4,12 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/rest"
-	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
 )
 
@@ -114,7 +114,7 @@ func setPagingLinks(links *app.PagingLinks, path string, resultLen, offset, limi
 	links.Last = &last
 }
 
-func buildAbsoluteURL(req *goa.RequestData) string {
+func buildAbsoluteURL(req *http.Request) string {
 	return rest.AbsoluteURL(req, req.URL.Path)
 }
 

--- a/controller/planner_backlog.go
+++ b/controller/planner_backlog.go
@@ -59,11 +59,11 @@ func (c *PlannerBacklogController) List(ctx *app.ListPlannerBacklogContext) erro
 	}
 	return ctx.ConditionalEntities(result, c.config.GetCacheControlWorkItems, func() error {
 		response := app.WorkItemList{
-			Data:  ConvertWorkItems(ctx.RequestData, result),
+			Data:  ConvertWorkItems(ctx.Request, result),
 			Links: &app.PagingLinks{},
 			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
 		}
-		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), count, offset, limit, count)
+		setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), count, offset, limit, count)
 		return ctx.OK(&response)
 	})
 

--- a/controller/search.go
+++ b/controller/search.go
@@ -41,7 +41,7 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 	offset, limit = computePagingLimits(ctx.PageOffset, ctx.PageLimit)
 
 	// TODO: Keep URL registeration central somehow.
-	hostString := ctx.RequestData.Host
+	hostString := ctx.Request.Host
 	if hostString == "" {
 		hostString = c.configuration.GetHTTPAddress()
 	}
@@ -75,10 +75,10 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 			response := app.SearchWorkItemList{
 				Links: &app.PagingLinks{},
 				Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
-				Data:  ConvertWorkItems(ctx.RequestData, result, hasChildren),
+				Data:  ConvertWorkItems(ctx.Request, result, hasChildren),
 			}
 
-			setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, "filter[expression]="+*ctx.FilterExpression)
+			setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(result), offset, limit, count, "filter[expression]="+*ctx.FilterExpression)
 			return ctx.OK(&response)
 		})
 
@@ -115,10 +115,10 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 		response := app.SearchWorkItemList{
 			Links: &app.PagingLinks{},
 			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
-			Data:  ConvertWorkItems(ctx.RequestData, result),
+			Data:  ConvertWorkItems(ctx.Request, result),
 		}
 
-		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, "q="+*ctx.Q)
+		setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(result), offset, limit, count, "q="+*ctx.Q)
 		return ctx.OK(&response)
 	})
 }
@@ -164,7 +164,7 @@ func (c *SearchController) Spaces(ctx *app.SpacesSearchContext) error {
 			}
 		}
 
-		spaceData, err := ConvertSpacesFromModel(ctx.Context, c.db, ctx.RequestData, result)
+		spaceData, err := ConvertSpacesFromModel(ctx.Context, c.db, ctx.Request, result)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -173,7 +173,7 @@ func (c *SearchController) Spaces(ctx *app.SpacesSearchContext) error {
 			Meta:  &app.SpaceListMeta{TotalCount: count},
 			Data:  spaceData,
 		}
-		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, "q="+q)
+		setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(result), offset, limit, count, "q="+q)
 
 		return ctx.OK(&response)
 	})
@@ -239,7 +239,7 @@ func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
 		Links: &app.PagingLinks{},
 		Meta:  &app.UserListMeta{TotalCount: count},
 	}
-	setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, "q="+q)
+	setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(result), offset, limit, count, "q="+q)
 
 	return ctx.OK(&response)
 }

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -262,12 +262,8 @@ func (s *searchBlackBoxTest) TestUnwantedCharactersRelatedToSearchLogic() {
 }
 
 func (s *searchBlackBoxTest) getWICreatePayload() *app.CreateWorkitemsPayload {
-	spaceRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(space.SystemSpace.String()))
-	witRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.WorkitemtypeHref(space.SystemSpace.String(), workitem.SystemTask.String()))
+	spaceRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
+	witRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.WorkitemtypeHref(space.SystemSpace.String(), workitem.SystemTask.String()))
 	c := app.CreateWorkitemsPayload{
 		Data: &app.WorkItem{
 			Type:       APIStringTypeWorkItem,

--- a/controller/space.go
+++ b/controller/space.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
@@ -30,10 +31,10 @@ var scopes = []string{"read:space", "admin:space"}
 
 // SpaceConfiguration represents space configuratoin
 type SpaceConfiguration interface {
-	GetKeycloakEndpointAuthzResourceset(*goa.RequestData) (string, error)
-	GetKeycloakEndpointToken(*goa.RequestData) (string, error)
-	GetKeycloakEndpointClients(*goa.RequestData) (string, error)
-	GetKeycloakEndpointAdmin(*goa.RequestData) (string, error)
+	GetKeycloakEndpointAuthzResourceset(*http.Request) (string, error)
+	GetKeycloakEndpointToken(*http.Request) (string, error)
+	GetKeycloakEndpointClients(*http.Request) (string, error)
+	GetKeycloakEndpointAdmin(*http.Request) (string, error)
 	GetKeycloakClientID() string
 	GetKeycloakSecret() string
 	GetCacheControlSpaces() string
@@ -127,7 +128,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 
 	// Create keycloak resource for this space
 
-	resource, err := c.resourceManager.CreateSpace(ctx, ctx.RequestData, spaceID.String())
+	resource, err := c.resourceManager.CreateSpace(ctx, ctx.Request, spaceID.String())
 	if err != nil {
 		// Unable to create a space resource. Can't proceed. Rool back space creation and return an error.
 		c.rollBackSpaceCreation(ctx, spaceID)
@@ -148,7 +149,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 	if err != nil {
 		// Rool back space and space resource creation
 		c.rollBackSpaceCreation(ctx, spaceID)
-		remoteErr := c.resourceManager.DeleteSpace(ctx, ctx.RequestData, spaceID.String())
+		remoteErr := c.resourceManager.DeleteSpace(ctx, ctx.Request, spaceID.String())
 		if remoteErr != nil {
 			log.Error(ctx, map[string]interface{}{
 				"err":      remoteErr,
@@ -158,14 +159,14 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *rSpace)
+	spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.Request, *rSpace)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	res := &app.SpaceSingle{
 		Data: spaceData,
 	}
-	ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.SpaceHref(res.Data.ID)))
+	ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.SpaceHref(res.Data.ID)))
 	return ctx.Created(res)
 }
 
@@ -236,7 +237,7 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	err = c.resourceManager.DeleteSpace(ctx, ctx.RequestData, ctx.SpaceID.String())
+	err = c.resourceManager.DeleteSpace(ctx, ctx.Request, ctx.SpaceID.String())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -259,7 +260,7 @@ func (c *SpaceController) List(ctx *app.ListSpaceContext) error {
 		}
 		entityErr := ctx.ConditionalEntities(spaces, c.config.GetCacheControlSpaces, func() error {
 			count := int(cnt)
-			spaceData, err := ConvertSpacesFromModel(ctx.Context, c.db, ctx.RequestData, spaces)
+			spaceData, err := ConvertSpacesFromModel(ctx.Context, c.db, ctx.Request, spaces)
 			if err != nil {
 				return err
 			}
@@ -268,7 +269,7 @@ func (c *SpaceController) List(ctx *app.ListSpaceContext) error {
 				Meta:  &app.SpaceListMeta{TotalCount: count},
 				Data:  spaceData,
 			}
-			setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(spaces), offset, limit, count)
+			setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(spaces), offset, limit, count)
 			return nil
 		})
 		if entityErr != nil {
@@ -295,7 +296,7 @@ func (c *SpaceController) Show(ctx *app.ShowSpaceContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		return ctx.ConditionalRequest(*s, c.config.GetCacheControlSpace, func() error {
-			spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
+			spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.Request, *s)
 			if err != nil {
 				log.Error(ctx, map[string]interface{}{
 					"err":      err,
@@ -347,7 +348,7 @@ func (c *SpaceController) Update(ctx *app.UpdateSpaceContext) error {
 			return err
 		}
 
-		spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
+		spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.Request, *s)
 		if err != nil {
 			return err
 		}
@@ -425,10 +426,10 @@ func ConvertSpaceToModel(appSpace app.Space) space.Space {
 
 // SpaceConvertFunc is a open ended function to add additional links/data/relations to a Space during
 // conversion from internal to API
-type SpaceConvertFunc func(*goa.RequestData, *space.Space, *app.Space)
+type SpaceConvertFunc func(*http.Request, *space.Space, *app.Space)
 
 // ConvertSpacesFromModel converts between internal and external REST representation
-func ConvertSpacesFromModel(ctx context.Context, db application.DB, request *goa.RequestData, spaces []space.Space, additional ...SpaceConvertFunc) ([]*app.Space, error) {
+func ConvertSpacesFromModel(ctx context.Context, db application.DB, request *http.Request, spaces []space.Space, additional ...SpaceConvertFunc) ([]*app.Space, error) {
 	var ps = []*app.Space{}
 	for _, p := range spaces {
 		spaceData, err := ConvertSpaceFromModel(ctx, db, request, p, additional...)
@@ -442,7 +443,7 @@ func ConvertSpacesFromModel(ctx context.Context, db application.DB, request *goa
 }
 
 // ConvertSpaceFromModel converts between internal and external REST representation
-func ConvertSpaceFromModel(ctx context.Context, db application.DB, request *goa.RequestData, sp space.Space, additional ...SpaceConvertFunc) (*app.Space, error) {
+func ConvertSpaceFromModel(ctx context.Context, db application.DB, request *http.Request, sp space.Space, additional ...SpaceConvertFunc) (*app.Space, error) {
 	relatedURL := rest.AbsoluteURL(request, app.SpaceHref(sp.ID))
 	spaceIDStr := sp.ID.String()
 	relatedIterationList := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/iterations", spaceIDStr))

--- a/controller/space.go
+++ b/controller/space.go
@@ -166,7 +166,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 	res := &app.SpaceSingle{
 		Data: spaceData,
 	}
-	ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.SpaceHref(res.Data.ID)))
+	ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.Request, app.SpaceHref(res.Data.ID)))
 	return ctx.Created(res)
 }
 

--- a/controller/space_areas.go
+++ b/controller/space_areas.go
@@ -45,7 +45,7 @@ func (c *SpaceAreasController) List(ctx *app.ListSpaceAreasContext) error {
 		}
 		return ctx.ConditionalEntities(areas, c.config.GetCacheControlAreas, func() error {
 			res := &app.AreaList{}
-			res.Data = ConvertAreas(appl, ctx.RequestData, areas, addResolvedPath)
+			res.Data = ConvertAreas(appl, ctx.Request, areas, addResolvedPath)
 			return ctx.OK(res)
 		})
 	})

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -3,6 +3,7 @@ package controller_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"time"
@@ -32,11 +33,11 @@ var spaceConfiguration *configuration.ConfigurationData
 type DummyResourceManager struct {
 }
 
-func (m *DummyResourceManager) CreateSpace(ctx context.Context, request *goa.RequestData, spaceID string) (*authservice.SpaceResource, error) {
+func (m *DummyResourceManager) CreateSpace(ctx context.Context, request *http.Request, spaceID string) (*authservice.SpaceResource, error) {
 	return &authservice.SpaceResource{Data: &authservice.SpaceResourceData{ResourceID: uuid.NewV4().String(), PermissionID: uuid.NewV4().String(), PolicyID: uuid.NewV4().String()}}, nil
 }
 
-func (m *DummyResourceManager) DeleteSpace(ctx context.Context, request *goa.RequestData, spaceID string) error {
+func (m *DummyResourceManager) DeleteSpace(ctx context.Context, request *http.Request, spaceID string) error {
 	return nil
 }
 

--- a/controller/space_codebases.go
+++ b/controller/space_codebases.go
@@ -62,9 +62,9 @@ func (c *SpaceCodebasesController) Create(ctx *app.CreateSpaceCodebasesContext) 
 		}
 
 		res := &app.CodebaseSingle{
-			Data: ConvertCodebase(ctx.RequestData, &newCodeBase),
+			Data: ConvertCodebase(ctx.Request, &newCodeBase),
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.CodebaseHref(res.Data.ID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.CodebaseHref(res.Data.ID)))
 		return ctx.Created(res)
 	})
 }
@@ -87,9 +87,9 @@ func (c *SpaceCodebasesController) List(ctx *app.ListSpaceCodebasesContext) erro
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 		}
 		res.Meta = &app.CodebaseListMeta{TotalCount: count}
-		res.Data = ConvertCodebases(ctx.RequestData, codebases)
+		res.Data = ConvertCodebases(ctx.Request, codebases)
 		res.Links = &app.PagingLinks{}
-		setPagingLinks(res.Links, buildAbsoluteURL(ctx.RequestData), len(codebases), offset, limit, count)
+		setPagingLinks(res.Links, buildAbsoluteURL(ctx.Request), len(codebases), offset, limit, count)
 
 		return ctx.OK(res)
 	})

--- a/controller/space_codebases.go
+++ b/controller/space_codebases.go
@@ -64,7 +64,7 @@ func (c *SpaceCodebasesController) Create(ctx *app.CreateSpaceCodebasesContext) 
 		res := &app.CodebaseSingle{
 			Data: ConvertCodebase(ctx.Request, &newCodeBase),
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.CodebaseHref(res.Data.ID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.Request, app.CodebaseHref(res.Data.ID)))
 		return ctx.Created(res)
 	})
 }

--- a/controller/space_iterations.go
+++ b/controller/space_iterations.go
@@ -102,14 +102,14 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 			for _, itr := range iterations {
 				itrMap[itr.ID] = itr
 			}
-			responseData = ConvertIteration(ctx.RequestData, newItr, parentPathResolver(itrMap), updateIterationsWithCounts(wiCounts))
+			responseData = ConvertIteration(ctx.Request, newItr, parentPathResolver(itrMap), updateIterationsWithCounts(wiCounts))
 		} else {
-			responseData = ConvertIteration(ctx.RequestData, newItr, updateIterationsWithCounts(wiCounts))
+			responseData = ConvertIteration(ctx.Request, newItr, updateIterationsWithCounts(wiCounts))
 		}
 		res := &app.IterationSingle{
 			Data: responseData,
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.IterationHref(res.Data.ID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.IterationHref(res.Data.ID)))
 		return ctx.Created(res)
 	})
 }
@@ -141,7 +141,7 @@ func (c *SpaceIterationsController) List(ctx *app.ListSpaceIterationsContext) er
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
 			res := &app.IterationList{}
-			res.Data = ConvertIterations(ctx.RequestData, iterations, updateIterationsWithCounts(wiCounts), parentPathResolver(itrMap))
+			res.Data = ConvertIterations(ctx.Request, iterations, updateIterationsWithCounts(wiCounts), parentPathResolver(itrMap))
 			return ctx.OK(res)
 		})
 	})

--- a/controller/space_iterations.go
+++ b/controller/space_iterations.go
@@ -109,7 +109,7 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 		res := &app.IterationSingle{
 			Data: responseData,
 		}
-		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData.Request, app.IterationHref(res.Data.ID)))
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.Request, app.IterationHref(res.Data.ID)))
 		return ctx.Created(res)
 	})
 }

--- a/controller/trackerquery_blackbox_test.go
+++ b/controller/trackerquery_blackbox_test.go
@@ -258,9 +258,7 @@ func (rest *TestTrackerQueryREST) TestUpdateTrackerQuery() {
 		t.Errorf("Id should be %s, but is %s", tqresult.ID, tqr.ID)
 	}
 
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	spaceSelfURL := witrest.AbsoluteURL(reqLong, app.SpaceHref(space.SystemSpace.String()))
 	payload2 := app.UpdateTrackerQueryAlternatePayload{
 		Query:     tqr.Query,
@@ -334,9 +332,7 @@ func (rest *TestTrackerQueryREST) TestCreateTrackerQueryValidId() {
 }
 
 func newCreateTrackerQueryPayload(trackerID string) app.CreateTrackerQueryAlternatePayload {
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	spaceSelfURL := witrest.AbsoluteURL(reqLong, app.SpaceHref(space.SystemSpace.String()))
 	return app.CreateTrackerQueryAlternatePayload{
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",

--- a/controller/user.go
+++ b/controller/user.go
@@ -70,7 +70,7 @@ func (c *UserController) Show(ctx *app.ShowUserContext) error {
 					c.InitTenant(ctx)
 				}(ctx)
 			}
-			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity))
+			return ctx.OK(ConvertToAppUser(ctx.Request, user, identity))
 		})
 	})
 }

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -213,9 +213,7 @@ func createParentChildWorkItemLinkType(name string, categoryID, spaceID uuid.UUI
 		LinkCategoryID: categoryID,
 		SpaceID:        spaceID,
 	}
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	payload := ConvertWorkItemLinkTypeFromModel(reqLong, lt)
 	// The create payload is required during creation. Simply copy data over.
 	return &app.CreateWorkItemLinkTypePayload{

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 
 	"github.com/fabric8-services/fabric8-wit/app"
@@ -47,22 +48,24 @@ type hrefLinkFunc func(obj interface{}) string
 // workItemLinkContext bundles objects that are needed by most of the functions.
 // It can easily be extended.
 type workItemLinkContext struct {
-	RequestData           *goa.RequestData
-	ResponseData          *goa.ResponseData
+	Request               *http.Request
+	ResponseWriter        http.ResponseWriter
 	Application           application.Application
 	Context               context.Context
+	Service               *goa.Service
 	CurrentUserIdentityID *uuid.UUID
 	DB                    application.DB
 	LinkFunc              hrefLinkFunc
 }
 
 // newWorkItemLinkContext returns a new workItemLinkContext
-func newWorkItemLinkContext(ctx context.Context, appl application.Application, db application.DB, requestData *goa.RequestData, responseData *goa.ResponseData, linkFunc hrefLinkFunc, currentUserIdentityID *uuid.UUID) *workItemLinkContext {
+func newWorkItemLinkContext(ctx context.Context, service *goa.Service, appl application.Application, db application.DB, request *http.Request, responseWriter http.ResponseWriter, linkFunc hrefLinkFunc, currentUserIdentityID *uuid.UUID) *workItemLinkContext {
 	return &workItemLinkContext{
-		RequestData:           requestData,
-		ResponseData:          responseData,
+		Request:               request,
+		ResponseWriter:        responseWriter,
 		Application:           appl,
 		Context:               ctx,
+		Service:               service,
 		CurrentUserIdentityID: currentUserIdentityID,
 		DB:       db,
 		LinkFunc: linkFunc,
@@ -86,7 +89,7 @@ func getTypesOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemLinkD
 		}
 		linkTypeModels = append(linkTypeModels, *linkTypeModel)
 	}
-	appLinkTypes, err := ConvertLinkTypesFromModels(ctx.RequestData.Request, linkTypeModels)
+	appLinkTypes, err := ConvertLinkTypesFromModels(ctx.Request, linkTypeModels)
 	if err != nil {
 		return nil, errs.WithStack(err)
 	}
@@ -109,7 +112,7 @@ func getWorkItemsOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemL
 		if err != nil {
 			return nil, errs.WithStack(err)
 		}
-		workItemArr = append(workItemArr, ConvertWorkItem(ctx.RequestData.Request, *wi))
+		workItemArr = append(workItemArr, ConvertWorkItem(ctx.Request, *wi))
 	}
 	return workItemArr, nil
 }
@@ -142,7 +145,7 @@ func enrichLinkSingle(ctx *workItemLinkContext, appLinks *app.WorkItemLinkSingle
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinkType := ConvertWorkItemLinkTypeFromModel(ctx.RequestData.Request, *modelLinkType)
+	appLinkType := ConvertWorkItemLinkTypeFromModel(ctx.Request, *modelLinkType)
 	appLinks.Included = append(appLinks.Included, appLinkType.Data)
 
 	// include link category
@@ -172,17 +175,17 @@ func enrichLinkSingle(ctx *workItemLinkContext, appLinks *app.WorkItemLinkSingle
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.RequestData.Request, *sourceWi))
+	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.Request, *sourceWi))
 
 	// TODO(kwk): include target work item
 	targetWi, err := ctx.Application.WorkItems().LoadByID(ctx.Context, appLinks.Data.Relationships.Target.Data.ID)
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.RequestData.Request, *targetWi))
+	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.Request, *targetWi))
 
 	// Add links to individual link data element
-	relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*appLinks.Data.ID))
+	relatedURL := rest.AbsoluteURL(ctx.Request, ctx.LinkFunc(*appLinks.Data.ID))
 	appLinks.Data.Links = &app.GenericLinks{
 		Self:    &relatedURL,
 		Related: &relatedURL,
@@ -234,7 +237,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 
 	// Add links to individual link data element
 	for _, link := range linkArr.Data {
-		relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*link.ID))
+		relatedURL := rest.AbsoluteURL(ctx.Request, ctx.LinkFunc(*link.ID))
 		link.Links = &app.GenericLinks{
 			Self:    &relatedURL,
 			Related: &relatedURL,
@@ -273,7 +276,7 @@ func createWorkItemLink(ctx *workItemLinkContext, httpFuncs createWorkItemLinkFu
 	if err := enrichLinkSingle(ctx, &createdAppLink); err != nil {
 		return jsonapi.JSONErrorResponse(httpFuncs, err)
 	}
-	ctx.ResponseData.Header().Set("Location", app.WorkItemLinkHref(createdAppLink.Data.ID))
+	ctx.ResponseWriter.Header().Set("Location", app.WorkItemLinkHref(createdAppLink.Data.ID))
 	return httpFuncs.Created(&createdAppLink)
 }
 
@@ -283,7 +286,7 @@ func (c *WorkItemLinkController) Create(ctx *app.CreateWorkItemLinkContext) erro
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	linkCtx := newWorkItemLinkContext(ctx.Context, c.db, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, currentUserIdentityID)
+	linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, c.db, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
 	return createWorkItemLink(linkCtx, ctx, ctx.Payload)
 }
 
@@ -311,7 +314,7 @@ func (c *WorkItemLinkController) Delete(ctx *app.DeleteWorkItemLinkContext) erro
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, currentUserIdentityID)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
 		return deleteWorkItemLink(linkCtx, ctx, ctx.LinkID)
 	})
 }
@@ -324,7 +327,7 @@ func (c *WorkItemLinkController) Show(ctx *app.ShowWorkItemLinkContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		return ctx.ConditionalRequest(*modelLink, c.config.GetCacheControlWorkItemLink, func() error {
-			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, nil)
+			linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, nil)
 			// convert to rest representation
 			appLink := ConvertLinkFromModel(*modelLink)
 			if err := enrichLinkSingle(linkCtx, &appLink); err != nil {
@@ -354,7 +357,7 @@ func updateWorkItemLink(ctx *workItemLinkContext, httpFuncs updateWorkItemLinkFu
 	savedModelLink, err := ctx.Application.WorkItemLinks().Save(ctx.Context, *modelLink, *ctx.CurrentUserIdentityID)
 	if err != nil {
 		jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(ctx.Context, err)
-		return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+		return ctx.Service.Send(ctx.Context, httpStatusCode, jerrors)
 	}
 	// Convert the created link type entry into a rest representation
 	savedAppLink := ConvertLinkFromModel(*savedModelLink)
@@ -372,7 +375,7 @@ func (c *WorkItemLinkController) Update(ctx *app.UpdateWorkItemLinkContext) erro
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, currentUserIdentityID)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
 		return updateWorkItemLink(linkCtx, ctx, ctx.Payload)
 	})
 }

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -86,7 +86,7 @@ func getTypesOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemLinkD
 		}
 		linkTypeModels = append(linkTypeModels, *linkTypeModel)
 	}
-	appLinkTypes, err := ConvertLinkTypesFromModels(ctx.RequestData, linkTypeModels)
+	appLinkTypes, err := ConvertLinkTypesFromModels(ctx.RequestData.Request, linkTypeModels)
 	if err != nil {
 		return nil, errs.WithStack(err)
 	}
@@ -109,7 +109,7 @@ func getWorkItemsOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemL
 		if err != nil {
 			return nil, errs.WithStack(err)
 		}
-		workItemArr = append(workItemArr, ConvertWorkItem(ctx.RequestData, *wi))
+		workItemArr = append(workItemArr, ConvertWorkItem(ctx.RequestData.Request, *wi))
 	}
 	return workItemArr, nil
 }
@@ -142,7 +142,7 @@ func enrichLinkSingle(ctx *workItemLinkContext, appLinks *app.WorkItemLinkSingle
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinkType := ConvertWorkItemLinkTypeFromModel(ctx.RequestData, *modelLinkType)
+	appLinkType := ConvertWorkItemLinkTypeFromModel(ctx.RequestData.Request, *modelLinkType)
 	appLinks.Included = append(appLinks.Included, appLinkType.Data)
 
 	// include link category
@@ -172,17 +172,17 @@ func enrichLinkSingle(ctx *workItemLinkContext, appLinks *app.WorkItemLinkSingle
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.RequestData, *sourceWi))
+	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.RequestData.Request, *sourceWi))
 
 	// TODO(kwk): include target work item
 	targetWi, err := ctx.Application.WorkItems().LoadByID(ctx.Context, appLinks.Data.Relationships.Target.Data.ID)
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.RequestData, *targetWi))
+	appLinks.Included = append(appLinks.Included, ConvertWorkItem(ctx.RequestData.Request, *targetWi))
 
 	// Add links to individual link data element
-	relatedURL := rest.AbsoluteURL(ctx.RequestData, ctx.LinkFunc(*appLinks.Data.ID))
+	relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*appLinks.Data.ID))
 	appLinks.Data.Links = &app.GenericLinks{
 		Self:    &relatedURL,
 		Related: &relatedURL,
@@ -234,7 +234,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 
 	// Add links to individual link data element
 	for _, link := range linkArr.Data {
-		relatedURL := rest.AbsoluteURL(ctx.RequestData, ctx.LinkFunc(*link.ID))
+		relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*link.ID))
 		link.Links = &app.GenericLinks{
 			Self:    &relatedURL,
 			Related: &relatedURL,

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -207,12 +207,8 @@ func newCreateWorkItemLinkCategoryPayload(name string) *app.CreateWorkItemLinkCa
 
 // CreateWorkItem defines a work item link
 func newCreateWorkItemPayload(spaceID uuid.UUID, workItemType uuid.UUID, title string) *app.CreateWorkitemsPayload {
-	spaceRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(spaceID.String()))
-	witRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.WorkitemtypeHref(spaceID.String(), workItemType))
+	spaceRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
+	witRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.WorkitemtypeHref(spaceID.String(), workItemType))
 	payload := app.CreateWorkitemsPayload{
 		Data: &app.WorkItem{
 			Attributes: map[string]interface{}{
@@ -250,9 +246,7 @@ func newCreateWorkItemLinkTypePayload(name string, categoryID, spaceID uuid.UUID
 		LinkCategoryID: categoryID,
 		SpaceID:        spaceID,
 	}
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	payload := ConvertWorkItemLinkTypeFromModel(reqLong, lt)
 	// The create payload is required during creation. Simply copy data over.
 	return &app.CreateWorkItemLinkTypePayload{

--- a/controller/work_item_link_category.go
+++ b/controller/work_item_link_category.go
@@ -29,7 +29,7 @@ func NewWorkItemLinkCategoryController(service *goa.Service, db application.DB) 
 // enrichLinkCategorySingle includes related resources in the single's "included" array
 func enrichLinkCategorySingle(ctx *workItemLinkContext, single app.WorkItemLinkCategorySingle) error {
 	// Add "links" element
-	relatedURL := rest.AbsoluteURL(ctx.RequestData, ctx.LinkFunc(single.Data.ID))
+	relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(single.Data.ID))
 	single.Data.Links = &app.GenericLinks{
 		Self:    &relatedURL,
 		Related: &relatedURL,
@@ -41,7 +41,7 @@ func enrichLinkCategorySingle(ctx *workItemLinkContext, single app.WorkItemLinkC
 func enrichLinkCategoryList(ctx *workItemLinkContext, list *app.WorkItemLinkCategoryList) error {
 	// Add "links" element
 	for _, data := range list.Data {
-		relatedURL := rest.AbsoluteURL(ctx.RequestData, ctx.LinkFunc(*data.ID))
+		relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*data.ID))
 		data.Links = &app.GenericLinks{
 			Self:    &relatedURL,
 			Related: &relatedURL,
@@ -168,8 +168,7 @@ func (c *WorkItemLinkCategoryController) Update(ctx *app.UpdateWorkItemLinkCateg
 	return application.Transactional(c.db, func(appl application.Application) error {
 		savedModelCategory, err := appl.WorkItemLinkCategories().Save(ctx.Context, modelCategory)
 		if err != nil {
-			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(ctx, err)
-			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		// convert to app representation
 		savedAppCategory := ConvertLinkCategoryFromModel(*savedModelCategory)

--- a/controller/work_item_link_category.go
+++ b/controller/work_item_link_category.go
@@ -29,7 +29,7 @@ func NewWorkItemLinkCategoryController(service *goa.Service, db application.DB) 
 // enrichLinkCategorySingle includes related resources in the single's "included" array
 func enrichLinkCategorySingle(ctx *workItemLinkContext, single app.WorkItemLinkCategorySingle) error {
 	// Add "links" element
-	relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(single.Data.ID))
+	relatedURL := rest.AbsoluteURL(ctx.Request, ctx.LinkFunc(single.Data.ID))
 	single.Data.Links = &app.GenericLinks{
 		Self:    &relatedURL,
 		Related: &relatedURL,
@@ -41,7 +41,7 @@ func enrichLinkCategorySingle(ctx *workItemLinkContext, single app.WorkItemLinkC
 func enrichLinkCategoryList(ctx *workItemLinkContext, list *app.WorkItemLinkCategoryList) error {
 	// Add "links" element
 	for _, data := range list.Data {
-		relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*data.ID))
+		relatedURL := rest.AbsoluteURL(ctx.Request, ctx.LinkFunc(*data.ID))
 		data.Links = &app.GenericLinks{
 			Self:    &relatedURL,
 			Related: &relatedURL,
@@ -68,7 +68,7 @@ func (c *WorkItemLinkCategoryController) Create(ctx *app.CreateWorkItemLinkCateg
 			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
 		}
 		appCategory := ConvertLinkCategoryFromModel(modelCategory)
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkCategoryHref, currentUserIdentityID)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkCategoryHref, currentUserIdentityID)
 		err = enrichLinkCategorySingle(linkCtx, appCategory)
 		if err != nil {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrInternal("Failed to enrich link category: %s", err.Error()))
@@ -88,7 +88,7 @@ func (c *WorkItemLinkCategoryController) Show(ctx *app.ShowWorkItemLinkCategoryC
 			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
 		}
 		appCategory := ConvertLinkCategoryFromModel(*modelCategory)
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkCategoryHref, nil)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkCategoryHref, nil)
 		err = enrichLinkCategorySingle(linkCtx, appCategory)
 		if err != nil {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrInternal("Failed to enrich link category: %s", err.Error()))
@@ -119,7 +119,7 @@ func (c *WorkItemLinkCategoryController) List(ctx *app.ListWorkItemLinkCategoryC
 			TotalCount: len(modelCategories),
 		}
 		// Enrich
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkCategoryHref, nil)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkCategoryHref, nil)
 		err = enrichLinkCategoryList(linkCtx, &appCategories)
 		if err != nil {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrInternal("Failed to enrich link categories: %s", err.Error()))
@@ -173,7 +173,7 @@ func (c *WorkItemLinkCategoryController) Update(ctx *app.UpdateWorkItemLinkCateg
 		// convert to app representation
 		savedAppCategory := ConvertLinkCategoryFromModel(*savedModelCategory)
 		// Enrich
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkCategoryHref, currentUserIdentityID)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkCategoryHref, currentUserIdentityID)
 		err = enrichLinkCategorySingle(linkCtx, savedAppCategory)
 		if err != nil {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrInternal("Failed to enrich link category: %s", err.Error()))

--- a/controller/work_item_link_type.go
+++ b/controller/work_item_link_type.go
@@ -41,7 +41,7 @@ func NewWorkItemLinkTypeController(service *goa.Service, db application.DB, conf
 // enrichLinkTypeSingle includes related resources in the single's "included" array
 func enrichLinkTypeSingle(ctx *workItemLinkContext, single *app.WorkItemLinkTypeSingle) error {
 	// Add "links" element
-	relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*single.Data.ID))
+	relatedURL := rest.AbsoluteURL(ctx.Request, ctx.LinkFunc(*single.Data.ID))
 	single.Data.Links = &app.GenericLinks{
 		Self:    &relatedURL,
 		Related: &relatedURL,
@@ -61,7 +61,7 @@ func enrichLinkTypeSingle(ctx *workItemLinkContext, single *app.WorkItemLinkType
 		return err
 	}
 
-	spaceData, err := ConvertSpaceFromModel(ctx.Context, ctx.DB, ctx.RequestData.Request, *space)
+	spaceData, err := ConvertSpaceFromModel(ctx.Context, ctx.DB, ctx.Request, *space)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func enrichLinkTypeSingle(ctx *workItemLinkContext, single *app.WorkItemLinkType
 func enrichLinkTypeList(ctx *workItemLinkContext, list *app.WorkItemLinkTypeList) error {
 	// Add "links" element
 	for _, data := range list.Data {
-		relatedURL := rest.AbsoluteURL(ctx.RequestData.Request, ctx.LinkFunc(*data.ID))
+		relatedURL := rest.AbsoluteURL(ctx.Request, ctx.LinkFunc(*data.ID))
 		data.Links = &app.GenericLinks{
 			Self:    &relatedURL,
 			Related: &relatedURL,
@@ -109,7 +109,7 @@ func enrichLinkTypeList(ctx *workItemLinkContext, list *app.WorkItemLinkTypeList
 		if err != nil {
 			return err
 		}
-		spaceData, err := ConvertSpaceFromModel(ctx.Context, ctx.DB, ctx.RequestData.Request, *space)
+		spaceData, err := ConvertSpaceFromModel(ctx.Context, ctx.DB, ctx.Request, *space)
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func (c *WorkItemLinkTypeController) Create(ctx *app.CreateWorkItemLinkTypeConte
 	// Set the space to the Payload
 	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil {
 		// We overwrite or use the space ID in the URL to set the space of this WI
-		spaceSelfURL := rest.AbsoluteURL(ctx.RequestData.Request, app.SpaceHref(ctx.SpaceID.String()))
+		spaceSelfURL := rest.AbsoluteURL(ctx.Request, app.SpaceHref(ctx.SpaceID.String()))
 		ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(ctx.SpaceID, spaceSelfURL)
 	}
 	modelLinkType, err := ConvertWorkItemLinkTypeToModel(appLinkType)
@@ -157,7 +157,7 @@ func (c *WorkItemLinkTypeController) Create(ctx *app.CreateWorkItemLinkTypeConte
 		hrefFunc := func(obj interface{}) string {
 			return fmt.Sprintf(app.WorkItemLinkTypeHref(createdModelLinkType.SpaceID, "%v"), obj)
 		}
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, currentUserIdentityID)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, hrefFunc, currentUserIdentityID)
 		err = enrichLinkTypeSingle(linkCtx, &appLinkType)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal("Failed to enrich link type: %s", err.Error()))
@@ -209,7 +209,7 @@ func (c *WorkItemLinkTypeController) List(ctx *app.ListWorkItemLinkTypeContext) 
 			hrefFunc := func(obj interface{}) string {
 				return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 			}
-			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, nil)
+			linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, hrefFunc, nil)
 			err = enrichLinkTypeList(linkCtx, &appLinkTypes)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal("Failed to enrich link types: %s", err.Error()))
@@ -235,7 +235,7 @@ func (c *WorkItemLinkTypeController) Show(ctx *app.ShowWorkItemLinkTypeContext) 
 			hrefFunc := func(obj interface{}) string {
 				return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 			}
-			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, nil)
+			linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, hrefFunc, nil)
 			err = enrichLinkTypeSingle(linkCtx, &appLinkType)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal("Failed to enrich link type: %s", err.Error()))
@@ -278,7 +278,7 @@ func (c *WorkItemLinkTypeController) Update(ctx *app.UpdateWorkItemLinkTypeConte
 		hrefFunc := func(obj interface{}) string {
 			return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 		}
-		linkTypeCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, currentUserIdentityID)
+		linkTypeCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, hrefFunc, currentUserIdentityID)
 		err = enrichLinkTypeSingle(linkTypeCtx, &appLinkType)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal("Failed to enrich link type: %s", err.Error()))

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -326,9 +326,7 @@ func createWorkItemLinkTypeInRepo(t *testing.T, db application.DB, ctx context.C
 		if err != nil {
 			return err
 		}
-		r := &goa.RequestData{
-			Request: &http.Request{Host: "domain.io"},
-		}
+		r := &http.Request{Host: "domain.io"}
 		appLinkTypeResult = ConvertWorkItemLinkTypeFromModel(r, *createdModelLinkType)
 		return nil
 	})

--- a/controller/work_item_relationships_links.go
+++ b/controller/work_item_relationships_links.go
@@ -78,7 +78,7 @@ func (c *WorkItemRelationshipsLinksController) Create(ctx *app.CreateWorkItemRel
 			ctx.Payload.Data.Relationships.Source.Data.ID = wi.ID
 			ctx.Payload.Data.Relationships.Source.Data.Type = link.EndpointWorkItems
 		}
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, currentUserIdentityID)
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
 		return createWorkItemLink(linkCtx, ctx, ctx.Payload)
 	})
 }
@@ -102,7 +102,7 @@ func (c *WorkItemRelationshipsLinksController) List(ctx *app.ListWorkItemRelatio
 			appLinks.Meta = &app.WorkItemLinkListMeta{
 				TotalCount: len(modelLinks),
 			}
-			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, nil)
+			linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, nil)
 			if err := enrichLinkList(linkCtx, &appLinks); err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}

--- a/controller/work_item_type_group.go
+++ b/controller/work_item_type_group.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"net/http"
+
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
@@ -36,10 +38,10 @@ func (c *WorkItemTypeGroupController) List(ctx *app.ListWorkItemTypeGroupContext
 	res.Data = &app.WorkItemTypeGroupData{
 		Attributes: &app.WorkItemTypeGroupAttributes{
 			Hierarchy: []*app.WorkItemTypeGroup{
-				ConvertTypeGroup(ctx.RequestData, typegroup.Portfolio0),
-				ConvertTypeGroup(ctx.RequestData, typegroup.Portfolio1),
-				ConvertTypeGroup(ctx.RequestData, typegroup.Requirements0),
-				ConvertTypeGroup(ctx.RequestData, typegroup.Execution0),
+				ConvertTypeGroup(ctx.Request, typegroup.Portfolio0),
+				ConvertTypeGroup(ctx.Request, typegroup.Portfolio1),
+				ConvertTypeGroup(ctx.Request, typegroup.Requirements0),
+				ConvertTypeGroup(ctx.Request, typegroup.Execution0),
 			},
 		},
 		Type: APIWorkItemTypeGroups,
@@ -49,7 +51,7 @@ func (c *WorkItemTypeGroupController) List(ctx *app.ListWorkItemTypeGroupContext
 
 // ConvertTypeGroup converts WorkitemTypeGroup model to a response resource
 // object for jsonapi.org specification
-func ConvertTypeGroup(request *goa.RequestData, tg typegroup.WorkItemTypeGroup) *app.WorkItemTypeGroup {
+func ConvertTypeGroup(request *http.Request, tg typegroup.WorkItemTypeGroup) *app.WorkItemTypeGroup {
 	return &app.WorkItemTypeGroup{
 		Group:         tg.Group,
 		Level:         tg.Level,

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -703,9 +703,7 @@ func getMinimumRequiredUpdatePayload(wi *app.WorkItem) *app.UpdateWorkitemPayloa
 }
 
 func minimumRequiredUpdatePayload() app.UpdateWorkitemPayload {
-	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(space.SystemSpace.String()))
+	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
 	return app.UpdateWorkitemPayload{
 		Data: &app.WorkItem{
 			Type:       APIStringTypeWorkItem,
@@ -739,10 +737,7 @@ func minimumRequiredCreateWithTypeAndSpace(witID uuid.UUID, spaceID uuid.UUID) a
 }
 
 func newRelationBaseType(spaceID, wit uuid.UUID) *app.RelationBaseType {
-	witRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.WorkitemtypeHref(spaceID.String(), wit.String()))
-
+	witRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.WorkitemtypeHref(spaceID.String(), wit.String()))
 	return &app.RelationBaseType{
 		Data: &app.BaseTypeData{
 			Type: "workitemtypes",
@@ -756,10 +751,7 @@ func newRelationBaseType(spaceID, wit uuid.UUID) *app.RelationBaseType {
 }
 
 func minimumRequiredCreatePayload() app.CreateWorkitemsPayload {
-	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(space.SystemSpace.String()))
-
+	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
 	return app.CreateWorkitemsPayload{
 		Data: &app.WorkItem{
 			Type:       APIStringTypeWorkItem,
@@ -1908,9 +1900,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithArea() {
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(space.SystemSpace.String()))
+	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
 	c.Data.Relationships = &app.WorkItemRelationships{
 		BaseType: newRelationBaseType(space.SystemSpace, workitem.SystemBug),
 		Space:    app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
@@ -1996,9 +1986,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootAreaIfMissing() {
 				workitem.SystemState: workitem.SystemStateNew,
 			},
 			Relationships: &app.WorkItemRelationships{
-				Space: app.NewSpaceRelation(testSpace.ID, rest.AbsoluteURL(&goa.RequestData{
-					Request: &http.Request{Host: "api.service.domain.org"},
-				}, app.SpaceHref(testSpace.ID.String()))),
+				Space: app.NewSpaceRelation(testSpace.ID, rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(testSpace.ID.String()))),
 				BaseType: &app.RelationBaseType{
 					Data: &app.BaseTypeData{
 						Type: "workitemtypes",
@@ -2067,9 +2055,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(space.SystemSpace.String()))
+	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
 	c.Data.Relationships = &app.WorkItemRelationships{
 		BaseType: newRelationBaseType(space.SystemSpace, workitem.SystemBug),
 		Space:    app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
@@ -2136,9 +2122,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootIterationIfMissing() {
 				workitem.SystemState: workitem.SystemStateNew,
 			},
 			Relationships: &app.WorkItemRelationships{
-				Space: app.NewSpaceRelation(testSpace.ID, rest.AbsoluteURL(&goa.RequestData{
-					Request: &http.Request{Host: "api.service.domain.org"},
-				}, app.SpaceHref(testSpace.ID.String()))),
+				Space: app.NewSpaceRelation(testSpace.ID, rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(testSpace.ID.String()))),
 				BaseType: &app.RelationBaseType{
 					Data: &app.BaseTypeData{
 						Type: "workitemtypes",
@@ -2747,10 +2731,7 @@ func (s *WorkItem2Suite) TestNotificationSendOnUpdate() {
 }
 
 func minimumRequiredCreatePayloadWithSpace(spaceID uuid.UUID) app.CreateWorkitemsPayload {
-	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(spaceID.String()))
-
+	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
 	return app.CreateWorkitemsPayload{
 		Data: &app.WorkItem{
 			Type:       APIStringTypeWorkItem,
@@ -2763,9 +2744,7 @@ func minimumRequiredCreatePayloadWithSpace(spaceID uuid.UUID) app.CreateWorkitem
 }
 
 func minimumRequiredUpdatePayloadWithSpace(spaceID uuid.UUID) app.UpdateWorkitemPayload {
-	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(spaceID.String()))
+	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
 	return app.UpdateWorkitemPayload{
 		Data: &app.WorkItem{
 			Type:       APIStringTypeWorkItem,

--- a/controller/workitem_whitebox_test.go
+++ b/controller/workitem_whitebox_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/space"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 
-	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -110,8 +109,7 @@ func TestSetPagingLinks(t *testing.T) {
 }
 
 func TestConvertWorkItemWithDescription(t *testing.T) {
-	request := http.Request{Host: "localhost"}
-	requestData := &goa.RequestData{Request: &request}
+	request := &http.Request{Host: "localhost"}
 	// map[string]interface{}
 	fields := map[string]interface{}{
 		workitem.SystemTitle:       "title",
@@ -122,21 +120,20 @@ func TestConvertWorkItemWithDescription(t *testing.T) {
 		Fields:  fields,
 		SpaceID: space.SystemSpace,
 	}
-	wi2 := ConvertWorkItem(requestData, wi)
+	wi2 := ConvertWorkItem(request, wi)
 	assert.Equal(t, "title", wi2.Attributes[workitem.SystemTitle])
 	assert.Equal(t, "description", wi2.Attributes[workitem.SystemDescription])
 }
 
 func TestConvertWorkItemWithoutDescription(t *testing.T) {
-	request := http.Request{Host: "localhost"}
-	requestData := &goa.RequestData{Request: &request}
+	request := &http.Request{Host: "localhost"}
 	wi := workitem.WorkItem{
 		Fields: map[string]interface{}{
 			workitem.SystemTitle: "title",
 		},
 		SpaceID: space.SystemSpace,
 	}
-	wi2 := ConvertWorkItem(requestData, wi)
+	wi2 := ConvertWorkItem(request, wi)
 	assert.Equal(t, "title", wi2.Attributes[workitem.SystemTitle])
 	assert.Nil(t, wi2.Attributes[workitem.SystemDescription])
 }
@@ -166,12 +163,8 @@ func (rest *TestWorkItemREST) TearDownTest() {
 }
 
 func prepareWI2(attributes map[string]interface{}) app.WorkItem {
-	spaceRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.SpaceHref(space.SystemSpace.String()))
-	witRelatedURL := rest.AbsoluteURL(&goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}, app.WorkitemtypeHref(space.SystemSpace.String(), workitem.SystemBug.String()))
+	spaceRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
+	witRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.WorkitemtypeHref(space.SystemSpace.String(), workitem.SystemBug.String()))
 	return app.WorkItem{
 		Type: "workitems",
 		Relationships: &app.WorkItemRelationships{

--- a/controller/workitems.go
+++ b/controller/workitems.go
@@ -104,7 +104,7 @@ func (c *WorkitemsController) Create(ctx *app.CreateWorkitemsContext) error {
 	// Set the space to the Payload
 	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil {
 		// We overwrite or use the space ID in the URL to set the space of this WI
-		spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(ctx.SpaceID.String()))
+		spaceSelfURL := rest.AbsoluteURL(ctx.Request, app.SpaceHref(ctx.SpaceID.String()))
 		ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(ctx.SpaceID, spaceSelfURL)
 	}
 	wi := &workitem.WorkItem{
@@ -129,11 +129,11 @@ func (c *WorkitemsController) Create(ctx *app.CreateWorkitemsContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
 		}
 		hasChildren := workItemIncludeHasChildren(appl, ctx)
-		wi2 := ConvertWorkItem(ctx.RequestData, *wi, hasChildren)
+		wi2 := ConvertWorkItem(ctx.Request, *wi, hasChildren)
 		resp := &app.WorkItemSingle{
 			Data: wi2,
 			Links: &app.WorkItemLinks{
-				Self: buildAbsoluteURL(ctx.RequestData),
+				Self: buildAbsoluteURL(ctx.Request),
 			},
 		}
 		ctx.ResponseData.Header().Set("Last-Modified", lastModified(*wi))
@@ -227,10 +227,10 @@ func (c *WorkitemsController) List(ctx *app.ListWorkitemsContext) error {
 			response := app.WorkItemList{
 				Links: &app.PagingLinks{},
 				Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
-				Data:  ConvertWorkItems(ctx.RequestData, workitems, hasChildren),
+				Data:  ConvertWorkItems(ctx.Request, workitems, hasChildren),
 			}
-			setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(workitems), offset, limit, count, additionalQuery...)
-			addFilterLinks(response.Links, ctx.RequestData)
+			setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(workitems), offset, limit, count, additionalQuery...)
+			addFilterLinks(response.Links, ctx.Request)
 			return ctx.OK(&response)
 		})
 
@@ -282,7 +282,7 @@ func (c *WorkitemsController) Reorder(ctx *app.ReorderWorkitemsContext) error {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
 			hasChildren := workItemIncludeHasChildren(appl, ctx)
-			wi2 := ConvertWorkItem(ctx.RequestData, *wi, hasChildren)
+			wi2 := ConvertWorkItem(ctx.Request, *wi, hasChildren)
 			dataArray = append(dataArray, wi2)
 		}
 		log.Debug(ctx, nil, "Reordered items: %d", len(dataArray))

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
@@ -52,7 +53,7 @@ func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		return ctx.ConditionalRequest(*witModel, c.config.GetCacheControlWorkItemType, func() error {
-			witData := ConvertWorkItemTypeFromModel(ctx.RequestData, witModel)
+			witData := ConvertWorkItemTypeFromModel(ctx.Request, witModel)
 			wit := &app.WorkItemTypeSingle{Data: &witData}
 			return ctx.OK(wit)
 		})
@@ -85,7 +86,7 @@ func (c *WorkitemtypeController) Create(ctx *app.CreateWorkitemtypeContext) erro
 		// Set the space to the Payload
 		if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil {
 			// We overwrite or use the space ID in the URL to set the space of this WI
-			spaceSelfURL := rest.AbsoluteURL(ctx.RequestData, app.SpaceHref(ctx.SpaceID.String()))
+			spaceSelfURL := rest.AbsoluteURL(ctx.Request, app.SpaceHref(ctx.SpaceID.String()))
 			ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(ctx.SpaceID, spaceSelfURL)
 		}
 		modelFields, err := ConvertFieldDefinitionsToModel(fields)
@@ -104,7 +105,7 @@ func (c *WorkitemtypeController) Create(ctx *app.CreateWorkitemtypeContext) erro
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		witData := ConvertWorkItemTypeFromModel(ctx.RequestData, witTypeModel)
+		witData := ConvertWorkItemTypeFromModel(ctx.Request, witTypeModel)
 		wit := &app.WorkItemTypeSingle{Data: &witData}
 		ctx.ResponseData.Header().Set("Location", app.WorkitemtypeHref(*ctx.Payload.Data.Relationships.Space.Data.ID, wit.Data.ID))
 		return ctx.Created(wit)
@@ -143,7 +144,7 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 			result := &app.WorkItemTypeList{}
 			result.Data = make([]*app.WorkItemTypeData, len(witModels))
 			for index, value := range witModels {
-				wit := ConvertWorkItemTypeFromModel(ctx.RequestData, &value)
+				wit := ConvertWorkItemTypeFromModel(ctx.Request, &value)
 				result.Data[index] = &wit
 			}
 			return ctx.OK(result)
@@ -151,8 +152,8 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 	})
 }
 
-// converts from models to app representation
-func ConvertWorkItemTypeFromModel(request *goa.RequestData, t *workitem.WorkItemType) app.WorkItemTypeData {
+// ConvertWorkItemTypeFromModel converts from models to app representation
+func ConvertWorkItemTypeFromModel(request *http.Request, t *workitem.WorkItemType) app.WorkItemTypeData {
 	spaceSelfURL := rest.AbsoluteURL(request, app.SpaceHref(t.SpaceID.String()))
 	id := t.ID
 	createdAt := t.CreatedAt.UTC()

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -115,9 +115,7 @@ func (s *workItemTypeSuite) createWorkItemTypeAnimal() (http.ResponseWriter, *ap
 
 	// Use the goa generated code to create a work item type
 	desc := "Description for 'animal'"
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	spaceSelfURL := rest.AbsoluteURL(reqLong, app.SpaceHref(space.SystemSpace.String()))
 	payload := app.CreateWorkitemtypePayload{
 		Data: &app.WorkItemTypeData{
@@ -163,9 +161,7 @@ func (s *workItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 	// Use the goa generated code to create a work item type
 	desc := "Description for 'person'"
 	id := personID
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	spaceSelfURL := rest.AbsoluteURL(reqLong, app.SpaceHref(space.SystemSpace.String()))
 	payload := app.CreateWorkitemtypePayload{
 		Data: &app.WorkItemTypeData{
@@ -198,9 +194,7 @@ func (s *workItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 func newCreateWorkItemTypePayload(id uuid.UUID, spaceID uuid.UUID) app.CreateWorkitemtypePayload {
 	// Use the goa generated code to create a work item type
 	desc := "Description for 'person'"
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	spaceSelfURL := rest.AbsoluteURL(reqLong, app.SpaceHref(spaceID.String()))
 	payload := app.CreateWorkitemtypePayload{
 		Data: &app.WorkItemTypeData{
@@ -288,9 +282,7 @@ func (s *workItemTypeSuite) TestValidate() {
 	// given
 	desc := "Description for 'person'"
 	id := personID
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	spaceSelfURL := rest.AbsoluteURL(reqLong, app.SpaceHref(space.SystemSpace.String()))
 	payload := app.CreateWorkitemtypePayload{
 		Data: &app.WorkItemTypeData{

--- a/controller/workitemtype_whitebox_test.go
+++ b/controller/workitemtype_whitebox_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/space"
 	"github.com/fabric8-services/fabric8-wit/workitem"
-	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,9 +70,7 @@ func TestConvertTypeFromModel(t *testing.T) {
 
 	// Create the type for "animal-type" field based on the enum above
 	stString := "string"
-	reqLong := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
 	spaceSelfURL := rest.AbsoluteURL(reqLong, app.SpaceHref(space.SystemSpace.String()))
 	version := 42
 	expected := app.WorkItemTypeSingle{

--- a/login/logout_blackbox_test.go
+++ b/login/logout_blackbox_test.go
@@ -67,9 +67,7 @@ func (s *TestLogoutSuite) checkRedirects(redirectParam string, referrerURL strin
 	logoutCtx, err := app.NewLogoutLogoutContext(goaCtx, req, goa.New("LogoutService"))
 	require.Nil(s.T(), err)
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.domain.io"},
-	}
+	r := &http.Request{Host: "api.domain.io"}
 	logoutEndpoint, err := s.configuration.GetKeycloakEndpointLogout(r)
 	require.Nil(s.T(), err)
 	validURLs, err := s.configuration.GetValidRedirectURLs(r)

--- a/login/profile_blackbox_test.go
+++ b/login/profile_blackbox_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/test"
-	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
@@ -58,9 +57,7 @@ func (s *ProfileBlackBoxTest) SetupSuite() {
 	s.profileService = keycloakUserProfileService
 
 	// Get the API endpoint - avoid repition in every test.
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.example.org"},
-	}
+	r := &http.Request{Host: "api.example.org"}
 	profileAPIURL, err := s.configuration.GetKeycloakAccountEndpoint(r)
 	s.profileAPIURL = &profileAPIURL
 
@@ -98,9 +95,7 @@ func (s *ProfileBlackBoxTest) generateAccessToken() (*string, error) {
 	scopes = append(scopes, test.TestObserverIdentity)
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.example.org"},
-	}
+	r := &http.Request{Host: "api.example.org"}
 	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(r)
 
 	res, err := client.PostForm(tokenEndpoint, url.Values{

--- a/login/service.go
+++ b/login/service.go
@@ -251,7 +251,7 @@ func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext, c
 
 	// First time access, redirect to oauth provider
 	redirect := ctx.Redirect
-	referrer := ctx.RequestData.Header.Get("Referer")
+	referrer := ctx.Request.Header.Get("Referer")
 	if redirect == nil {
 		if referrer == "" {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrBadRequest("Referer Header and redirect param are both empty. At least one should be specified."))
@@ -299,7 +299,7 @@ func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext, c
 
 func (keycloak *KeycloakOAuthProvider) autoLinkProvidersDuringLogin(ctx *app.AuthorizeLoginContext, token string, referrerURL string) error {
 	// Link all available Identity Providers
-	linkURL, err := url.Parse(rest.AbsoluteURL(ctx.RequestData, "/api/login/linksession"))
+	linkURL, err := url.Parse(rest.AbsoluteURL(ctx.RequestData.Request, "/api/login/linksession"))
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
@@ -363,7 +363,7 @@ func (keycloak *KeycloakOAuthProvider) Link(ctx *app.LinkLoginContext, brokerEnd
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal("Session state is missing in token"))
 	}
 	ss := sessionState.(*string)
-	return keycloak.linkAccountToProviders(ctx, ctx.RequestData, ctx.ResponseData, ctx.Redirect, ctx.Provider, *ss, brokerEndpoint, clientID, validRedirectURL)
+	return keycloak.linkAccountToProviders(ctx, ctx.Request, ctx.ResponseData, ctx.Redirect, ctx.Provider, *ss, brokerEndpoint, clientID, validRedirectURL)
 }
 
 // LinkSession links identity provider(s) to the user's account using session state
@@ -371,10 +371,10 @@ func (keycloak *KeycloakOAuthProvider) LinkSession(ctx *app.LinksessionLoginCont
 	if ctx.SessionState == nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest("Authorization header or session state param is required"))
 	}
-	return keycloak.linkAccountToProviders(ctx, ctx.RequestData, ctx.ResponseData, ctx.Redirect, ctx.Provider, *ctx.SessionState, brokerEndpoint, clientID, validRedirectURL)
+	return keycloak.linkAccountToProviders(ctx, ctx.Request, ctx.ResponseData, ctx.Redirect, ctx.Provider, *ctx.SessionState, brokerEndpoint, clientID, validRedirectURL)
 }
 
-func (keycloak *KeycloakOAuthProvider) linkAccountToProviders(ctx linkInterface, req *goa.RequestData, res *goa.ResponseData, redirect *string, provider *string, sessionState string, brokerEndpoint string, clientID string, validRedirectURL string) error {
+func (keycloak *KeycloakOAuthProvider) linkAccountToProviders(ctx linkInterface, req *http.Request, res *goa.ResponseData, redirect *string, provider *string, sessionState string, brokerEndpoint string, clientID string, validRedirectURL string) error {
 	referrer := req.Header.Get("Referer")
 
 	rdr := redirect
@@ -417,7 +417,7 @@ func (keycloak *KeycloakOAuthProvider) LinkCallback(ctx *app.LinkcallbackLoginCo
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrBadRequest("session state is empty"))
 			return ctx.Unauthorized(jerrors)
 		}
-		providerURL, err := getProviderURL(ctx.RequestData, *state, *sessionState, *next, nextProvider(*next), brokerEndpoint, clientID)
+		providerURL, err := getProviderURL(ctx.Request, *state, *sessionState, *next, nextProvider(*next), brokerEndpoint, clientID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 		}
@@ -452,7 +452,7 @@ func nextProvider(currentProvider string) *string {
 	return nil
 }
 
-func (keycloak *KeycloakOAuthProvider) linkProvider(ctx linkInterface, req *goa.RequestData, res *goa.ResponseData, state string, sessionState string, provider string, nextProvider *string, brokerEndpoint string, clientID string) error {
+func (keycloak *KeycloakOAuthProvider) linkProvider(ctx linkInterface, req *http.Request, res *goa.ResponseData, state string, sessionState string, provider string, nextProvider *string, brokerEndpoint string, clientID string) error {
 	providerURL, err := getProviderURL(req, state, sessionState, provider, nextProvider, brokerEndpoint, clientID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
@@ -531,7 +531,7 @@ func (keycloak *KeycloakOAuthProvider) getReferrer(ctx context.Context, state st
 	return referrer, nil
 }
 
-func getProviderURL(req *goa.RequestData, state string, sessionState string, provider string, nextProvider *string, brokerEndpoint string, clientID string) (string, error) {
+func getProviderURL(req *http.Request, state string, sessionState string, provider string, nextProvider *string, brokerEndpoint string, clientID string) (string, error) {
 	var nextParam string
 	if nextProvider != nil {
 		nextParam = "&next=" + *nextProvider

--- a/login/service.go
+++ b/login/service.go
@@ -299,7 +299,7 @@ func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext, c
 
 func (keycloak *KeycloakOAuthProvider) autoLinkProvidersDuringLogin(ctx *app.AuthorizeLoginContext, token string, referrerURL string) error {
 	// Link all available Identity Providers
-	linkURL, err := url.Parse(rest.AbsoluteURL(ctx.RequestData.Request, "/api/login/linksession"))
+	linkURL, err := url.Parse(rest.AbsoluteURL(ctx.Request, "/api/login/linksession"))
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -58,10 +58,7 @@ func (s *serviceBlackBoxTest) SetupSuite() {
 	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
-
-	req := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	req := &http.Request{Host: "api.service.domain.org"}
 	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(req)
 	if err != nil {
 		panic(err)
@@ -122,9 +119,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirect() {
 		panic("invalid test data " + err.Error()) // bug
 	}
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "demo.api.openshift.io"},
-	}
+	r := &http.Request{Host: "demo.api.openshift.io"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
@@ -136,9 +131,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirect() {
 }
 
 func (s *serviceBlackBoxTest) getValidRedirectURLs() string {
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "domain.com"},
-	}
+	r := &http.Request{Host: "domain.com"}
 	whitelist, err := s.configuration.GetValidRedirectURLs(r)
 	require.Nil(s.T(), err)
 	return whitelist
@@ -167,9 +160,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirectsToRedirectParam(
 		panic("invalid test data " + err.Error()) // bug
 	}
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.domain.io"},
-	}
+	r := &http.Request{Host: "api.domain.io"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
@@ -198,9 +189,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoRefererAndRedirectP
 		panic("invalid test data " + err.Error()) // bug
 	}
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.domain.io"},
-	}
+	r := &http.Request{Host: "api.domain.io"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
@@ -229,9 +218,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoValidRefererFails()
 		panic("invalid test data " + err.Error()) // bug
 	}
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.domain.io"},
-	}
+	r := &http.Request{Host: "api.domain.io"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
@@ -308,9 +295,7 @@ func keycloakLinkRedirect(s *serviceBlackBoxTest, provider string, redirect stri
 	linkCtx, err := app.NewLinkLoginContext(goaCtx, req, goa.New("LoginService"))
 	require.Nil(s.T(), err)
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.example.org"},
-	}
+	r := &http.Request{Host: "api.example.org"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 	clientID := s.configuration.GetKeycloakClientID()
@@ -351,9 +336,7 @@ func keycloakLinkCallbackRedirect(s *serviceBlackBoxTest, next string) {
 	linkCtx, err := app.NewLinkcallbackLoginContext(goaCtx, req, goa.New("LoginService"))
 	require.Nil(s.T(), err)
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.example.org"},
-	}
+	r := &http.Request{Host: "api.example.org"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 	clientID := s.configuration.GetKeycloakClientID()
@@ -397,9 +380,7 @@ func (s *serviceBlackBoxTest) TestInvalidState() {
 	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
 	require.Nil(s.T(), err)
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "demo.api.openshift.io"},
-	}
+	r := &http.Request{Host: "demo.api.openshift.io"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
@@ -438,9 +419,7 @@ func (s *serviceBlackBoxTest) TestInvalidOAuthAuthorizationCode() {
 	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
 	require.Nil(s.T(), err)
 
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "demo.api.openshift.io"},
-	}
+	r := &http.Request{Host: "demo.api.openshift.io"}
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 

--- a/remoteworkitem/trackerquery_repository.go
+++ b/remoteworkitem/trackerquery_repository.go
@@ -56,7 +56,7 @@ func (r *GormTrackerQueryRepository) Create(ctx context.Context, query string, s
 		return nil, InternalError{simpleError{err.Error()}}
 	}
 
-	spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(spaceID.String()))
+	spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx).Request, app.SpaceHref(spaceID.String()))
 	tq2 := app.TrackerQuery{
 		ID:        strconv.FormatUint(tq.ID, 10),
 		Query:     query,
@@ -96,7 +96,7 @@ func (r *GormTrackerQueryRepository) Load(ctx context.Context, ID string) (*app.
 		return nil, NotFoundError{"tracker query", ID}
 	}
 
-	spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(res.SpaceID.String()))
+	spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx).Request, app.SpaceHref(res.SpaceID.String()))
 	tq := app.TrackerQuery{
 		ID:        strconv.FormatUint(res.ID, 10),
 		Query:     res.Query,
@@ -178,7 +178,7 @@ func (r *GormTrackerQueryRepository) Save(ctx context.Context, tq app.TrackerQue
 		"tracker_query": newTq,
 	}, "Updated tracker query")
 
-	spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(tq.Relationships.Space.Data.ID.String()))
+	spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx).Request, app.SpaceHref(tq.Relationships.Space.Data.ID.String()))
 	t2 := app.TrackerQuery{
 		ID:        tq.ID,
 		Schedule:  tq.Schedule,
@@ -222,7 +222,7 @@ func (r *GormTrackerQueryRepository) List(ctx context.Context) ([]*app.TrackerQu
 	result := make([]*app.TrackerQuery, len(rows))
 
 	for i, tq := range rows {
-		spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(tq.SpaceID.String()))
+		spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx).Request, app.SpaceHref(tq.SpaceID.String()))
 		t := app.TrackerQuery{
 			ID:        strconv.FormatUint(tq.ID, 10),
 			Schedule:  tq.Schedule,

--- a/rest/url.go
+++ b/rest/url.go
@@ -4,15 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/fabric8-services/fabric8-wit/errors"
-
-	"github.com/goadesign/goa"
 )
 
 // AbsoluteURL prefixes a relative URL with absolute address
-func AbsoluteURL(req *goa.RequestData, relative string) string {
+func AbsoluteURL(req *http.Request, relative string) string {
 	scheme := "http"
 	if req.URL != nil && req.URL.Scheme == "https" { // isHTTPS
 		scheme = "https"

--- a/rest/url_blackbox_test.go
+++ b/rest/url_blackbox_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/fabric8-services/fabric8-wit/resource"
-	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,9 +14,7 @@ func TestAbsoluteURLOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	req := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
+	req := &http.Request{Host: "api.service.domain.org"}
 	// HTTP
 	urlStr := AbsoluteURL(req, "/testpath")
 	assert.Equal(t, "http://api.service.domain.org/testpath", urlStr)
@@ -25,10 +22,7 @@ func TestAbsoluteURLOK(t *testing.T) {
 	// HTTPS
 	r, err := http.NewRequest("", "https://api.service.domain.org", nil)
 	require.Nil(t, err)
-	req = &goa.RequestData{
-		Request: r,
-	}
-	urlStr = AbsoluteURL(req, "/testpath2")
+	urlStr = AbsoluteURL(r, "/testpath2")
 	assert.Equal(t, "https://api.service.domain.org/testpath2", urlStr)
 }
 
@@ -36,18 +30,11 @@ func TestAbsoluteURLOKWithProxyForward(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	req := &goa.RequestData{
-		Request: &http.Request{Host: "api.service.domain.org"},
-	}
-
 	// HTTPS
 	r, err := http.NewRequest("", "http://api.service.domain.org", nil)
 	require.Nil(t, err)
 	r.Header.Set("X-Forwarded-Proto", "https")
-	req = &goa.RequestData{
-		Request: r,
-	}
-	urlStr := AbsoluteURL(req, "/testpath2")
+	urlStr := AbsoluteURL(r, "/testpath2")
 	assert.Equal(t, "https://api.service.domain.org/testpath2", urlStr)
 }
 

--- a/space/authz/authz.go
+++ b/space/authz/authz.go
@@ -31,7 +31,7 @@ type AuthzService interface {
 
 // AuthzConfiguration represents a Keycloak entitlement endpoint configuration
 type AuthzConfiguration interface {
-	GetKeycloakEndpointEntitlement(*goa.RequestData) (string, error)
+	GetKeycloakEndpointEntitlement(*http.Request) (string, error)
 	IsAuthorizationEnabled() bool
 }
 
@@ -183,7 +183,7 @@ func InjectAuthzService(service AuthzService) goa.Middleware {
 			var endpoint string
 			if config != nil {
 				var err error
-				endpoint, err = config.GetKeycloakEndpointEntitlement(&goa.RequestData{Request: req})
+				endpoint, err = config.GetKeycloakEndpointEntitlement(req)
 				if err != nil {
 					log.Error(ctx, map[string]interface{}{
 						"err": err,

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	config "github.com/fabric8-services/fabric8-wit/configuration"
-	"github.com/goadesign/goa"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/application"
@@ -85,9 +84,7 @@ func (s *TestAuthzSuite) checkPermissions(authzPayload auth.AuthorizationPayload
 	testIdentity := testsupport.TestIdentity
 	svc := testsupport.ServiceAsUserWithAuthz("SpaceAuthz-Service", wittoken.NewManagerWithPrivateKey(priv), priv, testIdentity, authzPayload)
 	resource.UpdatedAt = time.Now()
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "api.example.org"},
-	}
+	r := &http.Request{Host: "api.example.org"}
 	entitlementEndpoint, err := s.configuration.GetKeycloakEndpointEntitlement(r)
 	require.Nil(s.T(), err)
 	ok, err := authzService.Authorize(svc.Context, entitlementEndpoint, spaceID)


### PR DESCRIPTION
Replace in most function calls.
This will make migration to gin-gonic easier.

Fixes #1606

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
