### PR TITLE
Pass on the original scheme

### DIFF
--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -102,13 +102,8 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 		if requestID != "" {
 			req.Header.Set("X-Request-ID", requestID)
 		}
-		// Remove all *Forwarded* headers from the request because they belong to the original request
-		// and we should not pass them along
-		for key := range req.Header {
-			if strings.Contains(key, "Forwarded") {
-				req.Header.Del(key)
-			}
-		}
+
+		req.Header.Set("X-Forwarded-proto", scheme)
 
 		// Log the original and target URLs
 		originalReqString := originalReq.String()

--- a/rest/proxy/proxy.go
+++ b/rest/proxy/proxy.go
@@ -103,8 +103,6 @@ func newDirector(ctx context.Context, originalRequestData *goa.RequestData, targ
 			req.Header.Set("X-Request-ID", requestID)
 		}
 
-		req.Header.Set("X-Forwarded-proto", scheme)
-
 		// Log the original and target URLs
 		originalReqString := originalReq.String()
 		targetReqString := req.URL.String()


### PR DESCRIPTION
This fixes the issue of proxied responses received from Auth has `http` links for all requests , in the related links section. https://github.com/fabric8-services/fabric8-wit/issues/1702


This PR sets the `X-Forwarded-Proto` while starting the proxy request, which would be picked up by the Auth service: 


https://github.com/fabric8-services/fabric8-auth/blob/master/rest/url.go#L20
```
xForwardProto := req.Header.Get("X-Forwarded-Proto")
if xForwardProto != "" {		
      scheme = xForwardProto
}
```