### PR TITLE
Validate if token is associated with a service account

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -124,14 +124,9 @@ func (mgm *tokenManager) IsServiceAccount(ctx context.Context) bool {
 		return false
 	}
 	accountNameTyped, isString := accountName.(string)
-	if !isString {
-		return false
-	}
+
 	// https://github.com/fabric8-services/fabric8-auth/commit/8d7f5a3646974ae8820893d75c29f3f5e9b1ff66#diff-6b1a7621961d1f6fe7463db59c5afef5R379
-	if accountNameTyped != "auth" {
-		return false
-	}
-	return true
+	return isString && accountNameTyped == "auth"
 }
 
 // ParseToken parses token claims

--- a/token/token.go
+++ b/token/token.go
@@ -55,6 +55,7 @@ type Manager interface {
 	ParseToken(ctx context.Context, tokenString string) (*TokenClaims, error)
 	PublicKey(kid string) *rsa.PublicKey
 	PublicKeys() []*rsa.PublicKey
+	IsServiceAccount(ctx context.Context) bool
 }
 
 type tokenManager struct {
@@ -111,6 +112,26 @@ func NewManagerWithPublicKey(id string, key *rsa.PublicKey) Manager {
 		publicKeysMap: map[string]*rsa.PublicKey{id: key},
 		publicKeys:    []*PublicKey{{KeyID: id, Key: key}},
 	}
+}
+
+func (mgm *tokenManager) IsServiceAccount(ctx context.Context) bool {
+	token := goajwt.ContextJWT(ctx)
+	if token == nil {
+		return false
+	}
+	accountName := token.Claims.(jwt.MapClaims)["service_accountname"]
+	if accountName == nil {
+		return false
+	}
+	accountNameTyped, isString := accountName.(string)
+	if !isString {
+		return false
+	}
+	// https://github.com/fabric8-services/fabric8-auth/commit/8d7f5a3646974ae8820893d75c29f3f5e9b1ff66#diff-6b1a7621961d1f6fe7463db59c5afef5R379
+	if accountNameTyped != "auth" {
+		return false
+	}
+	return true
 }
 
 // ParseToken parses token claims

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -107,6 +107,41 @@ func TestLocateTokenInContex(t *testing.T) {
 	assert.Equal(t, id, foundId, "ID in created context not equal")
 }
 
+func TestIsServiceAccountTokenInContextClaimPresent(t *testing.T) {
+	tk := jwt.New(jwt.SigningMethodRS256)
+	tk.Claims.(jwt.MapClaims)["service_accountname"] = "auth"
+	ctx := goajwt.WithJWT(context.Background(), tk)
+
+	isServiceAccount := tokenManager.IsServiceAccount(ctx)
+	require.True(t, isServiceAccount)
+}
+
+func TestIsServiceAccountTokenInContextClaimAbsent(t *testing.T) {
+	tk := jwt.New(jwt.SigningMethodRS256)
+	ctx := goajwt.WithJWT(context.Background(), tk)
+
+	isServiceAccount := tokenManager.IsServiceAccount(ctx)
+	require.False(t, isServiceAccount)
+}
+
+func TestIsServiceAccountTokenInContextClaimIncorrect(t *testing.T) {
+	tk := jwt.New(jwt.SigningMethodRS256)
+	tk.Claims.(jwt.MapClaims)["service_accountname"] = "Not-auth"
+	ctx := goajwt.WithJWT(context.Background(), tk)
+
+	isServiceAccount := tokenManager.IsServiceAccount(ctx)
+	require.False(t, isServiceAccount)
+}
+
+func TestIsServiceAccountTokenInContextClaimIncorrectType(t *testing.T) {
+	tk := jwt.New(jwt.SigningMethodRS256)
+	tk.Claims.(jwt.MapClaims)["service_accountname"] = 1
+	ctx := goajwt.WithJWT(context.Background(), tk)
+
+	isServiceAccount := tokenManager.IsServiceAccount(ctx)
+	require.False(t, isServiceAccount)
+}
+
 func TestLocateMissingTokenInContext(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Auth will be communicating with WIT using service account tokens . 
( https://github.com/fabric8-services/fabric8-auth/commit/8d7f5a3646974ae8820893d75c29f3f5e9b1ff66#diff-6b1a7621961d1f6fe7463db59c5afef5R374 ) 

This PR adds a method to detect if the token is a service account token ( and not a user token ) 