### PR TITLE
GOPATH should be set to a single directory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,8 +59,8 @@ Try to use at least version `0.11.0` as we haven't tested another version.
 
 === Get the code [[get-the-code]]
 
-Assuming you have Go installed and configured (have `$GOPATH` setup) here is
-how to build.
+Assuming you have Go installed and configured (have `$GOPATH` setup and
+pointing to a single directory) here is how to build.
 
 Check out the code
 


### PR DESCRIPTION
This document assume the GOPATH is set to a single directory.
Technically it is possible to set multiple directories as the
value for GOPATH environment variable [1].  With multiple
diretctories in the GOPATH, the commands given in the document
will not work as expected.

[1]: https://github.com/golang/go/wiki/GOPATH
