### PR TITLE
Fix a loop when proxy is used in OS env

### DIFF
--- a/auth/resource.go
+++ b/auth/resource.go
@@ -29,7 +29,7 @@ type AuthzResourceManager struct {
 // AuthServiceConfiguration represents auth service configuration
 type AuthServiceConfiguration interface {
 	GetAuthServiceURL() string
-	GetAuthShortServiceName() string
+	GetAuthShortServiceHostName() string
 	IsAuthorizationEnabled() bool
 }
 

--- a/auth/resource.go
+++ b/auth/resource.go
@@ -29,6 +29,7 @@ type AuthzResourceManager struct {
 // AuthServiceConfiguration represents auth service configuration
 type AuthServiceConfiguration interface {
 	GetAuthServiceURL() string
+	GetAuthShortServiceName() string
 	IsAuthorizationEnabled() bool
 }
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -50,6 +50,7 @@ const (
 	varHTTPAddress                  = "http.address"
 	varDeveloperModeEnabled         = "developer.mode.enabled"
 	varAuthDomainPrefix             = "auth.domain.prefix"
+	varAuthShortServiceName         = "auth.servicename.short"
 	varAuthURL                      = "auth.url"
 	varAuthorizationEnabled         = "authz.enabled"
 	varGithubAuthToken              = "github.auth.token"
@@ -192,6 +193,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// Auth-related defaults
 	c.v.SetDefault(varAuthURL, devModeAuthURL)
 	c.v.SetDefault(varAuthDomainPrefix, "auth")
+	c.v.SetDefault(varAuthShortServiceName, "auth")
 	c.v.SetDefault(varKeycloakClientID, defaultKeycloakClientID)
 	c.v.SetDefault(varKeycloakSecret, defaultKeycloakSecret)
 	c.v.SetDefault(varGithubAuthToken, defaultActualToken)
@@ -486,6 +488,14 @@ func (c *ConfigurationData) GetAuthDevModeURL() string {
 // GetAuthDomainPrefix returns the domain prefix which should be used in requests to the auth service
 func (c *ConfigurationData) GetAuthDomainPrefix() string {
 	return c.v.GetString(varAuthDomainPrefix)
+}
+
+// GetAuthShortServiceName returns the short Auth service name or the full Auth service URL if Dev Mode enabled
+func (c *ConfigurationData) GetAuthShortServiceName() string {
+	if c.IsPostgresDeveloperModeEnabled() {
+		return c.GetAuthServiceURL()
+	}
+	return c.v.GetString(varAuthShortServiceName)
 }
 
 // GetAuthServiceURL returns the Auth Service URL

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -193,7 +193,6 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// Auth-related defaults
 	c.v.SetDefault(varAuthURL, devModeAuthURL)
 	c.v.SetDefault(varAuthDomainPrefix, "auth")
-	c.v.SetDefault(varAuthShortServiceName, "auth")
 	c.v.SetDefault(varKeycloakClientID, defaultKeycloakClientID)
 	c.v.SetDefault(varKeycloakSecret, defaultKeycloakSecret)
 	c.v.SetDefault(varGithubAuthToken, defaultActualToken)
@@ -490,12 +489,16 @@ func (c *ConfigurationData) GetAuthDomainPrefix() string {
 	return c.v.GetString(varAuthDomainPrefix)
 }
 
-// GetAuthShortServiceName returns the short Auth service name or the full Auth service URL if Dev Mode enabled
+// GetAuthShortServiceName returns the short Auth service name
+// or the full Auth service URL if not set and Dev Mode enabled
 func (c *ConfigurationData) GetAuthShortServiceName() string {
+	if c.v.IsSet(varAuthShortServiceName) {
+		return c.v.GetString(varAuthShortServiceName)
+	}
 	if c.IsPostgresDeveloperModeEnabled() {
 		return c.GetAuthServiceURL()
 	}
-	return c.v.GetString(varAuthShortServiceName)
+	return defaultAuthShortServiceName
 }
 
 // GetAuthServiceURL returns the Auth Service URL
@@ -774,6 +777,8 @@ const (
 
 	// Auth service URL to be used in dev mode. Can be overridden by setting up auth.url
 	devModeAuthURL = "http://localhost:8089"
+
+	defaultAuthShortServiceName = "auth"
 
 	defaultKeycloakClientID = "fabric8-online-platform"
 	defaultKeycloakSecret   = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -50,7 +50,7 @@ const (
 	varHTTPAddress                  = "http.address"
 	varDeveloperModeEnabled         = "developer.mode.enabled"
 	varAuthDomainPrefix             = "auth.domain.prefix"
-	varAuthShortServiceName         = "auth.servicename.short"
+	varAuthShortServiceHostName     = "auth.servicehostname.short"
 	varAuthURL                      = "auth.url"
 	varAuthorizationEnabled         = "authz.enabled"
 	varGithubAuthToken              = "github.auth.token"
@@ -489,16 +489,17 @@ func (c *ConfigurationData) GetAuthDomainPrefix() string {
 	return c.v.GetString(varAuthDomainPrefix)
 }
 
-// GetAuthShortServiceName returns the short Auth service name
-// or the full Auth service URL if not set and Dev Mode enabled
-func (c *ConfigurationData) GetAuthShortServiceName() string {
-	if c.v.IsSet(varAuthShortServiceName) {
-		return c.v.GetString(varAuthShortServiceName)
+// GetAuthShortServiceHostName returns the short Auth service host name
+// or the full Auth service URL if not set and Dev Mode enabled.
+// Otherwise returns the default host - http://auth
+func (c *ConfigurationData) GetAuthShortServiceHostName() string {
+	if c.v.IsSet(varAuthShortServiceHostName) {
+		return c.v.GetString(varAuthShortServiceHostName)
 	}
 	if c.IsPostgresDeveloperModeEnabled() {
 		return c.GetAuthServiceURL()
 	}
-	return defaultAuthShortServiceName
+	return defaultAuthShortServiceHostName
 }
 
 // GetAuthServiceURL returns the Auth Service URL
@@ -778,7 +779,7 @@ const (
 	// Auth service URL to be used in dev mode. Can be overridden by setting up auth.url
 	devModeAuthURL = "http://localhost:8089"
 
-	defaultAuthShortServiceName = "auth"
+	defaultAuthShortServiceHostName = "http://auth"
 
 	defaultKeycloakClientID = "fabric8-online-platform"
 	defaultKeycloakSecret   = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -35,25 +35,25 @@ func NewCollaboratorsController(service *goa.Service, config CollaboratorsConfig
 
 // List collaborators for the given space ID.
 func (c *CollaboratorsController) List(ctx *app.ListCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }
 
 // Add user's identity to the list of space collaborators.
 func (c *CollaboratorsController) Add(ctx *app.AddCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }
 
 // AddMany adds user's identities to the list of space collaborators.
 func (c *CollaboratorsController) AddMany(ctx *app.AddManyCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }
 
 // Remove user from the list of space collaborators.
 func (c *CollaboratorsController) Remove(ctx *app.RemoveCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }
 
 // RemoveMany removes users from the list of space collaborators.
 func (c *CollaboratorsController) RemoveMany(ctx *app.RemoveManyCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -35,25 +35,25 @@ func NewCollaboratorsController(service *goa.Service, config CollaboratorsConfig
 
 // List collaborators for the given space ID.
 func (c *CollaboratorsController) List(ctx *app.ListCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }
 
 // Add user's identity to the list of space collaborators.
 func (c *CollaboratorsController) Add(ctx *app.AddCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }
 
 // AddMany adds user's identities to the list of space collaborators.
 func (c *CollaboratorsController) AddMany(ctx *app.AddManyCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }
 
 // Remove user from the list of space collaborators.
 func (c *CollaboratorsController) Remove(ctx *app.RemoveCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }
 
 // RemoveMany removes users from the list of space collaborators.
 func (c *CollaboratorsController) RemoveMany(ctx *app.RemoveManyCollaboratorsContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }

--- a/controller/login.go
+++ b/controller/login.go
@@ -54,7 +54,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 
 // Refresh obtain a new access token using the refresh token.
 func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
-	return proxy.RouteHTTPToPath(ctx, c.configuration.GetAuthShortServiceName(), authservice.RefreshTokenPath())
+	return proxy.RouteHTTPToPath(ctx, c.configuration.GetAuthShortServiceHostName(), authservice.RefreshTokenPath())
 }
 
 // Link links identity provider(s) to the user's account

--- a/controller/login.go
+++ b/controller/login.go
@@ -54,7 +54,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 
 // Refresh obtain a new access token using the refresh token.
 func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
-	return proxy.RouteHTTPToPath(ctx, c.configuration.GetAuthServiceURL(), authservice.RefreshTokenPath())
+	return proxy.RouteHTTPToPath(ctx, c.configuration.GetAuthShortServiceName(), authservice.RefreshTokenPath())
 }
 
 // Link links identity provider(s) to the user's account

--- a/controller/search.go
+++ b/controller/search.go
@@ -186,7 +186,7 @@ func (c *SearchController) Spaces(ctx *app.SpacesSearchContext) error {
 
 // Users runs the user search action.
 func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
-	return proxy.RouteHTTP(ctx, c.configuration.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.configuration.GetAuthShortServiceHostName())
 }
 
 // Iterate over the WI list and read parent IDs

--- a/controller/search.go
+++ b/controller/search.go
@@ -186,7 +186,7 @@ func (c *SearchController) Spaces(ctx *app.SpacesSearchContext) error {
 
 // Users runs the user search action.
 func (c *SearchController) Users(ctx *app.UsersSearchContext) error {
-	return proxy.RouteHTTP(ctx, c.configuration.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.configuration.GetAuthShortServiceName())
 }
 
 // Iterate over the WI list and read parent IDs

--- a/controller/users.go
+++ b/controller/users.go
@@ -50,7 +50,7 @@ func NewUsersController(service *goa.Service, db application.DB, config UsersCon
 
 // Show runs the show action.
 func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }
 
 // CreateUserAsServiceAccount updates a user when requested using a service account token
@@ -288,12 +288,12 @@ func (c *UsersController) updateUserInDB(id *uuid.UUID, ctx *app.UpdateUserAsSer
 
 // Update updates the authorized user based on the provided Token
 func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }
 
 // List runs the list action.
 func (c *UsersController) List(ctx *app.ListUsersContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthServiceURL())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
 }
 
 // ConvertUsersSimple converts a array of simple Identity IDs into a Generic Reletionship List

--- a/controller/users.go
+++ b/controller/users.go
@@ -50,7 +50,7 @@ func NewUsersController(service *goa.Service, db application.DB, config UsersCon
 
 // Show runs the show action.
 func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }
 
 // CreateUserAsServiceAccount updates a user when requested using a service account token
@@ -288,12 +288,12 @@ func (c *UsersController) updateUserInDB(id *uuid.UUID, ctx *app.UpdateUserAsSer
 
 // Update updates the authorized user based on the provided Token
 func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }
 
 // List runs the list action.
 func (c *UsersController) List(ctx *app.ListUsersContext) error {
-	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceName())
+	return proxy.RouteHTTP(ctx, c.config.GetAuthShortServiceHostName())
 }
 
 // ConvertUsersSimple converts a array of simple Identity IDs into a Generic Reletionship List

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -78,7 +78,11 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 		originalReq := &url.URL{Scheme: scheme, Host: originalRequestData.Host, Path: req.URL.Path, RawQuery: req.URL.RawQuery}
 
 		// Modify the request to route to a new target
-		req.URL.Scheme = target.Scheme
+		if target.Scheme == "" {
+			req.URL.Scheme = "http"
+		} else {
+			req.URL.Scheme = target.Scheme
+		}
 		req.URL.Host = target.Host
 		if targetPath != nil {
 			req.URL.Path = *targetPath

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/log"
 
+	"fmt"
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
 )
@@ -109,6 +110,8 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 		log.Info(ctx, map[string]interface{}{
 			"original_req_url": originalReqString,
 			"target_req_url":   targetReqString,
+			"target":           target,
+			"target_string":    target.String(),
 		}, "Routing %s to %s", originalReqString, targetReqString)
 	}
 }

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -104,7 +104,7 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 		}
 		// Remove all *Forwarded* headers from the request because they belong to the original request
 		// and we should not pass them along
-		for key, _ := range req.Header {
+		for key := range req.Header {
 			if strings.Contains(key, "Forwarded") {
 				req.Header.Del(key)
 			}

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/log"
 
-	"fmt"
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
 )

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -118,7 +118,6 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 			"target_req_url":   targetReqString,
 			"target":           target,
 			"target_string":    target.String(),
-			"headers":          req.Header,
 		}, "Routing %s to %s", originalReqString, targetReqString)
 	}
 }

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -118,6 +118,7 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 			"target_req_url":   targetReqString,
 			"target":           target,
 			"target_string":    target.String(),
+			"headers":          req.Header,
 		}, "Routing %s to %s", originalReqString, targetReqString)
 	}
 }

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -102,6 +102,13 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 		if requestID != "" {
 			req.Header.Set("X-Request-ID", requestID)
 		}
+		// Remove all *Forwarded* headers from the request because they belong to the original request
+		// and we should not pass them along
+		for key, _ := range req.Header {
+			if strings.Contains(key, "Forwarded") {
+				req.Header.Del(key)
+			}
+		}
 
 		// Log the original and target URLs
 		originalReqString := originalReq.String()


### PR DESCRIPTION
We have to use the short name of Auth service (auth) in our OS clusters instead of referring to the full Auth URL like https://auth.openshift.io when using reverse proxy. Otherwise the OS routers go crazy and route the traffic which targets auth to the same WIT. So, it's a loop.

Fixes https://github.com/fabric8-services/fabric8-wit/issues/1696