### PR TITLE
[DO NOT MERGE] representation of "empty" labels & assignees

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -932,8 +932,8 @@ func (s *searchBlackBoxTest) TestIncludedParents() {
 }
 
 func (s *searchBlackBoxTest) TestFilterAssigneeNullAfterWIUpdate() {
-	identitiesTestFixtures := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1), tf.Areas(1), tf.WorkItems(1))
-	spaceInstance := identitiesTestFixtures.Spaces[0]
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1), tf.Areas(1), tf.WorkItems(1))
+	spaceInstance := fxt.Spaces[0]
 	spaceIDStr := spaceInstance.ID.String()
 	filter := fmt.Sprintf(`
 							{"assignee":null}`,
@@ -972,8 +972,8 @@ func (s *searchBlackBoxTest) TestFilterAssigneeNullAfterWIUpdate() {
 }
 
 func (s *searchBlackBoxTest) TestFilterLabelNullAfterWIUpdate() {
-	identitiesTestFixtures := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1), tf.Areas(1), tf.WorkItems(1))
-	spaceInstance := identitiesTestFixtures.Spaces[0]
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1), tf.Areas(1), tf.WorkItems(1))
+	spaceInstance := fxt.Spaces[0]
 	spaceIDStr := spaceInstance.ID.String()
 	filter := fmt.Sprintf(`
 							{"label":null}`,

--- a/controller/workitems.go
+++ b/controller/workitems.go
@@ -168,7 +168,7 @@ func (c *WorkitemsController) List(ctx *app.ListWorkitemsContext) error {
 	}
 	if ctx.FilterAssignee != nil {
 		if *ctx.FilterAssignee == none {
-			exp = criteria.And(exp, criteria.IsNull("system.assignees"))
+			exp = criteria.And(exp, criteria.Literal("Fields->'system.assignees'='[]'"))
 			additionalQuery = append(additionalQuery, "filter[assignee]=none")
 
 		} else {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -352,6 +352,9 @@ func GetMigrations() Migrations {
 	// Version 76
 	m = append(m, steps{ExecuteSQLFile("076-drop-space-resources-and-oauth-state.sql")})
 
+	// Version 77
+	m = append(m, steps{ExecuteSQLFile("077-assignee-and-label-empty-value.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -131,6 +131,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration74", testMigration74)
 	t.Run("TestMigration75", testMigration75)
 	t.Run("TestMigration76", testMigration76)
+	t.Run("TestMigration77", testMigration77)
 
 	// Perform the migration
 	if err := migration.Migrate(sqlDB, databaseName); err != nil {
@@ -559,6 +560,13 @@ func testMigration76(t *testing.T) {
 	migrateToVersion(sqlDB, migrations[:77], 77)
 	assert.False(t, dialect.HasTable("space_resources"))
 	assert.False(t, dialect.HasTable("oauth_state_references"))
+}
+
+func testMigration77(t *testing.T) {
+	migrateToVersion(sqlDB, migrations[:78], 78)
+	count := -1
+	gormDB.Table("work_items").Where("Fields->>'system.labels' IS NULL").Count(&count)
+	assert.Equal(t, 0, count)
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/sql-files/077-assignee-and-label-empty-value.sql
+++ b/migration/sql-files/077-assignee-and-label-empty-value.sql
@@ -1,0 +1,2 @@
+update work_items set fields=jsonb_set(fields, '{system.assignees}', '[]') where Fields->>'system.assignees' is null;
+update work_items set fields=jsonb_set(fields, '{system.labels}', '[]') where Fields->>'system.labels' is null;

--- a/search/query_language_whitebox_test.go
+++ b/search/query_language_whitebox_test.go
@@ -335,8 +335,7 @@ func TestGenerateExpression(t *testing.T) {
 				c.Field("SpaceID"),
 				c.Literal(spaceName),
 			),
-
-			c.IsNull("system.assignees"),
+			c.Literal("Fields->'system.assignees'='[]'"),
 		)
 		expectEqualExpr(t, expectedExpr, actualExpr)
 	})
@@ -350,7 +349,7 @@ func TestGenerateExpression(t *testing.T) {
 		// when
 		actualExpr, _ := q.generateExpression()
 		// then
-		expectedExpr := c.IsNull("system.assignees")
+		expectedExpr := c.Literal("Fields->'system.assignees'='[]'")
 
 		expectEqualExpr(t, expectedExpr, actualExpr)
 	})
@@ -367,8 +366,8 @@ func TestGenerateExpression(t *testing.T) {
 		require.NotNil(t, err)
 		require.Nil(t, actualExpr)
 		assert.Contains(t, err.Error(), "negate for null not supported")
-	})
 
+	})
 	t.Run("NULL value with Negate", func(t *testing.T) {
 		t.Parallel()
 		// given
@@ -386,6 +385,7 @@ func TestGenerateExpression(t *testing.T) {
 		require.NotNil(t, err)
 		require.Nil(t, actualExpr)
 		assert.Contains(t, err.Error(), "negate for null not supported")
+
 	})
 
 }

--- a/workitem/expression_compiler.go
+++ b/workitem/expression_compiler.go
@@ -166,6 +166,11 @@ func isInJSONContext(exp criteria.Expression) bool {
 // you can write "a->'foo' < '5'" and it will return true for the json object { "a": 40 }.
 func (c *expressionCompiler) Literal(v *criteria.LiteralExpression) interface{} {
 	json := isInJSONContext(v)
+	if _, ok := v.Value.(string); ok {
+		if strings.Contains(v.Value.(string), "Fields->") {
+			return v.Value.(string)
+		}
+	}
 	if json {
 		stringVal, err := c.convertToString(v.Value)
 		if err == nil {

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -588,6 +588,9 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, spaceID uuid.UUID, 
 		if err != nil {
 			return nil, errors.NewBadParameterError(fieldName, fieldValue)
 		}
+		if (fieldName == SystemAssignees || fieldName == SystemLabels) && fieldValue == nil {
+			wi.Fields[fieldName] = make([]interface{}, 0)
+		}
 		if fieldName == SystemDescription && wi.Fields[fieldName] != nil {
 			description := rendering.NewMarkupContentFromMap(wi.Fields[fieldName].(map[string]interface{}))
 			if !rendering.IsMarkupSupported(description.Markup) {

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -58,6 +58,16 @@ func (s *workItemRepoBlackBoxTest) TestSave() {
 		assert.Equal(t, oldDate.UTC(), newTime.UTC())
 	})
 
+	s.T().Run("ok - save empty assignees & labels", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItems(1))
+		wi, err := s.repo.Save(s.Ctx, fxt.WorkItems[0].SpaceID, *fxt.WorkItems[0], fxt.Identities[0].ID)
+		// then
+		require.Nil(t, err)
+		require.Len(t, wi.Fields[workitem.SystemAssignees].([]interface{}), 0)
+		require.Len(t, wi.Fields[workitem.SystemLabels].([]interface{}), 0)
+	})
+
 	s.T().Run("change is not prohibited", func(t *testing.T) {
 		// tests that you can change the type of a work item. NOTE: This
 		// functionality only works on the DB layer and is not exposed to REST.
@@ -95,6 +105,19 @@ func (s *workItemRepoBlackBoxTest) TestCreate() {
 		require.Len(t, wi.Fields[workitem.SystemAssignees].([]interface{}), 2)
 		assert.Equal(t, "A", wi.Fields[workitem.SystemAssignees].([]interface{})[0])
 		assert.Equal(t, "B", wi.Fields[workitem.SystemAssignees].([]interface{})[1])
+	})
+
+	s.T().Run("ok - save without assignees & labels", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItems(1, func(fxt *tf.TestFixture, idx int) error {
+			return nil
+		}))
+		// when
+		wi, err := s.repo.LoadByID(s.Ctx, fxt.WorkItems[0].ID)
+		// then
+		require.Nil(t, err)
+		require.Len(t, wi.Fields[workitem.SystemAssignees].([]interface{}), 0)
+		require.Len(t, wi.Fields[workitem.SystemLabels].([]interface{}), 0)
 	})
 
 	s.T().Run("ok - create work item with description no markup", func(t *testing.T) {


### PR DESCRIPTION
When a new work item is created without lables, then labels data is
stored as "NULL" in the database. When the same work item is update
without labels, it store "[]" as the value in the database. This
behaviour is same for assignees as well.

The data should be set to `[]` during insert (POST) as well. Also the
existing data should be migrated to `[]` values wherever there is `NULL`
as value.

Fixes https://openshift.io/openshiftio/openshiftio/plan/detail/1517

**DO NOT MERGE**: I am working on an alternate implementation to store data as empty array.