### PR TITLE
[DO NOT MERGE] representation of "empty" labels & assignees

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -847,3 +847,83 @@ func (s *searchBlackBoxTest) TestSearchQueryScenarioDriven() {
 		compareWithGolden(t, filepath.Join(s.testDir, "show", "assignee_null_negate.headers.golden.json"), res.Header())
 	})
 }
+
+func (s *searchBlackBoxTest) TestFilterAssigneeNullAfterWIUpdate() {
+	identitiesTestFixtures := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1), tf.Areas(1), tf.WorkItems(1))
+	spaceInstance := identitiesTestFixtures.Spaces[0]
+	spaceIDStr := spaceInstance.ID.String()
+
+	filter := fmt.Sprintf(`
+							{"assignee":null}`,
+	)
+	_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+	require.NotEmpty(s.T(), result.Data)
+	assert.Len(s.T(), result.Data, 1)
+	wi := result.Data[0]
+	workitemCtrl := NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+
+	wi.Attributes[workitem.SystemTitle] = "Updated Test WI"
+	updatedDescription := "= Updated Test WI description"
+	wi.Attributes[workitem.SystemDescription] = updatedDescription
+	payload2 := app.UpdateWorkitemPayload{
+		Data: &app.WorkItem{
+			Type:       APIStringTypeWorkItem,
+			Attributes: map[string]interface{}{},
+			Relationships: &app.WorkItemRelationships{
+				Space: app.NewSpaceRelation(spaceInstance.ID, ""),
+			},
+		},
+	}
+	payload2.Data.ID = wi.ID
+	payload2.Data.Attributes = wi.Attributes
+	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
+	assert.NotNil(s.T(), updated.Data.Attributes[workitem.SystemCreatedAt])
+	assert.Equal(s.T(), (wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
+	assert.Equal(s.T(), *wi.ID, *updated.Data.ID)
+	assert.Equal(s.T(), wi.Attributes[workitem.SystemTitle], updated.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), updatedDescription, updated.Data.Attributes[workitem.SystemDescription])
+
+	_, result = test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+	require.NotEmpty(s.T(), result.Data)
+	assert.Len(s.T(), result.Data, 1)
+}
+
+func (s *searchBlackBoxTest) TestFilterLabelNullAfterWIUpdate() {
+	identitiesTestFixtures := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1), tf.Areas(1), tf.WorkItems(1))
+	spaceInstance := identitiesTestFixtures.Spaces[0]
+	spaceIDStr := spaceInstance.ID.String()
+
+	filter := fmt.Sprintf(`
+							{"label":null}`,
+	)
+	_, result := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+	require.NotEmpty(s.T(), result.Data)
+	assert.Len(s.T(), result.Data, 1)
+	wi := result.Data[0]
+	workitemCtrl := NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+
+	wi.Attributes[workitem.SystemTitle] = "Updated Test WI"
+	updatedDescription := "= Updated Test WI description"
+	wi.Attributes[workitem.SystemDescription] = updatedDescription
+	payload2 := app.UpdateWorkitemPayload{
+		Data: &app.WorkItem{
+			Type:       APIStringTypeWorkItem,
+			Attributes: map[string]interface{}{},
+			Relationships: &app.WorkItemRelationships{
+				Space: app.NewSpaceRelation(spaceInstance.ID, ""),
+			},
+		},
+	}
+	payload2.Data.ID = wi.ID
+	payload2.Data.Attributes = wi.Attributes
+	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
+	assert.NotNil(s.T(), updated.Data.Attributes[workitem.SystemCreatedAt])
+	assert.Equal(s.T(), (wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
+	assert.Equal(s.T(), *wi.ID, *updated.Data.ID)
+	assert.Equal(s.T(), wi.Attributes[workitem.SystemTitle], updated.Data.Attributes[workitem.SystemTitle])
+	assert.Equal(s.T(), updatedDescription, updated.Data.Attributes[workitem.SystemDescription])
+
+	_, result = test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+	require.NotEmpty(s.T(), result.Data)
+	assert.Len(s.T(), result.Data, 1)
+}

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -881,6 +881,7 @@ func (s *searchBlackBoxTest) TestFilterAssigneeNullAfterWIUpdate() {
 	assert.Equal(s.T(), (wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
 	assert.Equal(s.T(), *wi.ID, *updated.Data.ID)
 	assert.Equal(s.T(), wi.Attributes[workitem.SystemTitle], updated.Data.Attributes[workitem.SystemTitle])
+	assert.Nil(s.T(), wi.Attributes[workitem.SystemAssignees])
 	assert.Equal(s.T(), updatedDescription, updated.Data.Attributes[workitem.SystemDescription])
 
 	_, result = test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
@@ -921,6 +922,7 @@ func (s *searchBlackBoxTest) TestFilterLabelNullAfterWIUpdate() {
 	assert.Equal(s.T(), (wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
 	assert.Equal(s.T(), *wi.ID, *updated.Data.ID)
 	assert.Equal(s.T(), wi.Attributes[workitem.SystemTitle], updated.Data.Attributes[workitem.SystemTitle])
+	assert.Nil(s.T(), wi.Attributes[workitem.SystemLabels])
 	assert.Equal(s.T(), updatedDescription, updated.Data.Attributes[workitem.SystemDescription])
 
 	_, result = test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -349,6 +349,9 @@ func GetMigrations() Migrations {
 	// Version 75
 	m = append(m, steps{ExecuteSQLFile("075-label-unique-name.sql")})
 
+	// Version 76
+	m = append(m, steps{ExecuteSQLFile("076-assignee-and-label-empty-value.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -129,6 +129,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration72", testMigration72)
 	t.Run("TestMigration73", testMigration73)
 	t.Run("TestMigration74", testMigration74)
+	t.Run("TestMigration76", testMigration76)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName); err != nil {
@@ -551,6 +552,13 @@ func testMigration74(t *testing.T) {
 func testMigration75(t *testing.T) {
 	migrateToVersion(sqlDB, migrations[:76], 76)
 	assert.True(t, dialect.HasIndex("labels", "labels_name_space_id_unique_idx"))
+}
+
+func testMigration76(t *testing.T) {
+	migrateToVersion(sqlDB, migrations[:77], 77)
+	count := -1
+	gormDB.Table("work_items").Where("Fields->>'system.labels'='[]'").Count(&count)
+	assert.Equal(t, 0, count)
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/sql-files/076-assignee-and-label-empty-value.sql
+++ b/migration/sql-files/076-assignee-and-label-empty-value.sql
@@ -1,0 +1,2 @@
+update work_items set fields=jsonb_set(fields, '{system.assignees}', 'null') where Fields->>'system.assignees'='[]';
+update work_items set fields=jsonb_set(fields, '{system.labels}', 'null') where Fields->>'system.labels'='[]';

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -178,6 +178,12 @@ func (wit WorkItemType) ConvertWorkItemStorageToModel(workItem WorkItemStorage) 
 		if name == SystemCreatedAt {
 			continue
 		}
+		if name == SystemAssignees && workItem.Fields[name] == nil {
+			continue
+		}
+		if name == SystemLabels && workItem.Fields[name] == nil {
+			continue
+		}
 		result.Fields[name], err = field.ConvertFromModel(name, workItem.Fields[name])
 		if err != nil {
 			return nil, errors.WithStack(err)

--- a/workitem/workitemtype_whitebox_test.go
+++ b/workitem/workitemtype_whitebox_test.go
@@ -1,0 +1,46 @@
+package workitem
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-wit/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertWorkItemStorageToModelEmptyAssigneesAndLabels(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	lt := ListType{
+		SimpleType:    SimpleType{Kind: KindList},
+		ComponentType: SimpleType{Kind: KindString},
+	}
+
+	field := FieldDefinition{
+		Type:     lt,
+		Required: false,
+	}
+
+	wit := WorkItemType{
+		Name: "Empty Values",
+		Fields: map[string]FieldDefinition{
+			SystemAssignees: field,
+			SystemLabels:    field,
+		}}
+
+	wis := WorkItemStorage{Fields: map[string]interface{}{SystemAssignees: nil, SystemLabels: nil}}
+	wi, err := wit.ConvertWorkItemStorageToModel(wis)
+	require.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{}, wi.Fields)
+
+	wis = WorkItemStorage{Fields: map[string]interface{}{SystemAssignees: []interface{}{"a", "b"}, SystemLabels: nil}}
+	wi, err = wit.ConvertWorkItemStorageToModel(wis)
+	require.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{"system.assignees": []interface{}{"a", "b"}, "system.order": float64(0)}, wi.Fields)
+
+	wis = WorkItemStorage{Fields: map[string]interface{}{SystemAssignees: nil, SystemLabels: []interface{}{"a", "b"}}}
+	wi, err = wit.ConvertWorkItemStorageToModel(wis)
+	require.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{"system.labels": []interface{}{"a", "b"}, "system.order": float64(0)}, wi.Fields)
+}


### PR DESCRIPTION
When a new work item is created without lables, then labels data is
stored as "NULL" in the database. When the same work item is update
without labels, it store "[]" as the value in the database. This
behaviour is same for assignees as well.

The data should be set to "NULL" during update (PATCH) as well. Also the
existing data should be migrated to "NULL" values wherever there is "[]"
as value.

Fixes https://openshift.io/openshiftio/openshiftio/plan/detail/1517

**DO NOT MERGE**: I am working on an alternate implementation to store data as empty array.

## TODO

- [x] Test cases in workitem package level
- [x] Test cases for migration