### PR TITLE
'make dev' fails to start because of container connection issue on macOS (#1705)

### DIFF
--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -13,9 +13,10 @@ services:
     environment:
       F8_AUTH_URL: "http://localhost:8089"
       F8_DEVELOPER_MODE_ENABLED: "true"
+      F8_POSTGRES_HOST: db
+      F8_POSTGRES_PORT: 5432
     ports:
       - "8080:8080"
-    network_mode: "host"
     depends_on:
       - auth
   db-auth:
@@ -30,8 +31,9 @@ services:
     environment:
       AUTH_WIT_URL: "http://localhost:8080"
       AUTH_DEVELOPER_MODE_ENABLED: "true"
+      AUTH_POSTGRES_HOST: db-auth
+      AUTH_POSTGRES_PORT: 5432
     ports:
       - "8089:8089"
-    network_mode: "host"
     depends_on:
       - db-auth


### PR DESCRIPTION
keep the previous changes in `docker-compose.macos.yml` for now
revert the changes as they break on Linux

Fixes #1705

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>