### PR TITLE
Deploy WIT and Auth on Minikube instead of Docker Compose (#1724)

### DIFF
--- a/.make/minikube/README.adoc
+++ b/.make/minikube/README.adoc
@@ -1,0 +1,108 @@
+= Deploying the Auth and WIT services on Minikube
+
+
+== Creating the k8s objects for WIT and Auth
+
+Once you have installed Minikube and `kubectl` (make sure you d/l the version that matches the k8s version), run the following commands to create all deployments, replica sets, pods and services in the default namespace:
+
+````
+# auth database
+kubectl create -f fabric8-auth-db-deployment.yml,fabric8-auth-db-service.yml
+# auth app
+kubectl create -f fabric8-auth-deployment.yml,fabric8-auth-service.yml
+# wit database
+kubectl create -f fabric8-wit-db-deployment.yml,fabric8-wit-db-service.yml
+# wit app
+kubectl create -f fabric8-wit-deployment.yml,fabric8-wit-service.yml
+````
+
+Once all scripts passed, the Kubernetes objects will be avaiable:
+
+````
+> kubectl get all
+NAME                                  READY     STATUS    RESTARTS   AGE
+po/fabric8-auth-4268511339-tf1x3      1/1       Running   0          23m
+po/fabric8-auth-db-2232448541-qb2st   1/1       Running   0          22m
+po/fabric8-wit-920862249-66jgc        1/1       Running   0          17m
+po/fabric8-wit-db-366674767-7g5p7     1/1       Running   0          21m
+
+NAME                      CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
+svc/fabric8-auth-db-svc   10.0.0.171   <none>        5432/TCP       24m
+svc/fabric8-auth-svc      10.0.0.69    <nodes>       80:32089/TCP   5m
+svc/fabric8-wit-db-svc    10.0.0.46    <none>        5432/TCP       21m
+svc/fabric8-wit-svc       10.0.0.115   <nodes>       80:32080/TCP   5m
+
+NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deploy/fabric8-auth      1         1         1            1           23m
+deploy/fabric8-auth-db   1         1         1            1           24m
+deploy/fabric8-wit       1         1         1            1           21m
+deploy/fabric8-wit-db    1         1         1            1           21m
+
+NAME                            DESIRED   CURRENT   READY     AGE
+rs/fabric8-auth-4268511339      1         1         1         23m
+rs/fabric8-auth-db-2232448541   1         1         1         22m
+rs/fabric8-wit-920862249        1         1         1         17m
+rs/fabric8-wit-db-366674767     1         1         1         21m
+````
+
+
+Once the `kubectl create` commands for `auth` and `wit` have passed, you should be able to access the `auth` service on `http://$(minikube ip):32089`
+
+````
+> curl http://$(minikube ip):32089/api/status
+{"buildTime":"2017-10-15T17:29:19Z","commit":"26e19df61b885a92774632f23bb5590c5f768a31","startTime":"2017-10-20T09:09:41Z"}
+````
+
+and the `wit` service on `http://$(minikube ip):32080`:
+
+````
+curl http://$(minikube ip):32080/api/status
+{"buildTime":"2017-10-19T14:58:19Z","commit":"2a8fd6b0eace6fc17db9245b1dfda829534378a3","startTime":"2017-10-20T09:18:39Z"}
+````
+
+== Connecting to the services with custom hostnames
+
+You can also connect to the `auth` and `wit` services using their respective service names using the following hack:
+
+Add the following entries in `/etc/hosts`:
+
+````
+192.168.99.100 fabric8-auth-svc fabric8-wit-svc
+````
+(where `192.168.99.100` is the result of `minikube ip`)
+
+then create an ingress for each service:
+
+````
+# enable the ingress addon
+minikube addons enable ingress
+# auth ingress
+kubectl create -f fabric8-auth-ingress.yml,fabric8-auth-ingress.yml
+````
+
+From the host, you now have access to the service using:
+
+````
+> curl http://fabric8-wit-svc/api/status
+{"buildTime":"2017-10-19T14:58:19Z","commit":"2a8fd6b0eace6fc17db9245b1dfda829534378a3","startTime":"2017-10-20T15:43:31Z"}
+````
+
+With the special configuration where the DNS entries match the k8s service names and the services use the port `80` internally and externally with the ingresses, we can have the same URLs for inter-services and browser-to-service communication.
+
+== Using a custom namespace
+
+Optionally, if you want to use a custom namespace for the Fabric8 services, you can run the following commands prior to the one above:
+
+````
+> kubectl create -f fabric8-namespace.yml
+
+````
+
+From now on, you can either use the `--namespace=fabric8` option to specify that the kubectl commands must run within the `fabric8` namespace, or you can set `fabric8` as the default namespace in the config context:
+
+````
+> kubectl config set-context $(kubectl config current-context) --namespace=fabric8
+Context “minikube” modified.
+````
+
+

--- a/.make/minikube/fabric8-auth-db-deployment.yml
+++ b/.make/minikube/fabric8-auth-db-deployment.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fabric8-auth-db
+spec:
+  template:
+    metadata:
+      labels:
+        app: fabric8-auth-db
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:9.6.5
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          value: fabric8-auth-db
+        - name: POSTGRES_USER
+          value: fabric8-auth-user
+        - name: POSTGRES_PASSWORD
+          value: mysecretpassword

--- a/.make/minikube/fabric8-auth-db-service.yml
+++ b/.make/minikube/fabric8-auth-db-service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fabric8-auth-db-svc
+spec:
+  ports:
+  - port: 5432
+  selector:
+    app: fabric8-auth-db
+    

--- a/.make/minikube/fabric8-auth-deployment.yml
+++ b/.make/minikube/fabric8-auth-deployment.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fabric8-auth
+spec:
+  template:
+    metadata:
+      labels:
+        app: fabric8-auth
+    spec:
+      containers:
+      - name: fabric8-auth
+        image: docker.io/fabric8/fabric8-auth:latest
+        env:
+        - name: AUTH_WIT_URL
+          value: http://fabric8-wit-svc:8080
+        - name: AUTH_DEVELOPER_MODE_ENABLED
+          value: "true"
+        - name: AUTH_POSTGRES_HOST
+          value: fabric8-auth-db-svc
+        - name: AUTH_POSTGRES_PORT
+          value: "5432"
+        - name: AUTH_POSTGRES_DATABASE
+          value: fabric8-auth-db
+        - name: AUTH_POSTGRES_USER
+          value: fabric8-auth-user
+        - name: AUTH_POSTGRES_PASSWORD
+          value: mysecretpassword
+        ports:
+        - containerPort: 8089

--- a/.make/minikube/fabric8-auth-ingress.yml
+++ b/.make/minikube/fabric8-auth-ingress.yml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: fabric8-auth-ingress
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: fabric8-auth-svc
+    http:
+      paths:
+      - backend:
+          serviceName: fabric8-auth-svc
+          servicePort: 80

--- a/.make/minikube/fabric8-auth-service.yml
+++ b/.make/minikube/fabric8-auth-service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fabric8-auth-svc
+spec:
+  type: NodePort
+  ports:
+    - nodePort: 32089
+      port: 80
+      protocol: TCP
+      targetPort: 8089
+  selector:
+    app: fabric8-auth

--- a/.make/minikube/fabric8-namespace.yml
+++ b/.make/minikube/fabric8-namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: fabric8

--- a/.make/minikube/fabric8-wit-db-deployment.yml
+++ b/.make/minikube/fabric8-wit-db-deployment.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fabric8-wit-db
+spec:
+  template:
+    metadata:
+      labels:
+        app: fabric8-wit-db
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:9.6.5
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          value: fabric8-wit-db
+        - name: POSTGRES_USER
+          value: fabric8-wit-user
+        - name: POSTGRES_PASSWORD
+          value: mysecretpassword

--- a/.make/minikube/fabric8-wit-db-service.yml
+++ b/.make/minikube/fabric8-wit-db-service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fabric8-wit-db-svc
+spec:
+  ports:
+  - port: 5432
+  selector:
+    app: fabric8-wit-db
+    

--- a/.make/minikube/fabric8-wit-deployment.yml
+++ b/.make/minikube/fabric8-wit-deployment.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fabric8-wit
+spec:
+  template:
+    metadata:
+      labels:
+        app: fabric8-wit
+    spec:
+      containers:
+      - name: fabric8-wit
+        image: docker.io/fabric8/fabric8-wit:latest
+        env:
+        - name: F8_AUTH_URL
+          value: http://fabric8-auth-svc
+        - name: F8_DEVELOPER_MODE_ENABLED
+          value: "true"
+        - name: F8_POSTGRES_HOST
+          value: fabric8-wit-db-svc
+        - name: F8_POSTGRES_PORT
+          value: "5432"
+        - name: F8_POSTGRES_DATABASE
+          value: fabric8-wit-db
+        - name: F8_POSTGRES_USER
+          value: fabric8-wit-user
+        - name: F8_POSTGRES_PASSWORD
+          value: mysecretpassword
+        ports:
+        - containerPort: 8080

--- a/.make/minikube/fabric8-wit-ingress.yml
+++ b/.make/minikube/fabric8-wit-ingress.yml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: fabric8-wit-ingress
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: fabric8-wit-svc
+    http:
+      paths:
+      - backend:
+          serviceName: fabric8-wit-svc
+          servicePort: 80

--- a/.make/minikube/fabric8-wit-service.yml
+++ b/.make/minikube/fabric8-wit-service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fabric8-wit-svc
+spec:
+  type: NodePort
+  ports:
+    - nodePort: 32080
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: fabric8-wit


### PR DESCRIPTION
Include template to deploy `auth` and its `db`, exposing the db
as a service within the cluster and the `auth` as a node service, ie,
can be accessed from the host machine (if needed)
Same deployment/service strategy for `WIT` and its db.
Also include ingresses to access the service from `fabric8-wit-svc`
and `fabric8-auth-svc` host name (but they need to be added into
`/etc/hosts` beforehand)

Fixes #1724

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>