### PR TITLE
Fix test failures with golden file (openshiftio/openshift.io#1246)

### DIFF
--- a/controller/test-files/search/search_codebase_per_url_multi_match.json
+++ b/controller/test-files/search/search_codebase_per_url_multi_match.json
@@ -8,21 +8,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "80f43ec6-8889-4ec6-81f6-bede08f4c36a",
+      "id": "3bd4d12f-fc2a-42dd-bcde-329fc69ef98c",
       "links": {
-        "edit": "http:///api/codebases/80f43ec6-8889-4ec6-81f6-bede08f4c36a/edit",
-        "related": "http:///api/codebases/80f43ec6-8889-4ec6-81f6-bede08f4c36a",
-        "self": "http:///api/codebases/80f43ec6-8889-4ec6-81f6-bede08f4c36a"
+        "edit": "http:///api/codebases/3bd4d12f-fc2a-42dd-bcde-329fc69ef98c/edit",
+        "related": "http:///api/codebases/3bd4d12f-fc2a-42dd-bcde-329fc69ef98c",
+        "self": "http:///api/codebases/3bd4d12f-fc2a-42dd-bcde-329fc69ef98c"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "15cc6ff2-4013-49fa-8229-8a03caf34280",
+            "id": "262de8f6-1e88-492b-b357-1768db5647e5",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280",
-            "self": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5",
+            "self": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5"
           }
         }
       },
@@ -36,21 +36,105 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "e0445563-3bbb-49bc-a181-52f2dea5bcf6",
+      "id": "dc2d9c8a-0842-43a1-922a-00a1ae76313f",
       "links": {
-        "edit": "http:///api/codebases/e0445563-3bbb-49bc-a181-52f2dea5bcf6/edit",
-        "related": "http:///api/codebases/e0445563-3bbb-49bc-a181-52f2dea5bcf6",
-        "self": "http:///api/codebases/e0445563-3bbb-49bc-a181-52f2dea5bcf6"
+        "edit": "http:///api/codebases/dc2d9c8a-0842-43a1-922a-00a1ae76313f/edit",
+        "related": "http:///api/codebases/dc2d9c8a-0842-43a1-922a-00a1ae76313f",
+        "self": "http:///api/codebases/dc2d9c8a-0842-43a1-922a-00a1ae76313f"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "b43e277c-be5a-43cb-86c9-88ccef7017a1",
+            "id": "478b96bb-68e2-4285-9b77-e47d10ed83cd",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1",
-            "self": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd",
+            "self": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd"
+          }
+        }
+      },
+      "type": "codebases"
+    },
+    {
+      "attributes": {
+        "createdAt": "0001-01-01T00:00:00Z",
+        "last_used_workspace": "my-used-last-workspace",
+        "stackId": "golang-default",
+        "type": "git",
+        "url": "http://foo.com/multi/0"
+      },
+      "id": "9edc1dfe-f845-4abc-831f-a90cd06ec4d3",
+      "links": {
+        "edit": "http:///api/codebases/9edc1dfe-f845-4abc-831f-a90cd06ec4d3/edit",
+        "related": "http:///api/codebases/9edc1dfe-f845-4abc-831f-a90cd06ec4d3",
+        "self": "http:///api/codebases/9edc1dfe-f845-4abc-831f-a90cd06ec4d3"
+      },
+      "relationships": {
+        "space": {
+          "data": {
+            "id": "59848f9f-b5bd-4183-8325-465f8ec384f6",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6",
+            "self": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6"
+          }
+        }
+      },
+      "type": "codebases"
+    },
+    {
+      "attributes": {
+        "createdAt": "0001-01-01T00:00:00Z",
+        "last_used_workspace": "my-used-last-workspace",
+        "stackId": "golang-default",
+        "type": "git",
+        "url": "http://foo.com/multi/0"
+      },
+      "id": "e93f8371-93d9-47cd-910b-eb1157a126db",
+      "links": {
+        "edit": "http:///api/codebases/e93f8371-93d9-47cd-910b-eb1157a126db/edit",
+        "related": "http:///api/codebases/e93f8371-93d9-47cd-910b-eb1157a126db",
+        "self": "http:///api/codebases/e93f8371-93d9-47cd-910b-eb1157a126db"
+      },
+      "relationships": {
+        "space": {
+          "data": {
+            "id": "9829d8fb-cba6-4338-8cba-dab08bea5a13",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13",
+            "self": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13"
+          }
+        }
+      },
+      "type": "codebases"
+    },
+    {
+      "attributes": {
+        "createdAt": "0001-01-01T00:00:00Z",
+        "last_used_workspace": "my-used-last-workspace",
+        "stackId": "golang-default",
+        "type": "git",
+        "url": "http://foo.com/multi/0"
+      },
+      "id": "4484cf74-c6d0-4eff-a15e-96d3d64c1774",
+      "links": {
+        "edit": "http:///api/codebases/4484cf74-c6d0-4eff-a15e-96d3d64c1774/edit",
+        "related": "http:///api/codebases/4484cf74-c6d0-4eff-a15e-96d3d64c1774",
+        "self": "http:///api/codebases/4484cf74-c6d0-4eff-a15e-96d3d64c1774"
+      },
+      "relationships": {
+        "space": {
+          "data": {
+            "id": "ee37762e-f9b3-49f1-b317-b29a69e1ab53",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53",
+            "self": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53"
           }
         }
       },
@@ -62,41 +146,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space dd7b09d9-240f-4333-b326-3d34dc323725",
+        "name": "space 455bc143-0032-4323-a88c-f1f44be60961",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "15cc6ff2-4013-49fa-8229-8a03caf34280",
+      "id": "262de8f6-1e88-492b-b357-1768db5647e5",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/backlog"
+          "self": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280",
-        "self": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280",
-        "workitemlinktypes": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/15cc6ff2-4013-49fa-8229-8a03caf34280/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/workitemtypes"
+        "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5",
+        "self": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5",
+        "workitemlinktypes": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/areas"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/backlog"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/codebases"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/collaborators"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/collaborators"
           }
         },
         "filters": {
@@ -106,41 +190,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/iterations"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/labels"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "fda98de4-fd30-45e7-9bc8-b6359d6a2e4b",
+            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/fda98de4-fd30-45e7-9bc8-b6359d6a2e4b"
+            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/workitemlinktypes"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/workitems"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/15cc6ff2-4013-49fa-8229-8a03caf34280/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/15cc6ff2-4013-49fa-8229-8a03caf34280/workitemtypes"
+            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypes"
           }
         }
       },
@@ -150,41 +234,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 8466079a-48c0-4957-85d0-a9cdab61e8ba",
+        "name": "space 9a8affd8-5527-47c5-b274-1969733c1094",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "b43e277c-be5a-43cb-86c9-88ccef7017a1",
+      "id": "478b96bb-68e2-4285-9b77-e47d10ed83cd",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/backlog"
+          "self": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1",
-        "self": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1",
-        "workitemlinktypes": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/b43e277c-be5a-43cb-86c9-88ccef7017a1/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/workitemtypes"
+        "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd",
+        "self": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd",
+        "workitemlinktypes": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/areas"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/backlog"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/codebases"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/collaborators"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/collaborators"
           }
         },
         "filters": {
@@ -194,41 +278,305 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/iterations"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/labels"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "fda98de4-fd30-45e7-9bc8-b6359d6a2e4b",
+            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/fda98de4-fd30-45e7-9bc8-b6359d6a2e4b"
+            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/workitemlinktypes"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/workitems"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/b43e277c-be5a-43cb-86c9-88ccef7017a1/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/b43e277c-be5a-43cb-86c9-88ccef7017a1/workitemtypes"
+            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypes"
+          }
+        }
+      },
+      "type": "spaces"
+    },
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "Some description",
+        "name": "space 26fd2428-49cf-4b31-a21e-9e5e7e464c34",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "59848f9f-b5bd-4183-8325-465f8ec384f6",
+      "links": {
+        "backlog": {
+          "self": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/backlog"
+        },
+        "filters": "http:///api/filters",
+        "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6",
+        "self": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6",
+        "workitemlinktypes": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypes"
+      },
+      "relationships": {
+        "areas": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/areas"
+          }
+        },
+        "backlog": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/backlog"
+          }
+        },
+        "codebases": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/codebases"
+          }
+        },
+        "collaborators": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/collaborators"
+          }
+        },
+        "filters": {
+          "links": {
+            "related": "http:///api/filters"
+          }
+        },
+        "iterations": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/iterations"
+          }
+        },
+        "labels": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/labels"
+          }
+        },
+        "owned-by": {
+          "data": {
+            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "type": "identities"
+          },
+          "links": {
+            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+          }
+        },
+        "workitemlinktypes": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemlinktypes"
+          }
+        },
+        "workitems": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitems"
+          }
+        },
+        "workitemtypegroups": {
+          "links": {
+            "related": "http:///api/spacetemplates/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypegroups/"
+          }
+        },
+        "workitemtypes": {
+          "links": {
+            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypes"
+          }
+        }
+      },
+      "type": "spaces"
+    },
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "Some description",
+        "name": "space 9fb71213-122b-4c74-9c86-58cbe2801a4e",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "9829d8fb-cba6-4338-8cba-dab08bea5a13",
+      "links": {
+        "backlog": {
+          "self": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/backlog"
+        },
+        "filters": "http:///api/filters",
+        "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13",
+        "self": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13",
+        "workitemlinktypes": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypes"
+      },
+      "relationships": {
+        "areas": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/areas"
+          }
+        },
+        "backlog": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/backlog"
+          }
+        },
+        "codebases": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/codebases"
+          }
+        },
+        "collaborators": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/collaborators"
+          }
+        },
+        "filters": {
+          "links": {
+            "related": "http:///api/filters"
+          }
+        },
+        "iterations": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/iterations"
+          }
+        },
+        "labels": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/labels"
+          }
+        },
+        "owned-by": {
+          "data": {
+            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "type": "identities"
+          },
+          "links": {
+            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+          }
+        },
+        "workitemlinktypes": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemlinktypes"
+          }
+        },
+        "workitems": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitems"
+          }
+        },
+        "workitemtypegroups": {
+          "links": {
+            "related": "http:///api/spacetemplates/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypegroups/"
+          }
+        },
+        "workitemtypes": {
+          "links": {
+            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypes"
+          }
+        }
+      },
+      "type": "spaces"
+    },
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "Some description",
+        "name": "space 69cad477-00f6-4551-9af3-c44c0ab6f5cd",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "ee37762e-f9b3-49f1-b317-b29a69e1ab53",
+      "links": {
+        "backlog": {
+          "self": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/backlog"
+        },
+        "filters": "http:///api/filters",
+        "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53",
+        "self": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53",
+        "workitemlinktypes": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypes"
+      },
+      "relationships": {
+        "areas": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/areas"
+          }
+        },
+        "backlog": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/backlog"
+          }
+        },
+        "codebases": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/codebases"
+          }
+        },
+        "collaborators": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/collaborators"
+          }
+        },
+        "filters": {
+          "links": {
+            "related": "http:///api/filters"
+          }
+        },
+        "iterations": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/iterations"
+          }
+        },
+        "labels": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/labels"
+          }
+        },
+        "owned-by": {
+          "data": {
+            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "type": "identities"
+          },
+          "links": {
+            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+          }
+        },
+        "workitemlinktypes": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemlinktypes"
+          }
+        },
+        "workitems": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitems"
+          }
+        },
+        "workitemtypegroups": {
+          "links": {
+            "related": "http:///api/spacetemplates/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypegroups/"
+          }
+        },
+        "workitemtypes": {
+          "links": {
+            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypes"
           }
         }
       },
@@ -240,6 +588,6 @@
     "last": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=http://foo.com/multi/0"
   },
   "meta": {
-    "totalCount": 2
+    "totalCount": 5
   }
 }

--- a/controller/test-files/search/search_codebase_per_url_single_match.json
+++ b/controller/test-files/search/search_codebase_per_url_single_match.json
@@ -8,21 +8,21 @@
         "type": "git",
         "url": "http://foo.com/single/0"
       },
-      "id": "4a7c8d50-1471-4d45-9205-5d5e9bc6fa95",
+      "id": "1c69481d-963c-4aca-8ffe-0e3d066f9e27",
       "links": {
-        "edit": "http:///api/codebases/4a7c8d50-1471-4d45-9205-5d5e9bc6fa95/edit",
-        "related": "http:///api/codebases/4a7c8d50-1471-4d45-9205-5d5e9bc6fa95",
-        "self": "http:///api/codebases/4a7c8d50-1471-4d45-9205-5d5e9bc6fa95"
+        "edit": "http:///api/codebases/1c69481d-963c-4aca-8ffe-0e3d066f9e27/edit",
+        "related": "http:///api/codebases/1c69481d-963c-4aca-8ffe-0e3d066f9e27",
+        "self": "http:///api/codebases/1c69481d-963c-4aca-8ffe-0e3d066f9e27"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "952d975a-19bd-4c00-ac76-70e59cff2032",
+            "id": "3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032",
-            "self": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
+            "self": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3"
           }
         }
       },
@@ -34,41 +34,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 38423cf1-d489-4e44-96ca-facaa2e922c3",
+        "name": "space 133a3acd-dbdb-4a9f-a43c-a98cefc79e06",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "952d975a-19bd-4c00-ac76-70e59cff2032",
+      "id": "3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/backlog"
+          "self": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032",
-        "self": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032",
-        "workitemlinktypes": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/952d975a-19bd-4c00-ac76-70e59cff2032/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/workitemtypes"
+        "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
+        "self": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
+        "workitemlinktypes": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/areas"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/backlog"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/codebases"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/collaborators"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/collaborators"
           }
         },
         "filters": {
@@ -78,41 +78,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/iterations"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/labels"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "ed33f3b3-b07f-403d-98ae-d45e902d1762",
+            "id": "c81703af-3c37-4fdf-bb27-87783faa9c3b",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/ed33f3b3-b07f-403d-98ae-d45e902d1762"
+            "related": "/api/users/c81703af-3c37-4fdf-bb27-87783faa9c3b"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/workitemlinktypes"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/workitems"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/952d975a-19bd-4c00-ac76-70e59cff2032/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/952d975a-19bd-4c00-ac76-70e59cff2032/workitemtypes"
+            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypes"
           }
         }
       },


### PR DESCRIPTION
Use a different ordering to make sure that the test pass no matter which
ID has been allocated to the codebases and their spaces.
Ordering the codebases in `data` by the ID of their related space, and
ordering the `included` spaces by their ID ensures that all data are in
such an order, than replacing all ID with incremental UUIDs in the files
still works.

Fixes openshiftio/openshift.io#1246

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

* Please describe what your change is about.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
* If you are still working on the change please prefix the pull request title with "WIP"
