### PR TITLE
Fix bug in method to load public key #1625

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -521,7 +521,7 @@ func (c *ConfigurationData) GetTokenPublicKey() (*rsa.PublicKey, error) {
 		publicKeyParsingMutex.Lock()
 		defer publicKeyParsingMutex.Unlock()
 		// at this point, we can avoid parsing *again* the key if it's not nil anymore
-		if c.tokenPrivateKey == nil {
+		if c.tokenPublicKey == nil {
 			var err error
 			c.tokenPublicKey, err = jwt.ParseRSAPublicKeyFromPEM([]byte(c.v.GetString(varTokenPublicKey)))
 			return c.tokenPublicKey, err


### PR DESCRIPTION
Replace
  `if c.tokenPrivateKey == nil {`
with
  `if c.tokenPublicKey == nil {`

Fixes #1625

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

* Please describe what your change is about.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
* If you are still working on the change please prefix the pull request title with "WIP"
