### PR TITLE
Check GOPATH from 'go env GOPATH' when running 'make'

### DIFF
--- a/.make/check_gopath.go
+++ b/.make/check_gopath.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -35,6 +36,15 @@ func main() {
 				os.Exit(0)
 			}
 		}
+	}
+
+	goEnvCmd := exec.Command("go", "env", "GOPATH")
+	goEnvOut, err := goEnvCmd.Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if wd == filepath.Join(strings.TrimSpace(string(goEnvOut)), "src", packageName) {
+		os.Exit(0)
 	}
 
 	goPathStr := path.Join("$GOPATH", "src", packageName)


### PR DESCRIPTION
When running 'make', the GOPATH environment variable is used to determine if the project is in the correct location. This patch changes this step to also try to determine GOPATH from 'go env GOPATH'.

Addresses #1728
