### PR TITLE
simplify db-test-suite setup

### DIFF
--- a/account/identity_blackbox_test.go
+++ b/account/identity_blackbox_test.go
@@ -1,16 +1,12 @@
 package account_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
-
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,31 +15,16 @@ import (
 
 type identityBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
-	repo  account.IdentityRepository
-	clean func()
-	ctx   context.Context
+	repo account.IdentityRepository
 }
 
 func TestRunIdentityBlackBoxTest(t *testing.T) {
 	suite.Run(t, &identityBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *identityBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	s.ctx = migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
-}
-
 func (s *identityBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.repo = account.NewIdentityRepository(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-
-func (s *identityBlackBoxTest) TearDownTest() {
-	s.clean()
 }
 
 func (s *identityBlackBoxTest) TestOKToDelete() {
@@ -58,15 +39,15 @@ func (s *identityBlackBoxTest) TestOKToDelete() {
 		Username:     "onemoreuserTestIdentity",
 		ProviderType: account.KeycloakIDP}
 
-	err := s.repo.Create(s.ctx, identity)
+	err := s.repo.Create(s.Ctx, identity)
 	require.Nil(s.T(), err, "Could not create identity")
-	err = s.repo.Create(s.ctx, identity2)
+	err = s.repo.Create(s.Ctx, identity2)
 	require.Nil(s.T(), err, "Could not create identity")
 	// when
-	err = s.repo.Delete(s.ctx, identity.ID)
+	err = s.repo.Delete(s.Ctx, identity.ID)
 	// then
 	assert.Nil(s.T(), err)
-	identities, err := s.repo.List(s.ctx)
+	identities, err := s.repo.List(s.Ctx)
 	require.Nil(s.T(), err, "Could not list identities")
 	require.True(s.T(), len(identities) > 0)
 	for _, ident := range identities {
@@ -87,14 +68,14 @@ func (s *identityBlackBoxTest) TestExistsIdentity() {
 		// given
 		identity := createAndLoad(s)
 		// when
-		err := s.repo.CheckExists(s.ctx, identity.ID.String())
+		err := s.repo.CheckExists(s.Ctx, identity.ID.String())
 		// then
 		require.Nil(t, err, "Could not check if identity exists")
 	})
 
 	t.Run("identity doesn't exist", func(t *testing.T) {
 		//t.Parallel()
-		err := s.repo.CheckExists(s.ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
 		// then
 
 		require.IsType(t, errors.NotFoundError{}, err)
@@ -107,7 +88,7 @@ func (s *identityBlackBoxTest) TestOKToSave() {
 	identity := createAndLoad(s)
 	// when
 	identity.Username = "newusernameTestIdentity"
-	err := s.repo.Save(s.ctx, identity)
+	err := s.repo.Save(s.Ctx, identity)
 	// then
 	require.Nil(s.T(), err, "Could not update identity")
 }
@@ -118,10 +99,10 @@ func createAndLoad(s *identityBlackBoxTest) *account.Identity {
 		Username:     "someuserTestIdentity2",
 		ProviderType: account.KeycloakIDP}
 
-	err := s.repo.Create(s.ctx, identity)
+	err := s.repo.Create(s.Ctx, identity)
 	require.Nil(s.T(), err, "Could not create identity")
 	// when
-	idnt, err := s.repo.Load(s.ctx, identity.ID)
+	idnt, err := s.repo.Load(s.Ctx, identity.ID)
 	// then
 	require.Nil(s.T(), err, "Could not load identity")
 	require.Equal(s.T(), "someuserTestIdentity2", idnt.Username)

--- a/account/user_blackbox_test.go
+++ b/account/user_blackbox_test.go
@@ -1,14 +1,11 @@
 package account_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 
 	uuid "github.com/satori/go.uuid"
@@ -19,31 +16,16 @@ import (
 
 type userBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
-	repo  account.UserRepository
-	clean func()
-	ctx   context.Context
+	repo account.UserRepository
 }
 
 func TestRunUserBlackBoxTest(t *testing.T) {
 	suite.Run(t, &userBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *userBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	s.ctx = migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
-}
-
 func (s *userBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.repo = account.NewUserRepository(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-
-func (s *userBlackBoxTest) TearDownTest() {
-	s.clean()
 }
 
 func (s *userBlackBoxTest) TestOKToDelete() {
@@ -54,11 +36,11 @@ func (s *userBlackBoxTest) TestOKToDelete() {
 	user := createAndLoadUser(s)
 	createAndLoadUser(s)
 
-	err := s.repo.Delete(s.ctx, user.ID)
+	err := s.repo.Delete(s.Ctx, user.ID)
 	assert.Nil(s.T(), err)
 
 	// lets see how many are present.
-	users, err := s.repo.List(s.ctx)
+	users, err := s.repo.List(s.Ctx)
 	require.Nil(s.T(), err, "Could not list users")
 	require.True(s.T(), len(users) > 0)
 
@@ -84,7 +66,7 @@ func (s *userBlackBoxTest) TestExistsUser() {
 		//t.Parallel()
 		user := createAndLoadUser(s)
 		// when
-		err := s.repo.CheckExists(s.ctx, user.ID.String())
+		err := s.repo.CheckExists(s.Ctx, user.ID.String())
 		// then
 		require.Nil(t, err)
 	})
@@ -92,7 +74,7 @@ func (s *userBlackBoxTest) TestExistsUser() {
 	t.Run("user doesn't exist", func(t *testing.T) {
 		//t.Parallel()
 		// Check not existing
-		err := s.repo.CheckExists(s.ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
 		// then
 		//
 		require.IsType(s.T(), errors.NotFoundError{}, err)
@@ -106,10 +88,10 @@ func (s *userBlackBoxTest) TestOKToSave() {
 	user := createAndLoadUser(s)
 
 	user.FullName = "newusernameTestUser"
-	err := s.repo.Save(s.ctx, user)
+	err := s.repo.Save(s.Ctx, user)
 	require.Nil(s.T(), err, "Could not update user")
 
-	updatedUser, err := s.repo.Load(s.ctx, user.ID)
+	updatedUser, err := s.repo.Load(s.Ctx, user.ID)
 	require.Nil(s.T(), err, "Could not load user")
 	assert.Equal(s.T(), user.FullName, updatedUser.FullName)
 	fields := user.ContextInformation
@@ -133,10 +115,10 @@ func createAndLoadUser(s *userBlackBoxTest) *account.User {
 		},
 	}
 
-	err := s.repo.Create(s.ctx, user)
+	err := s.repo.Create(s.Ctx, user)
 	require.Nil(s.T(), err, "Could not create user")
 
-	createdUser, err := s.repo.Load(s.ctx, user.ID)
+	createdUser, err := s.repo.Load(s.Ctx, user.ID)
 	require.Nil(s.T(), err, "Could not load user")
 	require.Equal(s.T(), user.Email, createdUser.Email)
 	require.Equal(s.T(), user.ID, createdUser.ID)

--- a/auth/state_blackbox_test.go
+++ b/auth/state_blackbox_test.go
@@ -5,12 +5,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/auth"
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
-
-	"context"
-
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,31 +14,16 @@ import (
 
 type stateBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
-	repo  auth.OauthStateReferenceRepository
-	clean func()
-	ctx   context.Context
+	repo auth.OauthStateReferenceRepository
 }
 
 func TestRunStateBlackBoxTest(t *testing.T) {
 	suite.Run(t, &stateBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *stateBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	s.ctx = migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
-}
-
 func (s *stateBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.repo = auth.NewOauthStateReferenceRepository(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-
-func (s *stateBlackBoxTest) TearDownTest() {
-	s.clean()
 }
 
 func (s *stateBlackBoxTest) TestCreateDeleteLoad() {
@@ -56,19 +36,19 @@ func (s *stateBlackBoxTest) TestCreateDeleteLoad() {
 		ID:       uuid.NewV4(),
 		Referrer: "anotherdomain.com"}
 
-	_, err := s.repo.Create(s.ctx, state)
+	_, err := s.repo.Create(s.Ctx, state)
 	require.Nil(s.T(), err, "Could not create state reference")
-	_, err = s.repo.Create(s.ctx, state2)
+	_, err = s.repo.Create(s.Ctx, state2)
 	require.Nil(s.T(), err, "Could not create state reference")
 	// when
-	err = s.repo.Delete(s.ctx, state.ID)
+	err = s.repo.Delete(s.Ctx, state.ID)
 	// then
 	assert.Nil(s.T(), err)
-	_, err = s.repo.Load(s.ctx, state.ID)
+	_, err = s.repo.Load(s.Ctx, state.ID)
 	require.NotNil(s.T(), err)
 	require.IsType(s.T(), errors.NotFoundError{}, err)
 
-	foundState, err := s.repo.Load(s.ctx, state2.ID)
+	foundState, err := s.repo.Load(s.Ctx, state2.ID)
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), foundState)
 	require.True(s.T(), state2.Equal(*foundState))

--- a/comment/comment_revision_repository_blackbox_test.go
+++ b/comment/comment_revision_repository_blackbox_test.go
@@ -6,14 +6,11 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/comment"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
 	uuid "github.com/satori/go.uuid"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -28,25 +25,15 @@ type revisionRepositoryBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
 	repository         comment.Repository
 	revisionRepository comment.RevisionRepository
-	clean              func()
 	testIdentity1      account.Identity
 	testIdentity2      account.Identity
 	testIdentity3      account.Identity
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *revisionRepositoryBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
-}
-
 func (s *revisionRepositoryBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.repository = comment.NewRepository(s.DB)
 	s.revisionRepository = comment.NewRevisionRepository(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 	testIdentity1, err := testsupport.CreateTestIdentity(s.DB, "jdoe1", "test")
 	require.Nil(s.T(), err)
 	s.testIdentity1 = *testIdentity1
@@ -56,10 +43,6 @@ func (s *revisionRepositoryBlackBoxTest) SetupTest() {
 	testIdentity3, err := testsupport.CreateTestIdentity(s.DB, "jdoe3", "test")
 	require.Nil(s.T(), err)
 	s.testIdentity3 = *testIdentity3
-}
-
-func (s *revisionRepositoryBlackBoxTest) TearDownTest() {
-	s.clean()
 }
 
 func (s *revisionRepositoryBlackBoxTest) TestStoreCommentRevisions() {

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -1,7 +1,6 @@
 package controller_test
 
 import (
-	"context"
 	"fmt"
 	"html"
 	"net/http"
@@ -17,9 +16,7 @@ import (
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
@@ -43,21 +40,14 @@ func TestSuiteComments(t *testing.T) {
 type CommentsSuite struct {
 	gormtestsupport.DBTestSuite
 	db            *gormapplication.GormDB
-	clean         func()
 	testIdentity  account.Identity
 	testIdentity2 account.Identity
 	notification  testsupport.NotificationChannel
 }
 
-func (s *CommentsSuite) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
-}
-
 func (s *CommentsSuite) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.db = gormapplication.NewGormDB(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "CommentsSuite user", "test provider")
 	require.Nil(s.T(), err)
 	s.testIdentity = *testIdentity
@@ -65,10 +55,6 @@ func (s *CommentsSuite) SetupTest() {
 	require.Nil(s.T(), err)
 	s.testIdentity2 = *testIdentity2
 	s.notification = testsupport.NotificationChannel{}
-}
-
-func (s *CommentsSuite) TearDownTest() {
-	s.clean()
 }
 
 var (

--- a/controller/planner_backlog_blackbox_test.go
+++ b/controller/planner_backlog_blackbox_test.go
@@ -4,19 +4,15 @@ import (
 	"testing"
 	"time"
 
-	"context"
-
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	"github.com/fabric8-services/fabric8-wit/application"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/log"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
@@ -31,9 +27,7 @@ import (
 
 type TestPlannerBacklogBlackboxREST struct {
 	gormtestsupport.DBTestSuite
-	clean        func()
 	testIdentity account.Identity
-	ctx          context.Context
 }
 
 func TestRunPlannerBacklogBlackboxREST(t *testing.T) {
@@ -41,24 +35,12 @@ func TestRunPlannerBacklogBlackboxREST(t *testing.T) {
 	suite.Run(t, new(TestPlannerBacklogBlackboxREST))
 }
 
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (rest *TestPlannerBacklogBlackboxREST) SetupSuite() {
-	rest.DBTestSuite.SetupSuite()
-	rest.ctx = migration.NewMigrationContext(context.Background())
-	rest.DBTestSuite.PopulateDBTestSuite(rest.ctx)
-}
-
 func (rest *TestPlannerBacklogBlackboxREST) SetupTest() {
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
+	rest.DBTestSuite.SetupTest()
 	// create a test identity
 	testIdentity, err := testsupport.CreateTestIdentity(rest.DB, "TestPlannerBacklogBlackboxREST user", "test provider")
 	require.Nil(rest.T(), err)
 	rest.testIdentity = *testIdentity
-}
-
-func (rest *TestPlannerBacklogBlackboxREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestPlannerBacklogBlackboxREST) UnSecuredController() (*goa.Service, *PlannerBacklogController) {
@@ -73,12 +55,12 @@ func (rest *TestPlannerBacklogBlackboxREST) setupPlannerBacklogWorkItems() (test
 		testSpace = &space.Space{
 			Name: "PlannerBacklogWorkItems-" + uuid.NewV4().String(),
 		}
-		_, err := spacesRepo.Create(rest.ctx, testSpace)
+		_, err := spacesRepo.Create(rest.Ctx, testSpace)
 		require.Nil(rest.T(), err)
 		require.NotNil(rest.T(), testSpace.ID)
 		log.Info(nil, map[string]interface{}{"space_id": testSpace.ID}, "created space")
 		workitemTypesRepo := app.WorkItemTypes()
-		workitemType, err := workitemTypesRepo.Create(rest.ctx, testSpace.ID, nil, &workitem.SystemPlannerItem, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
+		workitemType, err := workitemTypesRepo.Create(rest.Ctx, testSpace.ID, nil, &workitem.SystemPlannerItem, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
 		require.Nil(rest.T(), err)
 		log.Info(nil, map[string]interface{}{"wit_id": workitemType.ID}, "created workitem type")
 
@@ -89,7 +71,7 @@ func (rest *TestPlannerBacklogBlackboxREST) setupPlannerBacklogWorkItems() (test
 			State:      iteration.IterationStateNew,
 			UserActive: &userActive,
 		}
-		iterationsRepo.Create(rest.ctx, parentIteration)
+		iterationsRepo.Create(rest.Ctx, parentIteration)
 		log.Info(nil, map[string]interface{}{"parent_iteration_id": parentIteration.ID}, "created parent iteration")
 
 		childIteration := &iteration.Iteration{
@@ -99,7 +81,7 @@ func (rest *TestPlannerBacklogBlackboxREST) setupPlannerBacklogWorkItems() (test
 			State:      iteration.IterationStateStart,
 			UserActive: &userActive,
 		}
-		iterationsRepo.Create(rest.ctx, childIteration)
+		iterationsRepo.Create(rest.Ctx, childIteration)
 		log.Info(nil, map[string]interface{}{"child_iteration_id": childIteration.ID}, "created child iteration")
 
 		fields := map[string]interface{}{
@@ -107,14 +89,14 @@ func (rest *TestPlannerBacklogBlackboxREST) setupPlannerBacklogWorkItems() (test
 			workitem.SystemState:     "new",
 			workitem.SystemIteration: parentIteration.ID.String(),
 		}
-		app.WorkItems().Create(rest.ctx, testSpace.ID, workitemType.ID, fields, rest.testIdentity.ID)
+		app.WorkItems().Create(rest.Ctx, testSpace.ID, workitemType.ID, fields, rest.testIdentity.ID)
 
 		fields2 := map[string]interface{}{
 			workitem.SystemTitle:     "childIteration Test",
 			workitem.SystemState:     "closed",
 			workitem.SystemIteration: childIteration.ID.String(),
 		}
-		createdWI, err = app.WorkItems().Create(rest.ctx, testSpace.ID, workitemType.ID, fields2, rest.testIdentity.ID)
+		createdWI, err = app.WorkItems().Create(rest.Ctx, testSpace.ID, workitemType.ID, fields2, rest.testIdentity.ID)
 		require.Nil(rest.T(), err)
 		return nil
 	})
@@ -216,7 +198,7 @@ func (rest *TestPlannerBacklogBlackboxREST) TestSuccessEmptyListPlannerBacklogWo
 		newSpace := space.Space{
 			Name: "TestSuccessEmptyListPlannerBacklogWorkItems" + uuid.NewV4().String(),
 		}
-		p, err := app.Spaces().Create(rest.ctx, &newSpace)
+		p, err := app.Spaces().Create(rest.Ctx, &newSpace)
 		if err != nil {
 			rest.T().Error(err)
 		}
@@ -228,14 +210,14 @@ func (rest *TestPlannerBacklogBlackboxREST) TestSuccessEmptyListPlannerBacklogWo
 			State:      iteration.IterationStateNew,
 			UserActive: &userActive,
 		}
-		iterationsRepo.Create(rest.ctx, parentIteration)
+		iterationsRepo.Create(rest.Ctx, parentIteration)
 
 		fields := map[string]interface{}{
 			workitem.SystemTitle:     "parentIteration Test",
 			workitem.SystemState:     "new",
 			workitem.SystemIteration: parentIteration.ID.String(),
 		}
-		app.WorkItems().Create(rest.ctx, spaceID, workitem.SystemPlannerItem, fields, rest.testIdentity.ID)
+		app.WorkItems().Create(rest.Ctx, spaceID, workitem.SystemPlannerItem, fields, rest.testIdentity.ID)
 
 		return nil
 	})

--- a/controller/planner_backlog_test.go
+++ b/controller/planner_backlog_test.go
@@ -3,22 +3,17 @@ package controller
 import (
 	"testing"
 
-	"context"
-
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/log"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
 	"github.com/fabric8-services/fabric8-wit/workitem"
-
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -28,9 +23,7 @@ import (
 
 type TestPlannerBacklogREST struct {
 	gormtestsupport.DBTestSuite
-	clean        func()
 	testIdentity account.Identity
-	ctx          context.Context
 }
 
 func TestRunPlannerBacklogREST(t *testing.T) {
@@ -38,24 +31,12 @@ func TestRunPlannerBacklogREST(t *testing.T) {
 	suite.Run(t, new(TestPlannerBacklogREST))
 }
 
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (rest *TestPlannerBacklogREST) SetupSuite() {
-	rest.DBTestSuite.SetupSuite()
-	rest.ctx = migration.NewMigrationContext(context.Background())
-	rest.DBTestSuite.PopulateDBTestSuite(rest.ctx)
-}
-
 func (rest *TestPlannerBacklogREST) SetupTest() {
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
+	rest.DBTestSuite.SetupTest()
 	// create a test identity
 	testIdentity, err := testsupport.CreateTestIdentity(rest.DB, "TestPlannerBacklogREST user", "test provider")
 	require.Nil(rest.T(), err)
 	rest.testIdentity = *testIdentity
-}
-
-func (rest *TestPlannerBacklogREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestPlannerBacklogREST) UnSecuredController() (*goa.Service, *PlannerBacklogController) {
@@ -70,12 +51,12 @@ func (rest *TestPlannerBacklogREST) setupPlannerBacklogWorkItems() (testSpace *s
 			Name:    "PlannerBacklogWorkItems-" + uuid.NewV4().String(),
 			OwnerId: rest.testIdentity.ID,
 		}
-		_, err := spacesRepo.Create(rest.ctx, testSpace)
+		_, err := spacesRepo.Create(rest.Ctx, testSpace)
 		require.Nil(rest.T(), err)
 		require.NotNil(rest.T(), testSpace.ID)
 		log.Info(nil, map[string]interface{}{"space_id": testSpace.ID}, "created space")
 		workitemTypesRepo := app.WorkItemTypes()
-		workitemType, err := workitemTypesRepo.Create(rest.ctx, testSpace.ID, nil, &workitem.SystemPlannerItem, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
+		workitemType, err := workitemTypesRepo.Create(rest.Ctx, testSpace.ID, nil, &workitem.SystemPlannerItem, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
 		require.Nil(rest.T(), err)
 		log.Info(nil, map[string]interface{}{"wit_id": workitemType.ID}, "created workitem type")
 
@@ -87,7 +68,7 @@ func (rest *TestPlannerBacklogREST) setupPlannerBacklogWorkItems() (testSpace *s
 			State:      iteration.IterationStateNew,
 			UserActive: &userActive,
 		}
-		iterationsRepo.Create(rest.ctx, parentIteration)
+		iterationsRepo.Create(rest.Ctx, parentIteration)
 		log.Info(nil, map[string]interface{}{"parent_iteration_id": parentIteration.ID}, "created parent iteration")
 
 		childIteration := &iteration.Iteration{
@@ -97,7 +78,7 @@ func (rest *TestPlannerBacklogREST) setupPlannerBacklogWorkItems() (testSpace *s
 			State:      iteration.IterationStateStart,
 			UserActive: &userActive,
 		}
-		iterationsRepo.Create(rest.ctx, childIteration)
+		iterationsRepo.Create(rest.Ctx, childIteration)
 		log.Info(nil, map[string]interface{}{"child_iteration_id": childIteration.ID}, "created child iteration")
 
 		fields := map[string]interface{}{
@@ -105,14 +86,14 @@ func (rest *TestPlannerBacklogREST) setupPlannerBacklogWorkItems() (testSpace *s
 			workitem.SystemState:     "new",
 			workitem.SystemIteration: parentIteration.ID.String(),
 		}
-		app.WorkItems().Create(rest.ctx, testSpace.ID, workitemType.ID, fields, rest.testIdentity.ID)
+		app.WorkItems().Create(rest.Ctx, testSpace.ID, workitemType.ID, fields, rest.testIdentity.ID)
 
 		fields2 := map[string]interface{}{
 			workitem.SystemTitle:     "childIteration Test",
 			workitem.SystemState:     "closed",
 			workitem.SystemIteration: childIteration.ID.String(),
 		}
-		createdWI, err = app.WorkItems().Create(rest.ctx, testSpace.ID, workitemType.ID, fields2, rest.testIdentity.ID)
+		createdWI, err = app.WorkItems().Create(rest.Ctx, testSpace.ID, workitemType.ID, fields2, rest.testIdentity.ID)
 		require.Nil(rest.T(), err)
 		return nil
 	})
@@ -152,7 +133,7 @@ func (rest *TestPlannerBacklogREST) TestCountZeroPlannerBacklogWorkItemsOK() {
 			Name:    "PlannerBacklogWorkItems-" + uuid.NewV4().String(),
 			OwnerId: rest.testIdentity.ID,
 		}
-		_, err := spacesRepo.Create(rest.ctx, spaceCount)
+		_, err := spacesRepo.Create(rest.Ctx, spaceCount)
 		require.Nil(rest.T(), err)
 
 		return nil

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -17,10 +17,8 @@ import (
 	config "github.com/fabric8-services/fabric8-wit/configuration"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/iteration"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
@@ -48,26 +46,17 @@ type searchBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
 	db                             *gormapplication.GormDB
 	svc                            *goa.Service
-	clean                          func()
 	testIdentity                   account.Identity
 	wiRepo                         *workitem.GormWorkItemRepository
 	controller                     *SearchController
 	spaceBlackBoxTestConfiguration *config.ConfigurationData
-	ctx                            context.Context
 	testDir                        string
 }
 
-func (s *searchBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	s.ctx = migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
-	s.testDir = filepath.Join("test-files", "search")
-}
-
 func (s *searchBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
+	s.testDir = filepath.Join("test-files", "search")
 	s.db = gormapplication.NewGormDB(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-
 	var err error
 	// create a test identity
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "SearchBlackBoxTest user", "test provider")
@@ -82,14 +71,10 @@ func (s *searchBlackBoxTest) SetupTest() {
 	s.controller = NewSearchController(s.svc, gormapplication.NewGormDB(s.DB), spaceBlackBoxTestConfiguration)
 }
 
-func (s *searchBlackBoxTest) TearDownTest() {
-	s.clean()
-}
-
 func (s *searchBlackBoxTest) TestSearchWorkItems() {
 	// given
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -113,7 +98,7 @@ func (s *searchBlackBoxTest) TestSearchWorkItems() {
 func (s *searchBlackBoxTest) TestSearchPagination() {
 	// given
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -139,7 +124,7 @@ func (s *searchBlackBoxTest) TestSearchPagination() {
 
 func (s *searchBlackBoxTest) TestSearchWithEmptyValue() {
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -164,7 +149,7 @@ func (s *searchBlackBoxTest) TestSearchWithDomainPortCombination() {
 	description := "http://localhost:8080/detail/154687364529310 is related issue"
 	expectedDescription := rendering.NewMarkupContentFromLegacy(description)
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -188,7 +173,7 @@ func (s *searchBlackBoxTest) TestSearchURLWithoutPort() {
 	description := "This issue is related to http://localhost/detail/876394"
 	expectedDescription := rendering.NewMarkupContentFromLegacy(description)
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -213,7 +198,7 @@ func (s *searchBlackBoxTest) TestUnregisteredURLWithPort() {
 	description := "Related to http://some-other-domain:8080/different-path/154687364529310/ok issue"
 	expectedDescription := rendering.NewMarkupContentFromLegacy(description)
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -238,7 +223,7 @@ func (s *searchBlackBoxTest) TestUnwantedCharactersRelatedToSearchLogic() {
 	expectedDescription := rendering.NewMarkupContentFromLegacy("Related to http://example-domain:8080/different-path/ok issue")
 
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -382,7 +367,7 @@ func (s *searchBlackBoxTest) TestSearchWorkItemsSpaceContext() {
 	// WI for space 1
 	for i := 0; i < 3; i++ {
 		wi, err := s.wiRepo.Create(
-			s.ctx,
+			s.Ctx,
 			space1.ID,
 			workitem.SystemBug,
 			map[string]interface{}{
@@ -398,7 +383,7 @@ func (s *searchBlackBoxTest) TestSearchWorkItemsSpaceContext() {
 	// WI for space 2
 	for i := 0; i < 5; i++ {
 		wi, err := s.wiRepo.Create(
-			s.ctx,
+			s.Ctx,
 			space2.ID,
 			workitem.SystemBug,
 			map[string]interface{}{
@@ -467,7 +452,7 @@ func (s *searchBlackBoxTest) TestSearchWorkItemsWithoutSpaceContext() {
 	// 10 WI for space 1
 	for i := 0; i < 10; i++ {
 		wi, err := s.wiRepo.Create(
-			s.ctx,
+			s.Ctx,
 			space1.ID,
 			workitem.SystemBug,
 			map[string]interface{}{
@@ -483,7 +468,7 @@ func (s *searchBlackBoxTest) TestSearchWorkItemsWithoutSpaceContext() {
 	// 5 WI for space 2
 	for i := 0; i < 5; i++ {
 		wi, err := s.wiRepo.Create(
-			s.ctx,
+			s.Ctx,
 			space2.ID,
 			workitem.SystemBug,
 			map[string]interface{}{
@@ -506,7 +491,7 @@ func (s *searchBlackBoxTest) TestSearchWorkItemsWithoutSpaceContext() {
 func (s *searchBlackBoxTest) TestSearchFilter() {
 	// given
 	_, err := s.wiRepo.Create(
-		s.ctx,
+		s.Ctx,
 		space.SystemSpace,
 		workitem.SystemBug,
 		map[string]interface{}{
@@ -563,14 +548,14 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 		Name:    "Sprint 1",
 		SpaceID: *spaceInstance.ID,
 	}
-	iterationRepo.Create(s.ctx, &sprint1)
+	iterationRepo.Create(s.Ctx, &sprint1)
 	assert.NotEqual(s.T(), uuid.UUID{}, sprint1.ID)
 
 	sprint2 := iteration.Iteration{
 		Name:    "Sprint 2",
 		SpaceID: *spaceInstance.ID,
 	}
-	iterationRepo.Create(s.ctx, &sprint2)
+	iterationRepo.Create(s.Ctx, &sprint2)
 	assert.NotEqual(s.T(), uuid.UUID{}, sprint2.ID)
 
 	wirepo := workitem.NewWorkItemRepository(s.DB)
@@ -578,7 +563,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 	// create 3 WI with state "resolved" and iteration 1
 	for i := 0; i < 3; i++ {
 		_, err := wirepo.Create(
-			s.ctx, sprint1.SpaceID, workitem.SystemBug,
+			s.Ctx, sprint1.SpaceID, workitem.SystemBug,
 			map[string]interface{}{
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateResolved,
@@ -591,7 +576,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 	// create 5 WI with state "closed" and iteration 2
 	for i := 0; i < 5; i++ {
 		_, err := wirepo.Create(
-			s.ctx, sprint2.SpaceID, workitem.SystemFeature,
+			s.Ctx, sprint2.SpaceID, workitem.SystemFeature,
 			map[string]interface{}{
 				workitem.SystemTitle:     fmt.Sprintf("Closed issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateClosed,
@@ -922,7 +907,7 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 		assert.Len(s.T(), result.Data, 0)
 	})
 	_, err = wirepo.Create(
-		s.ctx, sprint2.SpaceID, workitem.SystemFeature,
+		s.Ctx, sprint2.SpaceID, workitem.SystemFeature,
 		map[string]interface{}{
 			workitem.SystemTitle:     fmt.Sprintf("Unassigned issue"),
 			workitem.SystemState:     workitem.SystemStateClosed,

--- a/controller/work_item_type_group_blackbox_test.go
+++ b/controller/work_item_type_group_blackbox_test.go
@@ -1,15 +1,12 @@
 package controller_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
@@ -23,7 +20,6 @@ import (
 
 type workItemTypeGroupSuite struct {
 	gormtestsupport.DBTestSuite
-	clean         func()
 	svc           *goa.Service
 	typeGroupCtrl *WorkItemTypeGroupController
 }
@@ -35,23 +31,11 @@ func TestRunWorkItemTypeGroupSuite(t *testing.T) {
 	})
 }
 
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *workItemTypeGroupSuite) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
-}
-
 // The SetupTest method will be run before every test in the suite.
 func (s *workItemTypeGroupSuite) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.DBTestSuite.SetupTest()
 	s.svc = testsupport.ServiceAsUser("WITG-Service", testsupport.TestIdentity)
 	s.typeGroupCtrl = NewWorkItemTypeGroupController(s.svc, gormapplication.NewGormDB(s.DB))
-}
-
-func (s *workItemTypeGroupSuite) TearDownTest() {
-	s.clean()
 }
 
 func (s *workItemTypeGroupSuite) TestListTypeGroups() {

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -20,12 +20,10 @@ import (
 	"github.com/fabric8-services/fabric8-wit/configuration"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/log"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/path"
 	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -54,7 +52,6 @@ func TestSuiteWorkItem1(t *testing.T) {
 
 type WorkItemSuite struct {
 	gormtestsupport.DBTestSuite
-	clean          func()
 	workitemCtrl   app.WorkitemController
 	workitemsCtrl  app.WorkitemsController
 	spaceCtrl      app.SpaceController
@@ -62,29 +59,16 @@ type WorkItemSuite struct {
 	wi             *app.WorkItem
 	minimumPayload *app.UpdateWorkitemPayload
 	testIdentity   account.Identity
-	ctx            context.Context
 	repoWit        workitem.WorkItemRepository
 }
 
 func (s *WorkItemSuite) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
-	s.ctx = migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
 	s.repoWit = workitem.NewWorkItemRepository(s.DB)
 }
 
-func (s *WorkItemSuite) TearDownSuite() {
-	if s.DB != nil {
-		s.DB.Close()
-	}
-}
-
-func (s *WorkItemSuite) TearDownTest() {
-	s.clean()
-}
-
 func (s *WorkItemSuite) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.DBTestSuite.SetupTest()
 	// create a test identity
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "WorkItemSuite setup user", "test provider")
 	require.Nil(s.T(), err)
@@ -861,7 +845,6 @@ func ident(id uuid.UUID) *app.GenericData {
 
 type WorkItem2Suite struct {
 	gormtestsupport.DBTestSuite
-	clean          func()
 	workitemCtrl   app.WorkitemController
 	workitemsCtrl  app.WorkitemsController
 	linkCtrl       app.WorkItemLinkController
@@ -871,18 +854,11 @@ type WorkItem2Suite struct {
 	svc            *goa.Service
 	wi             *app.WorkItem
 	minimumPayload *app.UpdateWorkitemPayload
-	ctx            context.Context
 	notification   testsupport.NotificationChannel
 }
 
-func (s *WorkItem2Suite) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
-}
-
 func (s *WorkItem2Suite) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-
+	s.DBTestSuite.SetupTest()
 	s.notification = testsupport.NotificationChannel{}
 	// create identity
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "WorkItem2Suite setup user", "test provider")
@@ -902,10 +878,6 @@ func (s *WorkItem2Suite) SetupTest() {
 	s.wi = wi.Data
 	s.minimumPayload = getMinimumRequiredUpdatePayload(s.wi)
 	//s.minimumReorderPayload = getMinimumRequiredReorderPayload(s.wi)
-}
-
-func (s *WorkItem2Suite) TearDownTest() {
-	s.clean()
 }
 
 // ========== Actual Test functions ==========
@@ -1968,7 +1940,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootAreaIfMissing() {
 		Path:    path.Path{rootArea.ID},
 	}
 	areaRepo := area.NewAreaRepository(s.DB)
-	err := areaRepo.Create(s.ctx, &childArea)
+	err := areaRepo.Create(s.Ctx, &childArea)
 	require.Nil(s.T(), err)
 	log.Info(nil, nil, "child area created")
 	childAreaID := childArea.ID.String()

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -2,7 +2,6 @@ package controller_test
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -13,10 +12,8 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/space"
@@ -42,7 +39,6 @@ import (
 // It implements these interfaces from the suite package: SetupAllSuite, SetupTestSuite, TearDownAllSuite, TearDownTestSuite
 type workItemTypeSuite struct {
 	gormtestsupport.DBTestSuite
-	clean        func()
 	typeCtrl     *WorkitemtypeController
 	linkTypeCtrl *WorkItemLinkTypeController
 	linkCatCtrl  *WorkItemLinkCategoryController
@@ -64,14 +60,12 @@ func TestSuiteWorkItemType(t *testing.T) {
 // It sets up a database connection for all the tests in this suite without polluting global space.
 func (s *workItemTypeSuite) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
 	s.testDir = filepath.Join("test-files", "work_item_type")
 }
 
 // The SetupTest method will be run before every test in the suite.
 func (s *workItemTypeSuite) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.DBTestSuite.SetupTest()
 	idn := &account.Identity{
 		ID:           uuid.Nil,
 		Username:     "TestDeveloper",
@@ -83,10 +77,6 @@ func (s *workItemTypeSuite) SetupTest() {
 	s.typeCtrl = NewWorkitemtypeController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	s.linkTypeCtrl = NewWorkItemLinkTypeController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	s.linkCatCtrl = NewWorkItemLinkCategoryController(s.svc, gormapplication.NewGormDB(s.DB))
-}
-
-func (s *workItemTypeSuite) TearDownTest() {
-	s.clean()
 }
 
 //-----------------------------------------------------------------------------

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -44,23 +44,18 @@ func TestRunServiceBlackBoxTest(t *testing.T) {
 func (s *serviceBlackBoxTest) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 
-	var err error
-	s.configuration, err = config.GetConfigurationData()
-	if err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
-	}
 	req := &http.Request{Host: "api.service.domain.org"}
-	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(req)
+	authEndpoint, err := s.Configuration.GetKeycloakEndpointAuth(req)
 	if err != nil {
 		panic(err)
 	}
-	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(req)
+	tokenEndpoint, err := s.Configuration.GetKeycloakEndpointToken(req)
 	if err != nil {
 		panic(err)
 	}
 	s.oauth = &oauth2.Config{
-		ClientID:     s.configuration.GetKeycloakClientID(),
-		ClientSecret: s.configuration.GetKeycloakSecret(),
+		ClientID:     s.Configuration.GetKeycloakClientID(),
+		ClientSecret: s.Configuration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  authEndpoint,
@@ -98,7 +93,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirect() {
 	}
 
 	r := &http.Request{Host: "demo.api.openshift.io"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
 	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", "", s.getValidRedirectURLs(), "")
@@ -110,7 +105,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirect() {
 
 func (s *serviceBlackBoxTest) getValidRedirectURLs() string {
 	r := &http.Request{Host: "domain.com"}
-	whitelist, err := s.configuration.GetValidRedirectURLs(r)
+	whitelist, err := s.Configuration.GetValidRedirectURLs(r)
 	require.Nil(s.T(), err)
 	return whitelist
 }
@@ -139,7 +134,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirectsToRedirectParam(
 	}
 
 	r := &http.Request{Host: "api.domain.io"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
 	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", "", s.getValidRedirectURLs(), "")
@@ -168,7 +163,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoRefererAndRedirectP
 	}
 
 	r := &http.Request{Host: "api.domain.io"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
 	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", "", s.getValidRedirectURLs(), "")
@@ -197,7 +192,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoValidRefererFails()
 	}
 
 	r := &http.Request{Host: "api.domain.io"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
 	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", "", config.DefaultValidRedirectURLs, "")
@@ -274,9 +269,9 @@ func keycloakLinkRedirect(s *serviceBlackBoxTest, provider string, redirect stri
 	require.Nil(s.T(), err)
 
 	r := &http.Request{Host: "api.example.org"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
-	clientID := s.configuration.GetKeycloakClientID()
+	clientID := s.Configuration.GetKeycloakClientID()
 
 	err = s.loginService.Link(linkCtx, brokerEndpoint, clientID, s.getValidRedirectURLs())
 	require.Nil(s.T(), err)
@@ -315,9 +310,9 @@ func keycloakLinkCallbackRedirect(s *serviceBlackBoxTest, next string) {
 	require.Nil(s.T(), err)
 
 	r := &http.Request{Host: "api.example.org"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
-	clientID := s.configuration.GetKeycloakClientID()
+	clientID := s.Configuration.GetKeycloakClientID()
 
 	err = s.loginService.LinkCallback(linkCtx, brokerEndpoint, clientID)
 	if next != "" {
@@ -359,7 +354,7 @@ func (s *serviceBlackBoxTest) TestInvalidState() {
 	require.Nil(s.T(), err)
 
 	r := &http.Request{Host: "demo.api.openshift.io"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
 	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", "", s.getValidRedirectURLs(), "")
@@ -398,7 +393,7 @@ func (s *serviceBlackBoxTest) TestInvalidOAuthAuthorizationCode() {
 	require.Nil(s.T(), err)
 
 	r := &http.Request{Host: "demo.api.openshift.io"}
-	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
+	brokerEndpoint, err := s.Configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
 	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", "", s.getValidRedirectURLs(), "")

--- a/remoteworkitem/tracker_repository_blackbox_test.go
+++ b/remoteworkitem/tracker_repository_blackbox_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/remoteworkitem"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -17,15 +16,6 @@ import (
 type trackerRepoBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
 	repo application.TrackerRepository
-
-	clean func()
-}
-
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-func (s *trackerRepoBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
 }
 
 func TestRunTrackerRepoBlackBoxTest(t *testing.T) {
@@ -33,12 +23,8 @@ func TestRunTrackerRepoBlackBoxTest(t *testing.T) {
 }
 
 func (s *trackerRepoBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.repo = remoteworkitem.NewTrackerRepository(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-
-func (test *trackerRepoBlackBoxTest) TearDownTest() {
-	test.clean()
 }
 
 func (s *trackerRepoBlackBoxTest) TestFailDeleteZeroID() {

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -7,9 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/search"
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
@@ -28,24 +26,12 @@ func TestRunSearchRepositoryBlackboxTest(t *testing.T) {
 
 type searchRepositoryBlackboxTest struct {
 	gormtestsupport.DBTestSuite
-	clean      func()
 	searchRepo *search.GormSearchRepository
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-func (s *searchRepositoryBlackboxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
-}
-
 func (s *searchRepositoryBlackboxTest) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.DBTestSuite.SetupTest()
 	s.searchRepo = search.NewGormSearchRepository(s.DB)
-}
-
-func (s *searchRepositoryBlackboxTest) TearDownTest() {
-	s.clean()
 }
 
 func (s *searchRepositoryBlackboxTest) getTestFixture() *tf.TestFixture {

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,18 +10,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/models"
 	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
 	"github.com/fabric8-services/fabric8-wit/workitem"
-
-	"context"
-
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
@@ -38,26 +34,14 @@ func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {
 
 type searchRepositoryWhiteboxTest struct {
 	gormtestsupport.DBTestSuite
-	clean      func()
 	modifierID uuid.UUID
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-func (s *searchRepositoryWhiteboxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
-}
-
 func (s *searchRepositoryWhiteboxTest) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.DBTestSuite.SetupTest()
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "jdoe", "test")
 	require.Nil(s.T(), err)
 	s.modifierID = testIdentity.ID
-}
-
-func (s *searchRepositoryWhiteboxTest) TearDownTest() {
-	s.clean()
 }
 
 type SearchTestDescriptor struct {

--- a/workitem/workitem_revision_repository_blackbox_test.go
+++ b/workitem/workitem_revision_repository_blackbox_test.go
@@ -8,9 +8,7 @@ import (
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/account"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
@@ -31,25 +29,15 @@ type workItemRevisionRepositoryBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
 	repository         workitem.WorkItemRepository
 	revisionRepository workitem.RevisionRepository
-	clean              func()
 	testIdentity1      account.Identity
 	testIdentity2      account.Identity
 	testIdentity3      account.Identity
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *workItemRevisionRepositoryBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	ctx := migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(ctx)
-}
-
 func (s *workItemRevisionRepositoryBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.repository = workitem.NewWorkItemRepository(s.DB)
 	s.revisionRepository = workitem.NewRevisionRepository(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 	testIdentity1, err := testsupport.CreateTestIdentity(s.DB, "jdoe1", "test")
 	require.Nil(s.T(), err)
 	s.testIdentity1 = *testIdentity1
@@ -59,10 +47,6 @@ func (s *workItemRevisionRepositoryBlackBoxTest) SetupTest() {
 	testIdentity3, err := testsupport.CreateTestIdentity(s.DB, "jdoe3", "test")
 	require.Nil(s.T(), err)
 	s.testIdentity3 = *testIdentity3
-}
-
-func (s *workItemRevisionRepositoryBlackBoxTest) TearDownTest() {
-	s.clean()
 }
 
 func (s *workItemRevisionRepositoryBlackBoxTest) TestStoreRevisions() {

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -24,16 +24,6 @@ func TestRunWorkItemTypeRepoBlackBoxTest(t *testing.T) {
 	suite.Run(t, &workItemTypeRepoBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-// // SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-// // The SetupSuite method will run before the tests in the suite are run.
-// // It sets up a database connection for all the tests in this suite without polluting global space.
-// func (s *workItemTypeRepoBlackBoxTest) SetupSuite() {
-// 	s.DBTestSuite.SetupSuite()
-// 	req := &http.Request{Host: "localhost"}
-// 	params := url.Values{}
-// 	s.Ctx = goa.NewContext(context.Background(), nil, req, params)
-// }
-
 func (s *workItemTypeRepoBlackBoxTest) SetupTest() {
 	s.DBTestSuite.SetupTest()
 	s.repo = workitem.NewWorkItemTypeRepository(s.DB)

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -1,20 +1,14 @@
 package workitem_test
 
 import (
-	"context"
-	"net/http"
-	"net/url"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-	"github.com/fabric8-services/fabric8-wit/migration"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 
-	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,41 +17,32 @@ import (
 
 type workItemTypeRepoBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
-	clean func()
-	repo  workitem.WorkItemTypeRepository
-	ctx   context.Context
+	repo workitem.WorkItemTypeRepository
 }
 
 func TestRunWorkItemTypeRepoBlackBoxTest(t *testing.T) {
 	suite.Run(t, &workItemTypeRepoBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *workItemTypeRepoBlackBoxTest) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	s.ctx = migration.NewMigrationContext(context.Background())
-	s.DBTestSuite.PopulateDBTestSuite(s.ctx)
-
-	req := &http.Request{Host: "localhost"}
-	params := url.Values{}
-	s.ctx = goa.NewContext(context.Background(), nil, req, params)
-}
+// // SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
+// // The SetupSuite method will run before the tests in the suite are run.
+// // It sets up a database connection for all the tests in this suite without polluting global space.
+// func (s *workItemTypeRepoBlackBoxTest) SetupSuite() {
+// 	s.DBTestSuite.SetupSuite()
+// 	req := &http.Request{Host: "localhost"}
+// 	params := url.Values{}
+// 	s.Ctx = goa.NewContext(context.Background(), nil, req, params)
+// }
 
 func (s *workItemTypeRepoBlackBoxTest) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.DBTestSuite.SetupTest()
 	s.repo = workitem.NewWorkItemTypeRepository(s.DB)
 	workitem.ClearGlobalWorkItemTypeCache()
 }
 
-func (s *workItemTypeRepoBlackBoxTest) TearDownTest() {
-	s.clean()
-}
-
 func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 
-	wit, err := s.repo.Create(s.ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{
+	wit, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{
 		"foo": {
 			Required: true,
 			Type:     &workitem.SimpleType{Kind: workitem.KindFloat},
@@ -68,12 +53,12 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 	require.NotNil(s.T(), wit.ID)
 
 	// Test that we can create a WIT with the same name as before.
-	wit3, err := s.repo.Create(s.ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
+	wit3, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), wit3)
 	require.NotNil(s.T(), wit3.ID)
 
-	wit2, err := s.repo.Load(s.ctx, space.SystemSpace, wit.ID)
+	wit2, err := s.repo.Load(s.Ctx, space.SystemSpace, wit.ID)
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), wit2)
 	require.NotNil(s.T(), wit2.Fields)
@@ -90,7 +75,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestExistsWIT() {
 	t.Run("wit exists", func(t *testing.T) {
 		t.Parallel()
 		// given
-		wit, err := s.repo.Create(s.ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{
+		wit, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{
 			"foo": {
 				Required: true,
 				Type:     &workitem.SimpleType{Kind: workitem.KindFloat},
@@ -100,13 +85,13 @@ func (s *workItemTypeRepoBlackBoxTest) TestExistsWIT() {
 		require.NotNil(s.T(), wit)
 		require.NotNil(s.T(), wit.ID)
 
-		err = s.repo.CheckExists(s.ctx, wit.ID.String())
+		err = s.repo.CheckExists(s.Ctx, wit.ID.String())
 		require.Nil(s.T(), err)
 	})
 
 	t.Run("wit doesn't exist", func(t *testing.T) {
 		t.Parallel()
-		err := s.repo.CheckExists(s.ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
 
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
@@ -114,7 +99,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestExistsWIT() {
 }
 
 func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
-	wit, err := s.repo.Create(s.ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{
+	wit, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{
 		"foo": {
 			Required: true,
 			Type: &workitem.ListType{
@@ -126,12 +111,12 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
 	require.NotNil(s.T(), wit)
 	require.NotNil(s.T(), wit.ID)
 
-	wit3, err := s.repo.Create(s.ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
+	wit3, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, nil, "foo_bar", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), wit3)
 	require.NotNil(s.T(), wit3.ID)
 
-	wit2, err := s.repo.Load(s.ctx, space.SystemSpace, wit.ID)
+	wit2, err := s.repo.Load(s.Ctx, space.SystemSpace, wit.ID)
 	assert.Nil(s.T(), err)
 	require.NotNil(s.T(), wit2)
 	require.NotNil(s.T(), wit2.Fields)
@@ -143,7 +128,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
 
 func (s *workItemTypeRepoBlackBoxTest) TestCreateWITWithBaseType() {
 	basetype := "foo.bar"
-	baseWit, err := s.repo.Create(s.ctx, space.SystemSpace, nil, nil, basetype, nil, "fa-bomb", map[string]workitem.FieldDefinition{
+	baseWit, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, nil, basetype, nil, "fa-bomb", map[string]workitem.FieldDefinition{
 		"foo": {
 			Required: true,
 			Type: &workitem.ListType{
@@ -155,7 +140,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateWITWithBaseType() {
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), baseWit)
 	require.NotNil(s.T(), baseWit.ID)
-	extendedWit, err := s.repo.Create(s.ctx, space.SystemSpace, nil, &baseWit.ID, "foo.baz", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
+	extendedWit, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, &baseWit.ID, "foo.baz", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), extendedWit)
 	require.NotNil(s.T(), extendedWit.Fields)
@@ -165,7 +150,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateWITWithBaseType() {
 
 func (s *workItemTypeRepoBlackBoxTest) TestDoNotCreateWITWithMissingBaseType() {
 	baseTypeID := uuid.Nil
-	extendedWit, err := s.repo.Create(s.ctx, space.SystemSpace, nil, &baseTypeID, "foo.baz", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
+	extendedWit, err := s.repo.Create(s.Ctx, space.SystemSpace, nil, &baseTypeID, "foo.baz", nil, "fa-bomb", map[string]workitem.FieldDefinition{})
 	// expect an error as the given base type does not exist
 	require.NotNil(s.T(), err)
 	require.Nil(s.T(), extendedWit)


### PR DESCRIPTION
Now, each test suite sets up a new migration context and populates the
database with common values.

Also, the SetupTest() now automatically sets up a clean function that is
executed at TearDownTest(). No custom suite implementation needs to do
this manually now. For this to work, if you override SetupTest() you
need to call the embedded function manually.
