### PR TITLE
test to verify that create-child-iteration-API uses payload.ID correctly

### DIFF
--- a/controller/iteration.go
+++ b/controller/iteration.go
@@ -96,9 +96,6 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 			EndAt:       reqIter.Attributes.EndAt,
 			UserActive:  *reqIter.Attributes.UserActive,
 		}
-		if reqIter.ID != nil {
-			newItr.ID = *reqIter.ID
-		}
 		err = appl.Iterations().Create(ctx, &newItr)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/iteration.go
+++ b/controller/iteration.go
@@ -96,6 +96,9 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 			EndAt:       reqIter.Attributes.EndAt,
 			UserActive:  *reqIter.Attributes.UserActive,
 		}
+		if reqIter.ID != nil {
+			newItr.ID = *reqIter.ID
+		}
 		err = appl.Iterations().Create(ctx, &newItr)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -110,9 +110,9 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		ci := getChildIterationPayload(&name)
 		id := uuid.NewV4()
 		ci.Data.ID = &id // set different ID and it must be ignoed by controller
-		startAt, err := time.Parse(time.RFC3339, "2017-11-04T15:08:41+00:00")
+		startAt, err := time.Parse(time.RFC3339, "2016-11-04T15:08:41+00:00")
 		require.Nil(t, err)
-		endAt, err := time.Parse(time.RFC3339, "2017-11-25T15:08:41+00:00")
+		endAt, err := time.Parse(time.RFC3339, "2016-11-25T15:08:41+00:00")
 		require.Nil(t, err)
 		ci.Data.Attributes.StartAt = &startAt
 		ci.Data.Attributes.EndAt = &endAt

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -122,7 +122,7 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		// then
 		require.NotNil(t, created)
 		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_ID_paylod.golden.json"), created)
-		require.NotEqual(t, *ci.Data.ID, *created.Data.ID)
+		require.Equal(t, *ci.Data.ID, *created.Data.ID)
 	})
 
 	rest.T().Run("forbidden - only space owener can create child iteration", func(t *testing.T) {

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -78,8 +78,7 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 
 	rest.T().Run("success - create child iteration", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, rest.DB,
-			tf.Identities(1),
-			tf.Areas(1),
+			tf.CreateWorkItemEnvironment(),
 			tf.Iterations(2,
 				tf.SetIterationNames("root iteration", "child iteration"),
 				tf.PlaceIterationUnderRootIteration()))
@@ -102,15 +101,15 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 	rest.T().Run("success - create child iteration with ID in request payload", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, rest.DB,
-			tf.Identities(1),
-			tf.Areas(1),
+			tf.CreateWorkItemEnvironment(),
 			tf.Iterations(2,
 				tf.SetIterationNames("root iteration", "child iteration"),
 				tf.PlaceIterationUnderRootIteration()))
 		name := "Sprint #21"
 		childItr := fxt.IterationByName("child iteration")
 		ci := getChildIterationPayload(&name)
-		ci.Data.ID = &childItr.ID // set ID of parent and it must be ignoed by controller
+		id := uuid.NewV4()
+		ci.Data.ID = &id // set different ID and it must be ignoed by controller
 		startAt, err := time.Parse(time.RFC3339, "2017-11-04T15:08:41+00:00")
 		require.Nil(t, err)
 		endAt, err := time.Parse(time.RFC3339, "2017-11-25T15:08:41+00:00")
@@ -123,6 +122,7 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		// then
 		require.NotNil(t, created)
 		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_ID_paylod.golden.json"), created)
+		require.NotEqual(t, *ci.Data.ID, *created.Data.ID)
 	})
 
 	rest.T().Run("forbidden - only space owener can create child iteration", func(t *testing.T) {

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -104,7 +104,7 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			tf.CreateWorkItemEnvironment(),
 			tf.Iterations(2,
 				tf.SetIterationNames("root iteration", "child iteration"),
-				tf.PlaceIterationUnderRootIteration()))
+			))
 		name := "Sprint #21"
 		childItr := fxt.IterationByName("child iteration")
 		ci := getChildIterationPayload(&name)

--- a/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
@@ -1,0 +1,54 @@
+{
+  "data": {
+    "attributes": {
+      "active_status": true,
+      "created-at": "0001-01-01T00:00:00Z",
+      "description": "Some description",
+      "endAt": "2017-11-26T13:12:56.519317245+05:30",
+      "name": "Sprint #21",
+      "parent_path": "/d34fd7b7-63ba-4a31-8535-73016ce4b945/cadac76d-3fd1-42ba-8814-b0f034de2a2d",
+      "resolved_parent_path": "/root iteration/child iteration",
+      "startAt": "2017-11-02T13:12:56.519317245+05:30",
+      "state": "new",
+      "updated-at": "0001-01-01T00:00:00Z",
+      "user_active": false
+    },
+    "id": "6fcda61d-d79e-4fc0-9170-918978a13ff7",
+    "links": {
+      "related": "http:///api/iterations/6fcda61d-d79e-4fc0-9170-918978a13ff7",
+      "self": "http:///api/iterations/6fcda61d-d79e-4fc0-9170-918978a13ff7"
+    },
+    "relationships": {
+      "parent": {
+        "data": {
+          "id": "cadac76d-3fd1-42ba-8814-b0f034de2a2d",
+          "type": "iterations"
+        },
+        "links": {
+          "related": "http:///api/iterations/cadac76d-3fd1-42ba-8814-b0f034de2a2d",
+          "self": "http:///api/iterations/cadac76d-3fd1-42ba-8814-b0f034de2a2d"
+        }
+      },
+      "space": {
+        "data": {
+          "id": "2b488c80-513d-45af-b061-50230b95444e",
+          "type": "spaces"
+        },
+        "links": {
+          "related": "http:///api/spaces/2b488c80-513d-45af-b061-50230b95444e",
+          "self": "http:///api/spaces/2b488c80-513d-45af-b061-50230b95444e"
+        }
+      },
+      "workitems": {
+        "links": {
+          "related": "http:///api/workitems/?filter[iteration]=6fcda61d-d79e-4fc0-9170-918978a13ff7"
+        },
+        "meta": {
+          "closed": 0,
+          "total": 0
+        }
+      }
+    },
+    "type": "iterations"
+  }
+}

--- a/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
@@ -1,47 +1,47 @@
 {
   "data": {
     "attributes": {
-      "active_status": true,
+      "active_status": false,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2017-11-26T13:12:56.519317245+05:30",
+      "endAt": "2017-11-25T15:08:41Z",
       "name": "Sprint #21",
-      "parent_path": "/d34fd7b7-63ba-4a31-8535-73016ce4b945/cadac76d-3fd1-42ba-8814-b0f034de2a2d",
+      "parent_path": "/8319dda7-0e91-4445-9d7e-4964b024c917/67d326b8-d182-4fcb-b9e0-868bb08b155c",
       "resolved_parent_path": "/root iteration/child iteration",
-      "startAt": "2017-11-02T13:12:56.519317245+05:30",
+      "startAt": "2017-11-04T15:08:41Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false
     },
-    "id": "6fcda61d-d79e-4fc0-9170-918978a13ff7",
+    "id": "ee678073-2645-4ff3-afc7-a94b79e46546",
     "links": {
-      "related": "http:///api/iterations/6fcda61d-d79e-4fc0-9170-918978a13ff7",
-      "self": "http:///api/iterations/6fcda61d-d79e-4fc0-9170-918978a13ff7"
+      "related": "http:///api/iterations/ee678073-2645-4ff3-afc7-a94b79e46546",
+      "self": "http:///api/iterations/ee678073-2645-4ff3-afc7-a94b79e46546"
     },
     "relationships": {
       "parent": {
         "data": {
-          "id": "cadac76d-3fd1-42ba-8814-b0f034de2a2d",
+          "id": "67d326b8-d182-4fcb-b9e0-868bb08b155c",
           "type": "iterations"
         },
         "links": {
-          "related": "http:///api/iterations/cadac76d-3fd1-42ba-8814-b0f034de2a2d",
-          "self": "http:///api/iterations/cadac76d-3fd1-42ba-8814-b0f034de2a2d"
+          "related": "http:///api/iterations/67d326b8-d182-4fcb-b9e0-868bb08b155c",
+          "self": "http:///api/iterations/67d326b8-d182-4fcb-b9e0-868bb08b155c"
         }
       },
       "space": {
         "data": {
-          "id": "2b488c80-513d-45af-b061-50230b95444e",
+          "id": "f18bc172-6865-464d-9a06-390d3e6284d0",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2b488c80-513d-45af-b061-50230b95444e",
-          "self": "http:///api/spaces/2b488c80-513d-45af-b061-50230b95444e"
+          "related": "http:///api/spaces/f18bc172-6865-464d-9a06-390d3e6284d0",
+          "self": "http:///api/spaces/f18bc172-6865-464d-9a06-390d3e6284d0"
         }
       },
       "workitems": {
         "links": {
-          "related": "http:///api/workitems/?filter[iteration]=6fcda61d-d79e-4fc0-9170-918978a13ff7"
+          "related": "http:///api/workitems/?filter[iteration]=ee678073-2645-4ff3-afc7-a94b79e46546"
         },
         "meta": {
           "closed": 0,

--- a/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
@@ -4,11 +4,11 @@
       "active_status": false,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2017-11-25T15:08:41Z",
+      "endAt": "2016-11-25T15:08:41Z",
       "name": "Sprint #21",
       "parent_path": "/8319dda7-0e91-4445-9d7e-4964b024c917/67d326b8-d182-4fcb-b9e0-868bb08b155c",
       "resolved_parent_path": "/root iteration/child iteration",
-      "startAt": "2017-11-04T15:08:41Z",
+      "startAt": "2016-11-04T15:08:41Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false


### PR DESCRIPTION
Added a test to verify that when create-iteration payload has ID in it then it will be used as PK.