### PR TITLE
Simplify accessor to signing keys (#1615)

### DIFF
--- a/auth/policy_blackbox_test.go
+++ b/auth/policy_blackbox_test.go
@@ -28,7 +28,7 @@ type TestPolicySuite struct {
 }
 
 func (s *TestPolicySuite) SetupSuite() {
-	s.policyManager = auth.NewKeycloakPolicyManager(configuration)
+	s.policyManager = auth.NewKeycloakPolicyManager(config)
 }
 
 func (s *TestPolicySuite) TearDownSuite() {
@@ -52,7 +52,7 @@ func (s *TestPolicySuite) TestGetPolicyOK() {
 
 func (s *TestPolicySuite) TestUpdatePolicyOK() {
 	policy, policyID := createPermissionWithPolicy(s)
-	secondTestUserID := getUserID(s.T(), configuration.GetKeycloakTestUser2Name(), configuration.GetKeycloakTestUser2Secret())
+	secondTestUserID := getUserID(s.T(), config.GetKeycloakTestUser2Name(), config.GetKeycloakTestUser2Secret())
 	policy.RemoveUserFromPolicy(secondTestUserID)
 	policy.ID = &policyID
 	r := &http.Request{Host: "domain.io"}

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -11,7 +11,6 @@ import (
 
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-wit/configuration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/satori/go.uuid"
@@ -195,11 +194,7 @@ func TestGetTokenPrivateKeyFromConfigFile(t *testing.T) {
 
 	resetConfiguration(defaultConfigFilePath)
 	// env variable NOT set, so we check with config.yaml's value
-
-	viperValue := config.GetTokenPrivateKey()
-	assert.NotNil(t, viperValue)
-
-	parsedKey, err := jwt.ParseRSAPrivateKeyFromPEM(viperValue)
+	parsedKey, err := config.GetTokenPrivateKey()
 	require.Nil(t, err)
 	assert.NotNil(t, parsedKey)
 }
@@ -219,10 +214,7 @@ func TestGetTokenPublicKeyFromConfigFile(t *testing.T) {
 
 	// env variable is now unset for sure, this will lead to the test looking up for
 	// value in config.yaml
-	viperValue := config.GetTokenPublicKey()
-	assert.NotNil(t, viperValue)
-
-	parsedKey, err := jwt.ParseRSAPublicKeyFromPEM(viperValue)
+	parsedKey, err := config.GetTokenPublicKey()
 	require.Nil(t, err)
 	assert.NotNil(t, parsedKey)
 }

--- a/controller/area_blackbox_test.go
+++ b/controller/area_blackbox_test.go
@@ -54,14 +54,14 @@ func (rest *TestAreaREST) TearDownTest() {
 }
 
 func (rest *TestAreaREST) SecuredController() (*goa.Service, *AreaController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
-	//priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	pub, _ := wittoken.RSAPublicKey()
+	//priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsUser("Area-Service", wittoken.NewManager(pub), testsupport.TestIdentity)
 	return svc, NewAreaController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestAreaREST) SecuredControllerWithIdentity(idn *account.Identity) (*goa.Service, *AreaController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Area-Service", wittoken.NewManagerWithPrivateKey(priv), *idn)
 	return svc, NewAreaController(svc, rest.db, rest.Configuration)

--- a/controller/auth_utility_test.go
+++ b/controller/auth_utility_test.go
@@ -86,7 +86,7 @@ func UnauthorizeCreateUpdateDeleteTest(t *testing.T, getDataFunc func(t *testing
 	resource.Require(t, resource.Database)
 
 	// This will be modified after merge PR for "Viper Environment configurations"
-	publickey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(wittoken.RSAPublicKey))
+	publickey, err := wittoken.RSAPublicKey()
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}

--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -56,7 +56,7 @@ func (s *TestCodebaseREST) UnsecuredController() (*goa.Service, *CodebaseControl
 }
 
 func (s *TestCodebaseREST) SecuredControllers(identity account.Identity) (*goa.Service, *CodebaseController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
+	pub, _ := wittoken.RSAPublicKey()
 
 	svc := testsupport.ServiceAsUser("Codebase-Service", wittoken.NewManager(pub), identity)
 	return svc, controller.NewCodebaseController(svc, s.db, s.Configuration)

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -136,7 +136,7 @@ func (rest *TestCollaboratorsREST) TearDownTest() {
 }
 
 func (rest *TestCollaboratorsREST) SecuredController() (*goa.Service, *CollaboratorsController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), rest.testIdentity1, &DummySpaceAuthzService{rest})
 	return svc, NewCollaboratorsController(svc, rest.db, rest.authzConfig, &DummyPolicyManager{rest: rest})
 }
@@ -422,7 +422,7 @@ func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsUnauthorizedIfNoTo
 
 func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsUnauthorizedIfCurrentUserIsNotCollaborator() {
 	// given
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), rest.testIdentity2, &DummySpaceAuthzService{rest})
 	ctrl := NewCollaboratorsController(svc, rest.db, rest.authzConfig, &DummyPolicyManager{rest: rest})
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
@@ -434,7 +434,7 @@ func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsUnauthorizedIfCurrentU
 
 func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsUnauthorizedIfCurrentUserIsNotCollaborator() {
 	// given
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), rest.testIdentity2, &DummySpaceAuthzService{rest})
 	ctrl := NewCollaboratorsController(svc, rest.db, rest.authzConfig, &DummyPolicyManager{rest: rest})
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
@@ -599,7 +599,7 @@ func (s *TestSpaceAuthzService) Configuration() authz.AuthzConfiguration {
 }
 
 func CreateSecuredSpace(t *testing.T, db application.DB, config SpaceConfiguration, owner account.Identity) app.Space {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), owner, &TestSpaceAuthzService{owner})
 	spaceCtrl := NewSpaceController(svc, db, config, &DummyResourceManager{})
 	require.NotNil(t, spaceCtrl)

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -85,7 +85,7 @@ func (s *CommentsSuite) unsecuredController() (*goa.Service, *CommentsController
 }
 
 func (s *CommentsSuite) securedControllers(identity account.Identity) (*goa.Service, *WorkitemController, *WorkitemsController, *WorkItemCommentsController, *CommentsController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsUser("Comment-Service", wittoken.NewManagerWithPrivateKey(priv), identity)
 	workitemCtrl := NewWorkitemController(svc, s.db, s.Configuration)
 	workitemsCtrl := NewWorkitemsController(svc, s.db, s.Configuration)
@@ -382,7 +382,7 @@ func (s *CommentsSuite) TestNonCollaboraterCanNotDelete() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), *testIdentity, &TestSpaceAuthzService{*testIdentity})
 	workitemsCtrl := NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 
@@ -406,7 +406,7 @@ func (s *CommentsSuite) TestCollaboratorCanDelete() {
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
 	svc, _, workitemsCtrl, _, _ := s.securedControllers(*testIdentity)
-	// priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	// priv, _ := wittoken.RSAPrivateKey()
 	// svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), testIdentity, &TestSpaceAuthzService{testIdentity})
 	// ctrl := NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 
@@ -437,7 +437,7 @@ func (s *CommentsSuite) TestOtherCollaboratorCanDelete() {
 
 	// Add 2 identities as Collaborators
 	space := CreateSecuredSpace(s.T(), gormapplication.NewGormDB(s.DB), s.Configuration, *spaceOwner)
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svcWithSpaceOwner := testsupport.ServiceAsSpaceUser("Comments-Service", wittoken.NewManagerWithPrivateKey(priv), *spaceOwner, &TestSpaceAuthzService{*spaceOwner})
 	collaboratorRESTInstance := &TestCollaboratorsREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")}
 	collaboratorRESTInstance.policy = &auth.KeycloakPolicy{
@@ -480,7 +480,7 @@ func (s *CommentsSuite) TestNonCollaboraterCanNotUpdate() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI 2"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), *testIdentity, &TestSpaceAuthzService{*testIdentity})
 	workitemsCtrl := NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 
@@ -504,7 +504,7 @@ func (s *CommentsSuite) TestCollaboratorCanUpdate() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
-	// priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	// priv, _ := wittoken.RSAPrivateKey()
 	// svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), testIdentity, &TestSpaceAuthzService{testIdentity})
 	// ctrl := NewWorkitemController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	svc, _, workitemsCtrl, _, _ := s.securedControllers(*testIdentity)
@@ -544,7 +544,7 @@ func (s *CommentsSuite) TestOtherCollaboratorCanUpdate() {
 
 	// Add 2 Collaborators in space
 	space := CreateSecuredSpace(s.T(), gormapplication.NewGormDB(s.DB), s.Configuration, *spaceOwner)
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svcWithSpaceOwner := testsupport.ServiceAsSpaceUser("Comments-Service", wittoken.NewManagerWithPrivateKey(priv), *spaceOwner, &TestSpaceAuthzService{*spaceOwner})
 
 	collaboratorRESTInstance := &TestCollaboratorsREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")}

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -55,14 +55,14 @@ func (rest *TestIterationREST) TearDownTest() {
 }
 
 func (rest *TestIterationREST) SecuredController() (*goa.Service, *IterationController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Iteration-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, NewIterationController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestIterationREST) SecuredControllerWithIdentity(idn *account.Identity) (*goa.Service, *IterationController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Iteration-Service", wittoken.NewManagerWithPrivateKey(priv), *idn)
 	return svc, NewIterationController(svc, rest.db, rest.Configuration)

--- a/controller/login_recent_spaces_test.go
+++ b/controller/login_recent_spaces_test.go
@@ -3,15 +3,14 @@ package controller
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/fabric8-services/fabric8-wit/configuration"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/application"
-	"github.com/fabric8-services/fabric8-wit/configuration"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/login"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -28,7 +27,7 @@ import (
 
 type TestRecentSpacesREST struct {
 	gormtestsupport.RemoteTestSuite
-	configuration      *configuration.ConfigurationData
+	config             *configuration.ConfigurationData
 	tokenManager       token.Manager
 	identityRepository *MockIdentityRepository
 	userRepository     *MockUserRepository
@@ -42,7 +41,7 @@ func TestRunRecentSpacesREST(t *testing.T) {
 }
 
 func (rest *TestRecentSpacesREST) newTestKeycloakOAuthProvider(db application.DB) *login.KeycloakOAuthProvider {
-	publicKey, err := token.ParsePublicKey([]byte(rest.configuration.GetTokenPublicKey()))
+	publicKey, err := rest.config.GetTokenPublicKey()
 	require.Nil(rest.T(), err)
 	tokenManager := token.NewManager(publicKey)
 
@@ -50,12 +49,10 @@ func (rest *TestRecentSpacesREST) newTestKeycloakOAuthProvider(db application.DB
 }
 
 func (rest *TestRecentSpacesREST) SetupTest() {
-	c, err := configuration.GetConfigurationData()
-	if err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
-	}
-	rest.configuration = c
-	publicKey, err := token.ParsePublicKey([]byte(rest.configuration.GetTokenPublicKey()))
+	var err error
+	rest.config, err = configuration.GetConfigurationData()
+	require.Nil(rest.T(), err, "failed to setup configuration")
+	publicKey, err := rest.config.GetTokenPublicKey()
 	require.Nil(rest.T(), err)
 	rest.tokenManager = token.NewManager(publicKey)
 
@@ -82,7 +79,7 @@ func (rest *TestRecentSpacesREST) SecuredController() (*goa.Service, *LoginContr
 		Controller:         svc.NewController("login"),
 		auth:               rest.loginService,
 		tokenManager:       rest.tokenManager,
-		configuration:      rest.configuration,
+		configuration:      rest.config,
 		identityRepository: rest.identityRepository,
 	}
 	return svc, loginController
@@ -95,10 +92,10 @@ func (rest *TestRecentSpacesREST) TestResourceRequestPayload() {
 
 	// Generate an access token for a test identity
 	r := &http.Request{Host: "api.example.org"}
-	tokenEndpoint, err := rest.configuration.GetKeycloakEndpointToken(r)
+	tokenEndpoint, err := rest.config.GetKeycloakEndpointToken(r)
 	require.Nil(t, err)
 
-	accessToken, err := GenerateUserToken(service.Context, tokenEndpoint, rest.configuration, rest.configuration.GetKeycloakTestUserName(), rest.configuration.GetKeycloakTestUserSecret())
+	accessToken, err := GenerateUserToken(service.Context, tokenEndpoint, rest.config, rest.config.GetKeycloakTestUserName(), rest.config.GetKeycloakTestUserSecret())
 	require.Nil(t, err)
 
 	accessTokenString := accessToken.Token.AccessToken

--- a/controller/login_test.go
+++ b/controller/login_test.go
@@ -58,14 +58,14 @@ func (rest *TestLoginREST) TearDownTest() {
 }
 
 func (rest *TestLoginREST) UnSecuredController() (*goa.Service, *LoginController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	identityRepository := account.NewIdentityRepository(rest.DB)
 	svc := testsupport.ServiceAsUser("Login-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, &LoginController{Controller: svc.NewController("login"), auth: TestLoginService{}, configuration: rest.Configuration, identityRepository: identityRepository}
 }
 
 func (rest *TestLoginREST) SecuredController() (*goa.Service, *LoginController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	identityRepository := account.NewIdentityRepository(rest.DB)
 
@@ -74,7 +74,7 @@ func (rest *TestLoginREST) SecuredController() (*goa.Service, *LoginController) 
 }
 
 func (rest *TestLoginREST) newTestKeycloakOAuthProvider(db application.DB) *login.KeycloakOAuthProvider {
-	publicKey, err := token.ParsePublicKey([]byte(rest.configuration.GetTokenPublicKey()))
+	publicKey, err := rest.configuration.GetTokenPublicKey()
 	require.Nil(rest.T(), err)
 	tokenManager := token.NewManager(publicKey)
 	return login.NewKeycloakOAuthProvider(db.Identities(), db.Users(), tokenManager, db)

--- a/controller/logout_test.go
+++ b/controller/logout_test.go
@@ -36,7 +36,7 @@ func (rest *TestLogoutREST) TearDownTest() {
 }
 
 func (rest *TestLogoutREST) UnSecuredController() (*goa.Service, *LogoutController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Logout-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, &LogoutController{Controller: svc.NewController("logout"), logoutService: &login.KeycloakLogoutService{}, configuration: rest.configuration}

--- a/controller/named_work_items_blackbox_test.go
+++ b/controller/named_work_items_blackbox_test.go
@@ -43,7 +43,7 @@ func (s *TestNamedWorkItemsSuite) SetupTest() {
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "TestUpdateWorkitemForSpaceCollaborator-"+uuid.NewV4().String(), "TestWI")
 	require.Nil(s.T(), err)
 	s.testIdentity = *testIdentity
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	s.svc = testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), s.testIdentity, &TestSpaceAuthzService{s.testIdentity})
 	s.workitemsCtrl = NewWorkitemsController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	s.namedWorkItemsCtrl = NewNamedWorkItemsController(s.svc, gormapplication.NewGormDB(s.DB))

--- a/controller/namedspaces_test.go
+++ b/controller/namedspaces_test.go
@@ -38,7 +38,7 @@ func (rest *TestNamedSpaceREST) TearDownTest() {
 }
 
 func (rest *TestNamedSpaceREST) SecuredNamedSpaceController(identity account.Identity) (*goa.Service, *NamedspacesController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("NamedSpace-Service", wittoken.NewManagerWithPrivateKey(priv), identity)
 	return svc, NewNamedspacesController(svc, rest.db)
@@ -50,7 +50,7 @@ func (rest *TestNamedSpaceREST) UnSecuredNamedSpaceController() (*goa.Service, *
 }
 
 func (rest *TestNamedSpaceREST) SecuredSpaceController() (*goa.Service, *SpaceController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Space-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, NewSpaceController(svc, rest.db, rest.Configuration, &DummyResourceManager{})

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -79,7 +79,7 @@ func (s *searchBlackBoxTest) SetupTest() {
 	spaceBlackBoxTestConfiguration, err := config.GetConfigurationData()
 	require.Nil(s.T(), err)
 	s.spaceBlackBoxTestConfiguration = spaceBlackBoxTestConfiguration
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	s.svc = testsupport.ServiceAsUser("WorkItemComment-Service", wittoken.NewManagerWithPrivateKey(priv), s.testIdentity)
 	s.controller = NewSearchController(s.svc, gormapplication.NewGormDB(s.DB), spaceBlackBoxTestConfiguration)
 }
@@ -289,7 +289,7 @@ func (s *searchBlackBoxTest) getWICreatePayload() *app.CreateWorkitemsPayload {
 }
 
 func getServiceAsUser(testIdentity account.Identity) *goa.Service {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	service := testsupport.ServiceAsUser("TestSearch-Service", wittoken.NewManagerWithPrivateKey(priv), testIdentity)
 	return service
 }
@@ -550,7 +550,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 	spaceInstance := CreateSecuredSpace(s.T(), gormapplication.NewGormDB(s.DB), s.Configuration, *spaceOwner)
 	spaceIDStr := spaceInstance.ID.String()
 
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svcWithSpaceOwner := testsupport.ServiceAsSpaceUser("Search-Service", wittoken.NewManagerWithPrivateKey(priv), *spaceOwner, &TestSpaceAuthzService{*spaceOwner})
 	collaboratorRESTInstance := &TestCollaboratorsREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")}
 	collaboratorRESTInstance.policy = &auth.KeycloakPolicy{

--- a/controller/search_spaces_blackbox_test.go
+++ b/controller/search_spaces_blackbox_test.go
@@ -63,7 +63,7 @@ func (rest *TestSearchSpacesREST) TearDownTest() {
 }
 
 func (rest *TestSearchSpacesREST) SecuredController() (*goa.Service, *SearchController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Search-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, NewSearchController(svc, rest.db, rest.Configuration)

--- a/controller/space_areas_blackbox_test.go
+++ b/controller/space_areas_blackbox_test.go
@@ -53,19 +53,19 @@ func (rest *TestSpaceAreaREST) TearDownTest() {
 }
 
 func (rest *TestSpaceAreaREST) SecuredController() (*goa.Service, *SpaceAreasController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
+	pub, _ := wittoken.RSAPublicKey()
 	svc := testsupport.ServiceAsUser("Space-Area-Service", wittoken.NewManager(pub), testsupport.TestIdentity)
 	return svc, NewSpaceAreasController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestSpaceAreaREST) SecuredAreasController() (*goa.Service, *AreaController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
+	pub, _ := wittoken.RSAPublicKey()
 	svc := testsupport.ServiceAsUser("Area-Service", wittoken.NewManager(pub), testsupport.TestIdentity)
 	return svc, NewAreaController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestSpaceAreaREST) SecuredAreasControllerWithIdentity(idn *account.Identity) (*goa.Service, *AreaController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsUser("Area-Service-With-Identity", wittoken.NewManagerWithPrivateKey(priv), *idn)
 	return svc, NewAreaController(svc, rest.db, rest.Configuration)
 }

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -72,7 +72,7 @@ func (rest *TestSpaceREST) TearDownTest() {
 }
 
 func (rest *TestSpaceREST) SecuredController(identity account.Identity) (*goa.Service, *SpaceController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Space-Service", wittoken.NewManagerWithPrivateKey(priv), identity)
 	return svc, NewSpaceController(svc, rest.db, spaceConfiguration, &DummyResourceManager{})
@@ -134,13 +134,13 @@ func (rest *TestSpaceREST) TestSuccessCreateSpace() {
 }
 
 func (rest *TestSpaceREST) SecuredSpaceAreaController(identity account.Identity) (*goa.Service, *SpaceAreasController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
+	pub, _ := wittoken.RSAPublicKey()
 	svc := testsupport.ServiceAsUser("Area-Service", wittoken.NewManager(pub), identity)
 	return svc, NewSpaceAreasController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestSpaceREST) SecuredSpaceIterationController(identity account.Identity) (*goa.Service, *SpaceIterationsController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
+	pub, _ := wittoken.RSAPublicKey()
 	svc := testsupport.ServiceAsUser("Iteration-Service", wittoken.NewManager(pub), identity)
 	return svc, NewSpaceIterationsController(svc, rest.db, rest.Configuration)
 }

--- a/controller/space_codebases_test.go
+++ b/controller/space_codebases_test.go
@@ -52,8 +52,8 @@ func (rest *TestSpaceCodebaseREST) TearDownTest() {
 }
 
 func (rest *TestSpaceCodebaseREST) SecuredController() (*goa.Service, *SpaceCodebasesController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
-	//priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	pub, _ := wittoken.RSAPublicKey()
+	//priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("SpaceCodebase-Service", wittoken.NewManager(pub), testsupport.TestIdentity)
 	return svc, NewSpaceCodebasesController(svc, rest.db)

--- a/controller/space_iterations_test.go
+++ b/controller/space_iterations_test.go
@@ -72,14 +72,14 @@ func (rest *TestSpaceIterationREST) TearDownTest() {
 }
 
 func (rest *TestSpaceIterationREST) SecuredController() (*goa.Service, *SpaceIterationsController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Iteration-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, NewSpaceIterationsController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestSpaceIterationREST) SecuredControllerWithIdentity(idn *account.Identity) (*goa.Service, *SpaceIterationsController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Iteration-Service", wittoken.NewManagerWithPrivateKey(priv), *idn)
 	return svc, NewSpaceIterationsController(svc, rest.db, rest.Configuration)

--- a/controller/status_test.go
+++ b/controller/status_test.go
@@ -35,7 +35,7 @@ func (rest *TestStatusREST) TearDownTest() {
 }
 
 func (rest *TestStatusREST) SecuredController() (*goa.Service, *StatusController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Status-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, NewStatusController(svc, rest.DB)

--- a/controller/tracker_blackbox_test.go
+++ b/controller/tracker_blackbox_test.go
@@ -48,7 +48,7 @@ func (rest *TestTrackerREST) TearDownTest() {
 }
 
 func (rest *TestTrackerREST) SecuredController() (*goa.Service, *TrackerController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Tracker-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, NewTrackerController(svc, rest.db, rest.RwiScheduler, rest.Configuration)
@@ -71,7 +71,7 @@ func (rest *TestTrackerREST) TestUnauthorizeTrackerCUD() {
 }
 
 func getTrackerTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(wittoken.RSAPrivateKey))
+	privatekey, err := wittoken.RSAPrivateKey()
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}

--- a/controller/trackerquery_blackbox_test.go
+++ b/controller/trackerquery_blackbox_test.go
@@ -51,7 +51,7 @@ func (rest *TestTrackerQueryREST) TearDownTest() {
 }
 
 func (rest *TestTrackerQueryREST) SecuredController() (*goa.Service, *TrackerController, *TrackerqueryController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 
 	svc := testsupport.ServiceAsUser("Tracker-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	return svc, NewTrackerController(svc, rest.db, rest.RwiScheduler, rest.Configuration), NewTrackerqueryController(svc, rest.db, rest.RwiScheduler, rest.Configuration)
@@ -63,7 +63,7 @@ func (rest *TestTrackerQueryREST) UnSecuredController() (*goa.Service, *TrackerC
 }
 
 func getTrackerQueryTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(wittoken.RSAPrivateKey))
+	privatekey, err := wittoken.RSAPrivateKey()
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}

--- a/controller/user_test.go
+++ b/controller/user_test.go
@@ -57,7 +57,7 @@ func (rest *TestUserREST) SetupSuite() {
 }
 
 func (rest *TestUserREST) newUserController(identity *account.Identity, user *account.User) *UserController {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	return NewUserController(goa.New("wit-test"), newGormTestBase(identity, user), wittoken.NewManagerWithPrivateKey(priv), &rest.config)
 }
 

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -66,7 +66,7 @@ func (s *TestUsersSuite) TearDownTest() {
 }
 
 func (s *TestUsersSuite) SecuredController(identity account.Identity) (*goa.Service, *UsersController) {
-	pub, _ := wittoken.ParsePublicKey([]byte(wittoken.RSAPublicKey))
+	pub, _ := wittoken.RSAPublicKey()
 	svc := testsupport.ServiceAsUser("Users-Service", wittoken.NewManager(pub), identity)
 	return svc, NewUsersController(svc, s.db, s.Configuration, s.profileService)
 }

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -82,7 +82,7 @@ func (s *workItemChildSuite) SetupTest() {
 	require.Nil(s.T(), err)
 	s.testIdentity = *testIdentity
 
-	priv, err := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, err := wittoken.RSAPrivateKey()
 	require.Nil(s.T(), err)
 
 	svc := testsupport.ServiceAsUser("WorkItemLink-Service", wittoken.NewManagerWithPrivateKey(priv), s.testIdentity)
@@ -839,7 +839,7 @@ func (s *searchParentExistsSuite) SetupSuite() {
 func (s *searchParentExistsSuite) SetupTest() {
 	s.workItemChildSuite.SetupTest()
 
-	priv, err := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, err := wittoken.RSAPrivateKey()
 	require.Nil(s.T(), err)
 
 	s.svc = testsupport.ServiceAsUser("Search-Service", wittoken.NewManagerWithPrivateKey(priv), s.testIdentity)

--- a/controller/work_item_comments_blackbox_test.go
+++ b/controller/work_item_comments_blackbox_test.go
@@ -63,7 +63,7 @@ func (rest *TestCommentREST) TearDownTest() {
 }
 
 func (rest *TestCommentREST) SecuredController() (*goa.Service, *WorkItemCommentsController) {
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsUser("WorkItemComment-Service", wittoken.NewManagerWithPrivateKey(priv), rest.testIdentity)
 	return svc, NewNotifyingWorkItemCommentsController(svc, rest.db, &rest.notification, rest.Configuration)
 }

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -97,7 +97,7 @@ func (s *workItemLinkSuite) SetupSuite() {
 // It will also make sure that some resources that we rely on do exists.
 func (s *workItemLinkSuite) SetupTest() {
 	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-	priv, err := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, err := wittoken.RSAPrivateKey()
 	require.Nil(s.T(), err)
 	svc := goa.New("TestWorkItemLinkType-Service")
 	require.NotNil(s.T(), svc)
@@ -635,7 +635,7 @@ func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksNotFound() {
 
 func (s *workItemLinkSuite) getWorkItemLinkTestDataFunc() func(t *testing.T) []testSecureAPI {
 	return func(t *testing.T) []testSecureAPI {
-		privatekey, err := jwt.ParseRSAPrivateKeyFromPEM(s.Configuration.GetTokenPrivateKey())
+		privatekey, err := s.Configuration.GetTokenPrivateKey()
 		require.Nil(t, err, "Could not parse private key")
 		differentPrivatekey, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSADifferentPrivateKeyTest)))
 		require.Nil(t, err, "Could not parse private key")
@@ -791,7 +791,7 @@ func (s *workItemLinkSuite) TestUnauthorizeWorkItemLinkCUD() {
 // The work item ID will be used to construct /api/workitems/:id/relationships/links endpoints
 func (s *workItemLinkSuite) getWorkItemRelationshipLinksTestData(spaceID, wiID uuid.UUID) func(t *testing.T) []testSecureAPI {
 	return func(t *testing.T) []testSecureAPI {
-		privatekey, err := jwt.ParseRSAPrivateKeyFromPEM(s.Configuration.GetTokenPrivateKey())
+		privatekey, err := s.Configuration.GetTokenPrivateKey()
 		if err != nil {
 			t.Fatal("Could not parse Key ", err)
 		}

--- a/controller/work_item_link_category_blackbox_test.go
+++ b/controller/work_item_link_category_blackbox_test.go
@@ -66,7 +66,7 @@ func (s *workItemLinkCategorySuite) SetupSuite() {
 	s.db, err = gorm.Open("postgres", wilCatConfiguration.GetPostgresConfigString())
 	require.Nil(s.T(), err)
 	s.appDB = gormapplication.NewGormDB(s.db)
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	s.svc = testsupport.ServiceAsUser("workItemLinkSpace-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	require.NotNil(s.T(), s.svc)
 	s.linkCatCtrl = NewWorkItemLinkCategoryController(s.svc, gormapplication.NewGormDB(s.db))
@@ -467,7 +467,7 @@ func (s *workItemLinkCategorySuite) TestListWorkItemLinkCategoryOK() {
 }
 
 func getWorkItemLinkCategoryTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((wilCatConfiguration.GetTokenPrivateKey()))
+	privatekey, err := wilCatConfiguration.GetTokenPrivateKey()
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -65,7 +65,7 @@ func (s *workItemLinkTypeSuite) SetupSuite() {
 	require.NotNil(s.T(), s.linkCatCtrl)
 	s.typeCtrl = NewWorkitemtypeController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	require.NotNil(s.T(), s.typeCtrl)
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	s.svc = testsupport.ServiceAsUser("workItemLinkSpace-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	s.spaceCtrl = NewSpaceController(svc, gormapplication.NewGormDB(s.DB), s.Configuration, &DummyResourceManager{})
 	require.NotNil(s.T(), s.spaceCtrl)
@@ -115,7 +115,7 @@ func (s *workItemLinkTypeSuite) SetupTest() {
 	require.NotNil(s.T(), s.linkCatCtrl)
 	s.typeCtrl = NewWorkitemtypeController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	require.NotNil(s.T(), s.typeCtrl)
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	s.svc = testsupport.ServiceAsUser("workItemLinkSpace-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	s.spaceCtrl = NewSpaceController(svc, gormapplication.NewGormDB(s.DB), s.Configuration, &DummyResourceManager{})
 	require.NotNil(s.T(), s.spaceCtrl)
@@ -526,7 +526,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeNotModifiedUsingIfNoneMa
 func (s *workItemLinkTypeSuite) getWorkItemLinkTypeTestDataFunc() func(t *testing.T) []testSecureAPI {
 	return func(t *testing.T) []testSecureAPI {
 
-		privatekey, err := jwt.ParseRSAPrivateKeyFromPEM(s.Configuration.GetTokenPrivateKey())
+		privatekey, err := s.Configuration.GetTokenPrivateKey()
 		if err != nil {
 			t.Fatal("Could not parse Key ", err)
 		}

--- a/controller/work_item_type_group_blackbox_test.go
+++ b/controller/work_item_type_group_blackbox_test.go
@@ -47,7 +47,7 @@ func (s *workItemTypeGroupSuite) SetupSuite() {
 // The SetupTest method will be run before every test in the suite.
 func (s *workItemTypeGroupSuite) SetupTest() {
 	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	s.svc = testsupport.ServiceAsUser("WITG-Service", wittoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
 	s.typeGroupCtrl = NewWorkItemTypeGroupController(s.svc, gormapplication.NewGormDB(s.DB))
 }

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -73,7 +73,7 @@ func (s *WorkItemSuite) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 	s.ctx = migration.NewMigrationContext(context.Background())
 	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
-	s.priKey, _ = wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	s.priKey, _ = wittoken.RSAPrivateKey()
 	s.repoWit = workitem.NewWorkItemRepository(s.DB)
 }
 
@@ -521,7 +521,7 @@ func (s *WorkItemSuite) TestListByFields() {
 }
 func getWorkItemTestDataFunc(config configuration.ConfigurationData) func(t *testing.T) []testSecureAPI {
 	return func(t *testing.T) []testSecureAPI {
-		privatekey, err := jwt.ParseRSAPrivateKeyFromPEM(config.GetTokenPrivateKey())
+		privatekey, err := config.GetTokenPrivateKey()
 		if err != nil {
 			t.Fatal("Could not parse Key ", err)
 		}
@@ -896,7 +896,7 @@ func (s *WorkItem2Suite) SetupTest() {
 	// create identity
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "WorkItem2Suite setup user", "test provider")
 	require.Nil(s.T(), err)
-	s.priKey, _ = wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	s.priKey, _ = wittoken.RSAPrivateKey()
 	s.svc = testsupport.ServiceAsUser("TestUpdateWI2-Service", wittoken.NewManagerWithPrivateKey(s.priKey), *testIdentity)
 	s.workitemCtrl = NewNotifyingWorkitemController(s.svc, gormapplication.NewGormDB(s.DB), &s.notification, s.Configuration)
 	s.workitemsCtrl = NewNotifyingWorkitemsController(s.svc, gormapplication.NewGormDB(s.DB), &s.notification, s.Configuration)
@@ -2765,7 +2765,7 @@ func (s *WorkItemSuite) TestUpdateWorkitemForSpaceCollaborator() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", wittoken.NewManagerWithPrivateKey(priv), *testIdentity, &TestSpaceAuthzService{*testIdentity})
 	workitemCtrl := NewWorkitemController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	workitemsCtrl := NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -72,7 +72,7 @@ func (s *workItemTypeSuite) SetupSuite() {
 // The SetupTest method will be run before every test in the suite.
 func (s *workItemTypeSuite) SetupTest() {
 	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	idn := &account.Identity{
 		ID:           uuid.Nil,
 		Username:     "TestDeveloper",
@@ -264,7 +264,7 @@ func (s *workItemTypeSuite) TestCreateByNotOwnerForbidden() {
 	defer resetFn()
 
 	s.T().Run("forbidden", func(t *testing.T) {
-		priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+		priv, _ := wittoken.RSAPrivateKey()
 		idn := &account.Identity{
 			ID:           uuid.NewV4(),
 			Username:     "TestDeveloper",
@@ -590,7 +590,7 @@ func (s *workItemTypeSuite) TestUnauthorizeWorkItemTypeCreate() {
 }
 
 func (s *workItemTypeSuite) getWorkItemTypeTestDataFunc() func(*testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((s.Configuration.GetTokenPrivateKey()))
+	privatekey, err := s.Configuration.GetTokenPrivateKey()
 	return func(t *testing.T) []testSecureAPI {
 		if err != nil {
 			t.Fatal("Could not parse Key ", err)

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -76,7 +76,7 @@ func (s *serviceBlackBoxTest) SetupSuite() {
 			TokenURL: tokenEndpoint,
 		},
 	}
-	privateKey, err := token.ParsePrivateKey([]byte(token.RSAPrivateKey))
+	privateKey, err := token.RSAPrivateKey()
 	if err != nil {
 		panic(err)
 	}

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -35,7 +35,7 @@ func init() {
 	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
-	privateKey, err = token.ParsePrivateKey([]byte(configuration.GetTokenPrivateKey()))
+	privateKey, err = configuration.GetTokenPrivateKey()
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/auth"
-	config "github.com/fabric8-services/fabric8-wit/configuration"
+	"github.com/fabric8-services/fabric8-wit/configuration"
 	"github.com/fabric8-services/fabric8-wit/controller"
 	witmiddleware "github.com/fabric8-services/fabric8-wit/goamiddleware"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
@@ -68,7 +68,7 @@ func main() {
 		}
 	}
 
-	configuration, err := config.NewConfigurationData(configFilePath)
+	config, err := configuration.NewConfigurationData(configFilePath)
 	if err != nil {
 		log.Panic(nil, map[string]interface{}{
 			"config_file_path": configFilePath,
@@ -81,42 +81,42 @@ func main() {
 	}
 
 	// Initialized developer mode flag and log level for the logger
-	log.InitializeLogger(configuration.IsLogJSON(), configuration.GetLogLevel())
+	log.InitializeLogger(config.IsLogJSON(), config.GetLogLevel())
 
 	printUserInfo()
 
 	var db *gorm.DB
 	for {
-		db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
+		db, err = gorm.Open("postgres", config.GetPostgresConfigString())
 		if err != nil {
 			db.Close()
 			log.Logger().Errorf("ERROR: Unable to open connection to database %v", err)
-			log.Logger().Infof("Retrying to connect in %v...", configuration.GetPostgresConnectionRetrySleep())
-			time.Sleep(configuration.GetPostgresConnectionRetrySleep())
+			log.Logger().Infof("Retrying to connect in %v...", config.GetPostgresConnectionRetrySleep())
+			time.Sleep(config.GetPostgresConnectionRetrySleep())
 		} else {
 			defer db.Close()
 			break
 		}
 	}
 
-	if configuration.IsPostgresDeveloperModeEnabled() && log.IsDebug() {
+	if config.IsPostgresDeveloperModeEnabled() && log.IsDebug() {
 		db = db.Debug()
 	}
 
-	if configuration.GetPostgresConnectionMaxIdle() > 0 {
-		log.Logger().Infof("Configured connection pool max idle %v", configuration.GetPostgresConnectionMaxIdle())
-		db.DB().SetMaxIdleConns(configuration.GetPostgresConnectionMaxIdle())
+	if config.GetPostgresConnectionMaxIdle() > 0 {
+		log.Logger().Infof("Configured connection pool max idle %v", config.GetPostgresConnectionMaxIdle())
+		db.DB().SetMaxIdleConns(config.GetPostgresConnectionMaxIdle())
 	}
-	if configuration.GetPostgresConnectionMaxOpen() > 0 {
-		log.Logger().Infof("Configured connection pool max open %v", configuration.GetPostgresConnectionMaxOpen())
-		db.DB().SetMaxOpenConns(configuration.GetPostgresConnectionMaxOpen())
+	if config.GetPostgresConnectionMaxOpen() > 0 {
+		log.Logger().Infof("Configured connection pool max open %v", config.GetPostgresConnectionMaxOpen())
+		db.DB().SetMaxOpenConns(config.GetPostgresConnectionMaxOpen())
 	}
 
 	// Set the database transaction timeout
-	application.SetDatabaseTransactionTimeout(configuration.GetPostgresTransactionTimeout())
+	application.SetDatabaseTransactionTimeout(config.GetPostgresTransactionTimeout())
 
 	// Migrate the schema
-	err = migration.Migrate(db.DB(), configuration.GetPostgresDatabase())
+	err = migration.Migrate(db.DB(), config.GetPostgresDatabase())
 	if err != nil {
 		log.Panic(nil, map[string]interface{}{
 			"err": err,
@@ -129,7 +129,7 @@ func main() {
 	}
 
 	// Make sure the database is populated with the correct types (e.g. bug etc.)
-	if configuration.GetPopulateCommonTypes() {
+	if config.GetPopulateCommonTypes() {
 		ctx := migration.NewMigrationContext(context.Background())
 
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
@@ -165,13 +165,13 @@ func main() {
 	userRepository := account.NewUserRepository(db)
 
 	var notificationChannel notification.Channel = &notification.DevNullChannel{}
-	if configuration.GetNotificationServiceURL() != "" {
-		log.Logger().Infof("Enabling Notification service %v", configuration.GetNotificationServiceURL())
-		channel, err := notification.NewServiceChannel(configuration)
+	if config.GetNotificationServiceURL() != "" {
+		log.Logger().Infof("Enabling Notification service %v", config.GetNotificationServiceURL())
+		channel, err := notification.NewServiceChannel(config)
 		if err != nil {
 			log.Panic(nil, map[string]interface{}{
 				"err": err,
-				"url": configuration.GetNotificationServiceURL(),
+				"url": config.GetNotificationServiceURL(),
 			}, "failed to parse notification service url")
 		}
 		notificationChannel = channel
@@ -179,7 +179,7 @@ func main() {
 
 	appDB := gormapplication.NewGormDB(db)
 
-	publicKey, err := token.ParsePublicKey(configuration.GetTokenPublicKey())
+	publicKey, err := config.GetTokenPublicKey()
 	if err != nil {
 		log.Panic(nil, map[string]interface{}{
 			"err": err,
@@ -191,17 +191,17 @@ func main() {
 	service.Use(jwtMiddlewareTokenContext)
 
 	service.Use(login.InjectTokenManager(tokenManager))
-	service.Use(log.LogRequest(configuration.IsPostgresDeveloperModeEnabled()))
+	service.Use(log.LogRequest(config.IsPostgresDeveloperModeEnabled()))
 	app.UseJWTMiddleware(service, goajwt.New(publicKey, nil, app.NewJWTSecurity()))
 
-	spaceAuthzService := authz.NewAuthzService(configuration, appDB)
+	spaceAuthzService := authz.NewAuthzService(config, appDB)
 	service.Use(authz.InjectAuthzService(spaceAuthzService))
 
 	loginService := login.NewKeycloakOAuthProvider(identityRepository, userRepository, tokenManager, appDB)
-	loginCtrl := controller.NewLoginController(service, loginService, tokenManager, configuration, identityRepository)
+	loginCtrl := controller.NewLoginController(service, loginService, tokenManager, config, identityRepository)
 	app.MountLoginController(service, loginCtrl)
 
-	logoutCtrl := controller.NewLogoutController(service, &login.KeycloakLogoutService{}, configuration)
+	logoutCtrl := controller.NewLogoutController(service, &login.KeycloakLogoutService{}, config)
 	app.MountLogoutController(service, logoutCtrl)
 
 	// Mount "status" controller
@@ -209,8 +209,8 @@ func main() {
 	app.MountStatusController(service, statusCtrl)
 
 	// Mount "workitem" controller
-	//workitemCtrl := controller.NewWorkitemController(service, appDB, configuration)
-	workitemCtrl := controller.NewNotifyingWorkitemController(service, appDB, notificationChannel, configuration)
+	//workitemCtrl := controller.NewWorkitemController(service, appDB, config)
+	workitemCtrl := controller.NewNotifyingWorkitemController(service, appDB, notificationChannel, config)
 	app.MountWorkitemController(service, workitemCtrl)
 
 	// Mount "named workitem" controller
@@ -218,12 +218,12 @@ func main() {
 	app.MountNamedWorkItemsController(service, namedWorkitemsCtrl)
 
 	// Mount "workitems" controller
-	//workitemsCtrl := controller.NewWorkitemsController(service, appDB, configuration)
-	workitemsCtrl := controller.NewNotifyingWorkitemsController(service, appDB, notificationChannel, configuration)
+	//workitemsCtrl := controller.NewWorkitemsController(service, appDB, config)
+	workitemsCtrl := controller.NewNotifyingWorkitemsController(service, appDB, notificationChannel, config)
 	app.MountWorkitemsController(service, workitemsCtrl)
 
 	// Mount "workitemtype" controller
-	workitemtypeCtrl := controller.NewWorkitemtypeController(service, appDB, configuration)
+	workitemtypeCtrl := controller.NewWorkitemtypeController(service, appDB, config)
 	app.MountWorkitemtypeController(service, workitemtypeCtrl)
 
 	// Mount "work item link category" controller
@@ -231,77 +231,77 @@ func main() {
 	app.MountWorkItemLinkCategoryController(service, workItemLinkCategoryCtrl)
 
 	// Mount "work item link type" controller
-	workItemLinkTypeCtrl := controller.NewWorkItemLinkTypeController(service, appDB, configuration)
+	workItemLinkTypeCtrl := controller.NewWorkItemLinkTypeController(service, appDB, config)
 	app.MountWorkItemLinkTypeController(service, workItemLinkTypeCtrl)
 
 	// Mount "work item link" controller
-	workItemLinkCtrl := controller.NewWorkItemLinkController(service, appDB, configuration)
+	workItemLinkCtrl := controller.NewWorkItemLinkController(service, appDB, config)
 	app.MountWorkItemLinkController(service, workItemLinkCtrl)
 
 	// Mount "work item comments" controller
-	//workItemCommentsCtrl := controller.NewWorkItemCommentsController(service, appDB, configuration)
-	workItemCommentsCtrl := controller.NewNotifyingWorkItemCommentsController(service, appDB, notificationChannel, configuration)
+	//workItemCommentsCtrl := controller.NewWorkItemCommentsController(service, appDB, config)
+	workItemCommentsCtrl := controller.NewNotifyingWorkItemCommentsController(service, appDB, notificationChannel, config)
 	app.MountWorkItemCommentsController(service, workItemCommentsCtrl)
 
 	// Mount "work item relationships links" controller
-	workItemRelationshipsLinksCtrl := controller.NewWorkItemRelationshipsLinksController(service, appDB, configuration)
+	workItemRelationshipsLinksCtrl := controller.NewWorkItemRelationshipsLinksController(service, appDB, config)
 	app.MountWorkItemRelationshipsLinksController(service, workItemRelationshipsLinksCtrl)
 
 	// Mount "comments" controller
-	//commentsCtrl := controller.NewCommentsController(service, appDB, configuration)
-	commentsCtrl := controller.NewNotifyingCommentsController(service, appDB, notificationChannel, configuration)
+	//commentsCtrl := controller.NewCommentsController(service, appDB, config)
+	commentsCtrl := controller.NewNotifyingCommentsController(service, appDB, notificationChannel, config)
 	app.MountCommentsController(service, commentsCtrl)
 
-	if configuration.GetFeatureWorkitemRemote() {
+	if config.GetFeatureWorkitemRemote() {
 		// Scheduler to fetch and import remote tracker items
 		scheduler = remoteworkitem.NewScheduler(db)
 		defer scheduler.Stop()
 
-		accessTokens := controller.GetAccessTokens(configuration)
+		accessTokens := controller.GetAccessTokens(config)
 		scheduler.ScheduleAllQueries(service.Context, accessTokens)
 
 		// Mount "tracker" controller
-		c5 := controller.NewTrackerController(service, appDB, scheduler, configuration)
+		c5 := controller.NewTrackerController(service, appDB, scheduler, config)
 		app.MountTrackerController(service, c5)
 
 		// Mount "trackerquery" controller
-		c6 := controller.NewTrackerqueryController(service, appDB, scheduler, configuration)
+		c6 := controller.NewTrackerqueryController(service, appDB, scheduler, config)
 		app.MountTrackerqueryController(service, c6)
 	}
 
 	// Mount "space" controller
-	spaceCtrl := controller.NewSpaceController(service, appDB, configuration, auth.NewAuthzResourceManager(configuration))
+	spaceCtrl := controller.NewSpaceController(service, appDB, config, auth.NewAuthzResourceManager(config))
 	app.MountSpaceController(service, spaceCtrl)
 
 	// Mount "user" controller
-	userCtrl := controller.NewUserController(service, appDB, tokenManager, configuration)
-	if configuration.GetTenantServiceURL() != "" {
-		log.Logger().Infof("Enabling Init Tenant service %v", configuration.GetTenantServiceURL())
-		userCtrl.InitTenant = account.NewInitTenant(configuration)
+	userCtrl := controller.NewUserController(service, appDB, tokenManager, config)
+	if config.GetTenantServiceURL() != "" {
+		log.Logger().Infof("Enabling Init Tenant service %v", config.GetTenantServiceURL())
+		userCtrl.InitTenant = account.NewInitTenant(config)
 	}
 	app.MountUserController(service, userCtrl)
 
 	userServiceCtrl := controller.NewUserServiceController(service)
-	userServiceCtrl.UpdateTenant = account.NewUpdateTenant(configuration)
-	userServiceCtrl.CleanTenant = account.NewCleanTenant(configuration)
-	userServiceCtrl.ShowTenant = account.NewShowTenant(configuration)
+	userServiceCtrl.UpdateTenant = account.NewUpdateTenant(config)
+	userServiceCtrl.CleanTenant = account.NewCleanTenant(config)
+	userServiceCtrl.ShowTenant = account.NewShowTenant(config)
 	app.MountUserServiceController(service, userServiceCtrl)
 
 	// Mount "search" controller
-	searchCtrl := controller.NewSearchController(service, appDB, configuration)
+	searchCtrl := controller.NewSearchController(service, appDB, config)
 	app.MountSearchController(service, searchCtrl)
 
 	// Mount "users" controller
 	keycloakProfileService := login.NewKeycloakUserProfileClient()
-	usersCtrl := controller.NewUsersController(service, appDB, configuration, keycloakProfileService)
+	usersCtrl := controller.NewUsersController(service, appDB, config, keycloakProfileService)
 	app.MountUsersController(service, usersCtrl)
 
 	// Mount "iterations" controller
-	iterationCtrl := controller.NewIterationController(service, appDB, configuration)
+	iterationCtrl := controller.NewIterationController(service, appDB, config)
 	app.MountIterationController(service, iterationCtrl)
 
 	// Mount "spaceiterations" controller
-	spaceIterationCtrl := controller.NewSpaceIterationsController(service, appDB, configuration)
+	spaceIterationCtrl := controller.NewSpaceIterationsController(service, appDB, config)
 	app.MountSpaceIterationsController(service, spaceIterationCtrl)
 
 	// Mount "userspace" controller
@@ -313,13 +313,13 @@ func main() {
 	app.MountRenderController(service, renderCtrl)
 
 	// Mount "areas" controller
-	areaCtrl := controller.NewAreaController(service, appDB, configuration)
+	areaCtrl := controller.NewAreaController(service, appDB, config)
 	app.MountAreaController(service, areaCtrl)
 
-	spaceAreaCtrl := controller.NewSpaceAreasController(service, appDB, configuration)
+	spaceAreaCtrl := controller.NewSpaceAreasController(service, appDB, config)
 	app.MountSpaceAreasController(service, spaceAreaCtrl)
 
-	filterCtrl := controller.NewFilterController(service, configuration)
+	filterCtrl := controller.NewFilterController(service, config)
 	app.MountFilterController(service, filterCtrl)
 
 	// Mount "namedspaces" controller
@@ -327,12 +327,12 @@ func main() {
 	app.MountNamedspacesController(service, namedSpacesCtrl)
 
 	// Mount "plannerBacklog" controller
-	plannerBacklogCtrl := controller.NewPlannerBacklogController(service, appDB, configuration)
+	plannerBacklogCtrl := controller.NewPlannerBacklogController(service, appDB, config)
 	app.MountPlannerBacklogController(service, plannerBacklogCtrl)
 
 	// Mount "codebase" controller
-	codebaseCtrl := controller.NewCodebaseController(service, appDB, configuration)
-	codebaseCtrl.ShowTenant = account.NewShowTenant(configuration)
+	codebaseCtrl := controller.NewCodebaseController(service, appDB, config)
+	codebaseCtrl.ShowTenant = account.NewShowTenant(config)
 	app.MountCodebaseController(service, codebaseCtrl)
 
 	// Mount "spacecodebases" controller
@@ -340,7 +340,7 @@ func main() {
 	app.MountSpaceCodebasesController(service, spaceCodebaseCtrl)
 
 	// Mount "collaborators" controller
-	collaboratorsCtrl := controller.NewCollaboratorsController(service, appDB, configuration, auth.NewKeycloakPolicyManager(configuration))
+	collaboratorsCtrl := controller.NewCollaboratorsController(service, appDB, config, auth.NewKeycloakPolicyManager(config))
 	app.MountCollaboratorsController(service, collaboratorsCtrl)
 
 	// Mount "space template" controller
@@ -354,7 +354,7 @@ func main() {
 	log.Logger().Infoln("Git Commit SHA: ", controller.Commit)
 	log.Logger().Infoln("UTC Build Time: ", controller.BuildTime)
 	log.Logger().Infoln("UTC Start Time: ", controller.StartTime)
-	log.Logger().Infoln("Dev mode:       ", configuration.IsPostgresDeveloperModeEnabled())
+	log.Logger().Infoln("Dev mode:       ", config.IsPostgresDeveloperModeEnabled())
 	log.Logger().Infoln("GOMAXPROCS:     ", runtime.GOMAXPROCS(-1))
 	log.Logger().Infoln("NumCPU:         ", runtime.NumCPU())
 
@@ -363,9 +363,9 @@ func main() {
 	http.Handle("/favicon.ico", http.NotFoundHandler())
 
 	// Start http
-	if err := http.ListenAndServe(configuration.GetHTTPAddress(), nil); err != nil {
+	if err := http.ListenAndServe(config.GetHTTPAddress(), nil); err != nil {
 		log.Error(nil, map[string]interface{}{
-			"addr": configuration.GetHTTPAddress(),
+			"addr": config.GetHTTPAddress(),
 			"err":  err,
 		}, "unable to connect to server")
 		service.LogError("startup", "err", err)

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -80,7 +80,7 @@ func (s *TestAuthzSuite) TestUserIsNotAmongSpaceCollaboratorsFails() {
 func (s *TestAuthzSuite) checkPermissions(authzPayload auth.AuthorizationPayload, spaceID string) bool {
 	resource := &space.Resource{}
 	authzService := authz.NewAuthzService(s.configuration, &db{app{resource: resource}})
-	priv, _ := wittoken.ParsePrivateKey([]byte(wittoken.RSAPrivateKey))
+	priv, _ := wittoken.RSAPrivateKey()
 	testIdentity := testsupport.TestIdentity
 	svc := testsupport.ServiceAsUserWithAuthz("SpaceAuthz-Service", wittoken.NewManagerWithPrivateKey(priv), priv, testIdentity, authzPayload)
 	resource.UpdatedAt = time.Now()

--- a/token/token.go
+++ b/token/token.go
@@ -90,18 +90,16 @@ func (mgm tokenManager) PublicKey() *rsa.PublicKey {
 }
 
 // ParsePublicKey parses a []byte representation of a public key into a rsa.PublicKey instance
-func ParsePublicKey(key []byte) (*rsa.PublicKey, error) {
+func parsePublicKey(key []byte) (*rsa.PublicKey, error) {
 	return jwt.ParseRSAPublicKeyFromPEM(key)
 }
 
 // ParsePrivateKey parses a []byte representation of a private key into a rsa.PrivateKey instance
-func ParsePrivateKey(key []byte) (*rsa.PrivateKey, error) {
+func parsePrivateKey(key []byte) (*rsa.PrivateKey, error) {
 	return jwt.ParseRSAPrivateKeyFromPEM(key)
 }
 
-// RSAPrivateKey for signing JWT Tokens
-// ssh-keygen -f wit_rsa
-var RSAPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+var privateKey = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAnwrjH5iTSErw9xUptp6QSFoUfpHUXZ+PaslYSUrpLjw1q27O
 DSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nwxBobS723okFaIkshRrf6qgtD6coT
 HlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3bwTIFlLlVMiZf7XVE7P3yuOCpqkk
@@ -129,9 +127,13 @@ BA/cKaLPqUF+08Tz/9MPBw51UH4GYfppA/x0ktc8998984FeIpfIFX6I2U9yUnoQ
 OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
 -----END RSA PRIVATE KEY-----`
 
-// RSAPublicKey for verifying JWT Tokens
-// openssl rsa -in wit_rsa -pubout -out wit_rsa.pub
-var RSAPublicKey = `-----BEGIN PUBLIC KEY-----
+// RSAPrivateKey returns the key used to sign JWT Tokens
+// ssh-keygen -f wit_rsa
+func RSAPrivateKey() (*rsa.PrivateKey, error) {
+	return parsePrivateKey([]byte(privateKey))
+}
+
+var publicKey = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiRd6pdNjiwQFH2xmNugn
 TkVhkF+TdJw19Kpj3nRtsoUe4/6gIureVi7FWqcb+2t/E0dv8rAAs6vl+d7roz3R
 SkAzBjPxVW5+hi5AJjUbAxtFX/aYJpZePVhK0Dv8StCPSv9GC3T6bUSF3q3E9R9n
@@ -140,3 +142,9 @@ G1SZFkN9m2DhL+45us4THzX2eau6s0bISjAUqEGNifPyYYUzKVmXmHS9fiZJR61h
 JXdQ7zylRlpaLopock0FGiZrJhEaAh6BGuaoUWLiMEvqrLuyZnJYEg9f/vyxUJSD
 JwIDAQAB
 -----END PUBLIC KEY-----`
+
+// RSAPublicKey returns the key used to verify JWT Tokens
+// openssl rsa -in wit_rsa -pubout -out wit_rsa.pub
+func RSAPublicKey() (*rsa.PublicKey, error) {
+	return parsePublicKey([]byte(publicKey))
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -25,7 +25,7 @@ func TestExtractToken(t *testing.T) {
 		ID:       uuid.NewV4(),
 		Username: "testuser",
 	}
-	privateKey, err := token.ParsePrivateKey([]byte(token.RSAPrivateKey))
+	privateKey, err := token.RSAPrivateKey()
 	if err != nil {
 		t.Fatal("Could not parse private key", err)
 	}
@@ -48,7 +48,7 @@ func TestExtractWithInvalidToken(t *testing.T) {
 	// all above cases are invalid
 	// hence manager.Extract should fail in all above cases
 	manager := createManager(t)
-	privateKey, err := token.ParsePrivateKey([]byte(token.RSAPrivateKey))
+	privateKey, err := token.RSAPrivateKey()
 
 	tok := jwt.New(jwt.SigningMethodRS256)
 	// add already expired time to "exp" claim"
@@ -141,7 +141,7 @@ func TestLocateInvalidUUIDInTokenInContext(t *testing.T) {
 }
 
 func createManager(t *testing.T) token.Manager {
-	privateKey, err := token.ParsePrivateKey([]byte(token.RSAPrivateKey))
+	privateKey, err := token.RSAPrivateKey()
 	if err != nil {
 		t.Fatal("Could not parse private key")
 	}


### PR DESCRIPTION
Modify methods in configuration to return `rsa.PublicKey`
and `rsa.PrivateKey` instead of `[]byte` that need to be
parsed everytime.

Also, use `config` as the variable name instead of `configuration`
to avoid clashes and ambiguity with the `configuration` package.

Fixes #1615

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

* Please describe what your change is about.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
* If you are still working on the change please prefix the pull request title with "WIP"
