### PR TITLE
`make dev` fails to start because of container connection issue on macOS (#1705)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       F8_DEVELOPER_MODE_ENABLED: "true"
     ports:
       - "8080:8080"
-    network_mode: "host"
     depends_on:
       - auth
   db-auth:
@@ -30,8 +29,9 @@ services:
     environment:
       AUTH_WIT_URL: "http://localhost:8080"
       AUTH_DEVELOPER_MODE_ENABLED: "true"
+      AUTH_POSTGRES_HOST: db-auth
+      AUTH_POSTGRES_PORT: 5432
     ports:
       - "8089:8089"
-    network_mode: "host"
     depends_on:
       - db-auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     environment:
       F8_AUTH_URL: "http://localhost:8089"
       F8_DEVELOPER_MODE_ENABLED: "true"
+      F8_POSTGRES_HOST: db
+      F8_POSTGRES_PORT: 5432
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
remove the `network_mode` option in the containers
specify the host/port for the `auth` service to connect to its `db`, using the
internal Postgres port (5432) and using the container's hostname (the container
name itself)

Fixes #1705

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>