### PR TITLE
Include auth service in make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ regenerate: clean-generated generate
 
 .PHONY: dev
 dev: prebuild-check deps generate $(FRESH_BIN)
-	docker-compose up -d auth
+	docker-compose up -d db auth
 	F8_DEVELOPER_MODE_ENABLED=true $(FRESH_BIN)
 
 include ./.make/test.mk

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ regenerate: clean-generated generate
 
 .PHONY: dev
 dev: prebuild-check deps generate $(FRESH_BIN)
-	docker-compose up -d db
+	docker-compose up -d auth
 	F8_DEVELOPER_MODE_ENABLED=true $(FRESH_BIN)
 
 include ./.make/test.mk

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -814,7 +814,7 @@ const (
 	defaultLogLevel = "info"
 
 	// Auth service URL to be used in dev mode. Can be overridden by setting up auth.url
-	devModeAuthURL = "https://auth.prod-preview.openshift.io"
+	devModeAuthURL = "http://localhost:8089"
 
 	defaultKeycloakClientID = "fabric8-online-platform"
 	defaultKeycloakSecret   = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,16 +7,32 @@ services:
       - "5432:5432"
     environment:
       POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
-    networks:
-      - default
   core:
     image: fabric8-services/fabric8-wit:latest
-    command: -config /usr/local/wit/etc/config.yaml
+#    command: -config /usr/local/wit/etc/config.yaml
     environment:
-      F8_POSTGRES_HOST: db
+      F8_AUTH_URL: "http://localhost:8089"
+      F8_DEVELOPER_MODE_ENABLED: "true"
     ports:
       - "8080:8080"
-    networks:
-      - default
+    network_mode: "host"
     depends_on:
+      - auth
+  db-auth:
+    image: registry.centos.org/postgresql/postgresql:9.6
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
+  auth:
+    image: docker.io/fabric8/fabric8-auth:latest
+#    command: -config /usr/local/auth/etc/config.yaml
+    environment:
+      AUTH_WIT_URL: "http://localhost:8080"
+      AUTH_DEVELOPER_MODE_ENABLED: "true"
+    ports:
+      - "8089:8089"
+    network_mode: "host"
+    depends_on:
+      - db-auth
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,4 +35,3 @@ services:
     network_mode: "host"
     depends_on:
       - db-auth
-      - db


### PR DESCRIPTION
This PR adds new WIT dependencies to the docker compose file on the Auth service and its DB.
So, `make dev` now creates and starts three containers:
- WIT DB
- Auth DB
- Auth

We can't relay on prod-preview auth only because auth needs to create a new user in WIT during login. Otherwise WIT won't have any user in the WIT DB. The workflow is the following:

- User logs into Auth via <auth>/login (if wit api is used then <wit>/login/authorize will redirect to <auth>/login)
- Auth redirects to KC to login and after successful login will creates a new user in the Auth DB and will call WIT to create a new user in WIT. So, Auth need to know the WIT URL.

`make dev` configures all containers so, no additional configuration needed by default.