### PR TITLE
Make the parenting link type have a tree-topology

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -878,7 +878,7 @@ func (s *searchBlackBoxTest) TestIncludedParents() {
 		tf.WorkItemLinkTypes(1, func(fxt *tf.TestFixture, idx int) error {
 			wilt := fxt.WorkItemLinkTypes[idx]
 			wilt.ForwardName = link.TypeParentOf
-			wilt.Topology = link.TopologyNetwork
+			wilt.Topology = link.TopologyTree
 			return nil
 		}),
 		tf.WorkItemLinks(3, func(fxt *tf.TestFixture, idx int) error {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -583,7 +583,7 @@ func BootstrapWorkItemLinking(ctx context.Context, linkCatRepo *link.GormWorkIte
 		ID:             link.SystemWorkItemLinkTypeParentChildID,
 		Name:           "Parent child item",
 		Description:    &parentingDesc,
-		Topology:       link.TopologyNetwork,
+		Topology:       link.TopologyTree,
 		ForwardName:    "parent of",
 		ReverseName:    "child of",
 		LinkCategoryID: systemCat.ID,

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -473,7 +473,7 @@ func (r *GormWorkItemLinkRepository) GetParentID(ctx context.Context, ID uuid.UU
 		workitem.WorkItemStorage{}.TableName(),
 		WorkItemLink{}.TableName(),
 		WorkItemLinkType{}.TableName(),
-		TopologyNetwork)
+		TopologyTree)
 	var parentID uuid.UUID
 	db := r.db.CommonDB()
 	err := db.QueryRow(query, ID.String()).Scan(&parentID)

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -171,6 +171,22 @@ func (s *linkRepoBlackBoxTest) TestCreate() {
 		// then expect an error because a parent/link relation already exists with the child item
 		require.NotNil(t, err)
 	})
+
+	s.T().Run("fail - multiple parents with tree-topology-based link type", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.WorkItems(3, tf.SetWorkItemTitles("parent1", "parent2", "child")),
+			tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyTree), tf.SetWorkItemLinkTypeNames("tree-type")),
+		)
+		// when creating link between "parent1" and "child"
+		_, err := s.workitemLinkRepo.Create(s.Ctx, fxt.WorkItemByTitle("parent1").ID, fxt.WorkItemByTitle("child").ID, fxt.WorkItemLinkTypeByName("tree-type").ID, fxt.Identities[0].ID)
+		// then it works
+		require.Nil(t, err)
+		// when creating link between "parent2" and "child"
+		_, err = s.workitemLinkRepo.Create(s.Ctx, fxt.WorkItemByTitle("parent2").ID, fxt.WorkItemByTitle("child").ID, fxt.WorkItemLinkTypeByName("tree-type").ID, fxt.Identities[0].ID)
+		// then we expect an error because "child" is already a child of "parent1"
+		require.NotNil(t, err)
+	})
 }
 
 func (s *linkRepoBlackBoxTest) TestSave() {

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -212,7 +212,7 @@ func (s *linkRepoBlackBoxTest) TestExistsLink() {
 
 func (s *linkRepoBlackBoxTest) TestGetParentID() {
 	// create 1 links between 2 work items having TopologyNetwork with ForwardName = "parent of"
-	fixtures := tf.NewTestFixture(s.T(), s.DB, tf.WorkItemLinks(1), tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyNetwork), func(fxt *tf.TestFixture, idx int) error {
+	fixtures := tf.NewTestFixture(s.T(), s.DB, tf.WorkItemLinks(1), tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyTree), func(fxt *tf.TestFixture, idx int) error {
 		fxt.WorkItemLinkTypes[idx].ForwardName = "parent of"
 		return nil
 	}))
@@ -223,7 +223,7 @@ func (s *linkRepoBlackBoxTest) TestGetParentID() {
 
 func (s *linkRepoBlackBoxTest) TestGetParentIDNotExist() {
 	// create 1 links between 2 work items having TopologyNetwork with ForwardName = "parent of"
-	fixtures := tf.NewTestFixture(s.T(), s.DB, tf.WorkItemLinks(1), tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyNetwork), func(fxt *tf.TestFixture, idx int) error {
+	fixtures := tf.NewTestFixture(s.T(), s.DB, tf.WorkItemLinks(1), tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyTree), func(fxt *tf.TestFixture, idx int) error {
 		fxt.WorkItemLinkTypes[idx].ForwardName = "parent of"
 		return nil
 	}))

--- a/workitem/link/topology.go
+++ b/workitem/link/topology.go
@@ -32,13 +32,7 @@ const (
 // BadParameterError is returned.
 func (t Topology) CheckValid() error {
 	switch t {
-	case TopologyNetwork:
-		return nil
-	case TopologyDirectedNetwork:
-		return nil
-	case TopologyDependency:
-		return nil
-	case TopologyTree:
+	case TopologyNetwork, TopologyDirectedNetwork, TopologyDependency, TopologyTree:
 		return nil
 	default:
 		return errors.NewBadParameterError("topolgy", t).Expected(TopologyNetwork + "|" + TopologyDirectedNetwork + "|" + TopologyDependency + "|" + TopologyTree)


### PR DESCRIPTION
Based on [this discussion](https://chat.openshift.io/developers/pl/gqwxx3mj13fejfdwqqc61mrwba) we decided to make the parenting link type have a tree topology.

See also https://github.com/fabric8-ui/fabric8-planner/pull/2291#issuecomment-339278719