### PR TITLE
Top-level assignee = null produce error in WIQL

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -916,7 +916,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 		compareWithGolden(t, filepath.Join(s.testDir, "show", "non_existing_key.error.golden.json"), jerrs)
 		compareWithGolden(t, filepath.Join(s.testDir, "show", "non_existing_key.headers.golden.json"), res.Header())
 	})
-	s.T().Run("assignee=null after", func(t *testing.T) {
+	s.T().Run("assignee=null before WI creation", func(t *testing.T) {
 		filter := fmt.Sprintf(`
 					{"$AND": [
 						{"assignee":null}
@@ -934,7 +934,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 			workitem.SystemIteration: sprint2.ID.String(),
 		}, s.testIdentity.ID)
 	require.Nil(s.T(), err)
-	s.T().Run("assignee=null after", func(t *testing.T) {
+	s.T().Run("assignee=null after WI creation", func(t *testing.T) {
 		filter := fmt.Sprintf(`
 					{"$AND": [
 						{"assignee":null}
@@ -944,6 +944,15 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 		require.NotEmpty(s.T(), result.Data)
 		assert.Len(s.T(), result.Data, 1)
 	})
+	s.T().Run("assignee=null after WI creation (top-level)", func(t *testing.T) {
+		filter := fmt.Sprintf(`
+					{"assignee":null}`,
+		)
+		_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+		require.NotEmpty(s.T(), result.Data)
+		assert.Len(s.T(), result.Data, 1)
+	})
+
 	s.T().Run("assignee=null with negate", func(t *testing.T) {
 		filter := fmt.Sprintf(`
 					{"$AND": [
@@ -960,5 +969,4 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 		compareWithGolden(t, filepath.Join(s.testDir, "show", "assignee_null_negate.error.golden.json"), jerrs)
 		compareWithGolden(t, filepath.Join(s.testDir, "show", "assignee_null_negate.headers.golden.json"), res.Header())
 	})
-
 }

--- a/search/query_language_whitebox_test.go
+++ b/search/query_language_whitebox_test.go
@@ -341,6 +341,20 @@ func TestGenerateExpression(t *testing.T) {
 		expectEqualExpr(t, expectedExpr, actualExpr)
 	})
 
+	t.Run("NULL value at top-level", func(t *testing.T) {
+		t.Parallel()
+		// given
+		q := Query{
+			Name: "assignee", Value: nil,
+		}
+		// when
+		actualExpr, _ := q.generateExpression()
+		// then
+		expectedExpr := c.IsNull("system.assignees")
+
+		expectEqualExpr(t, expectedExpr, actualExpr)
+	})
+
 	t.Run("NULL value with Negate", func(t *testing.T) {
 		t.Parallel()
 		// given

--- a/search/query_language_whitebox_test.go
+++ b/search/query_language_whitebox_test.go
@@ -355,6 +355,20 @@ func TestGenerateExpression(t *testing.T) {
 		expectEqualExpr(t, expectedExpr, actualExpr)
 	})
 
+	t.Run("NULL value at top-level with Negate", func(t *testing.T) {
+		t.Parallel()
+		// given
+		q := Query{
+			Name: "assignee", Value: nil, Negate: true,
+		}
+		// when
+		actualExpr, err := q.generateExpression()
+		// then
+		require.NotNil(t, err)
+		require.Nil(t, actualExpr)
+		assert.Contains(t, err.Error(), "negate for null not supported")
+	})
+
 	t.Run("NULL value with Negate", func(t *testing.T) {
 		t.Parallel()
 		// given

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -370,11 +370,18 @@ func (q Query) generateExpression() (criteria.Expression, error) {
 			return nil, errors.NewBadParameterError("key not found", q.Name)
 		}
 		left := criteria.Field(key)
-		right := q.determineLiteralType(key, *q.Value)
-		if q.Negate {
-			myexpr = append(myexpr, criteria.Not(left, right))
+		if q.Value != nil {
+			right := q.determineLiteralType(key, *q.Value)
+			if q.Negate {
+				myexpr = append(myexpr, criteria.Not(left, right))
+			} else {
+				myexpr = append(myexpr, criteria.Equals(left, right))
+			}
 		} else {
-			myexpr = append(myexpr, criteria.Equals(left, right))
+			if q.Negate {
+				return nil, errors.NewBadParameterError("negate for null not supported", q.Name)
+			}
+			myexpr = append(myexpr, criteria.IsNull(key))
 		}
 	}
 	for _, child := range q.Children {


### PR DESCRIPTION
Fixes #1609
Filter query with assignee = null in the top-level produce 500 error

- [x] Write unit test
- [x] Write integration test at controller level