### PR TITLE
Codebase removal (#1673)

### DIFF
--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -277,3 +277,45 @@ func (test *TestCodebaseRepository) TestSearchByURL() {
 		assert.Len(t, result, 0)
 	})
 }
+
+func (test *TestCodebaseRepository) TestDeleteCodebase() {
+	repo := codebase.NewCodebaseRepository(test.DB)
+	test.T().Run("ok", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, test.DB, tf.Codebases(1))
+		id := fxt.Codebases[0].ID
+		// double check that we can load this codebase
+		cb, err := repo.Load(test.Ctx, id)
+		require.Nil(t, err)
+		require.NotNil(t, cb)
+
+		// when
+		err = repo.Delete(test.Ctx, id)
+
+		// then
+		require.Nil(t, err)
+		// double check that we can no longer load the codebase
+		cb, err = repo.Load(test.Ctx, id)
+		require.NotNil(t, err)
+		require.IsType(t, errors.NotFoundError{}, err, "error was %v", err)
+		require.Nil(t, cb)
+	})
+	test.T().Run("not found - not existing codebase ID", func(t *testing.T) {
+		// given a not existing codebase ID
+		nonExistingCodebaseID := uuid.NewV4()
+		// when
+		err := repo.Delete(test.Ctx, nonExistingCodebaseID)
+		// then
+		require.NotNil(t, err)
+		require.IsType(t, errors.NotFoundError{}, err, "error was %v", err)
+	})
+	test.T().Run("not found - nil codebase ID", func(t *testing.T) {
+		// given a not existing codebase ID
+		nilCodebaseID := uuid.Nil
+		// when
+		err := repo.Delete(test.Ctx, nilCodebaseID)
+		// then
+		require.NotNil(t, err)
+		require.IsType(t, errors.NotFoundError{}, err, "error was %v", err)
+	})
+}

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -120,6 +120,7 @@ func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
 	return ctx.OK(resp)
 }
 
+// Delete deletes the given codebase if the user is authenticated and authorized
 func (c *CodebaseController) Delete(ctx *app.DeleteCodebaseContext) error {
 	currentUser, err := login.ContextIdentity(ctx)
 	if err != nil {
@@ -135,11 +136,11 @@ func (c *CodebaseController) Delete(ctx *app.DeleteCodebaseContext) error {
 		if err != nil {
 			return err
 		}
-		if !uuid.Equal(*currentUser, s.OwnerId) {
+		if !uuid.Equal(*currentUser, s.OwnerID) {
 			log.Warn(ctx, map[string]interface{}{
 				"codebase_id":  ctx.CodebaseID,
 				"space_id":     cb.SpaceID,
-				"space_owner":  s.OwnerId,
+				"space_owner":  s.OwnerID,
 				"current_user": *currentUser,
 			}, "user is not the space owner")
 			return errors.NewForbiddenError("user is not the space owner")
@@ -151,7 +152,7 @@ func (c *CodebaseController) Delete(ctx *app.DeleteCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	return ctx.OK([]byte{})
+	return ctx.NoContent()
 }
 
 // Create runs the create action.

--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -1,13 +1,10 @@
 package controller_test
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/app/test"
-	"github.com/fabric8-services/fabric8-wit/application"
-	"github.com/fabric8-services/fabric8-wit/codebase"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/controller"
@@ -16,8 +13,8 @@ import (
 	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
-	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
+	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
@@ -25,166 +22,127 @@ import (
 )
 
 // a normal test function that will kick off TestSuiteCodebases
-func TestRunCodebasesTest(t *testing.T) {
+func TestCodebaseController(t *testing.T) {
 	resource.Require(t, resource.Database)
-	suite.Run(t, &TestCodebaseREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &CodebaseControllerTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-// ========== TestCodebaseREST struct that implements SetupSuite, TearDownSuite, SetupTest, TearDownTest ==========
-type TestCodebaseREST struct {
+// ========== CodebaseControllerTestSuite struct that implements SetupSuite, TearDownSuite, SetupTest, TearDownTest ==========
+type CodebaseControllerTestSuite struct {
 	gormtestsupport.DBTestSuite
 	db      *gormapplication.GormDB
 	clean   func()
 	testDir string
 }
 
-func (s *TestCodebaseREST) SetupTest() {
+func (s *CodebaseControllerTestSuite) SetupTest() {
 	s.db = gormapplication.NewGormDB(s.DB)
 	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 	s.testDir = filepath.Join("test-files", "codebase")
 }
 
-func (s *TestCodebaseREST) TearDownTest() {
+func (s *CodebaseControllerTestSuite) TearDownTest() {
 	s.clean()
 }
 
-func (s *TestCodebaseREST) UnsecuredController() (*goa.Service, *CodebaseController) {
+func (s *CodebaseControllerTestSuite) UnsecuredController() (*goa.Service, *CodebaseController) {
 	svc := goa.New("Codebases-service")
 	return svc, NewCodebaseController(svc, s.db, s.Configuration)
 }
 
-func (s *TestCodebaseREST) SecuredControllers(identity account.Identity) (*goa.Service, *CodebaseController) {
+func (s *CodebaseControllerTestSuite) SecuredControllers(identity account.Identity) (*goa.Service, *CodebaseController) {
 	svc := testsupport.ServiceAsUser("Codebase-Service", identity)
 	return svc, controller.NewCodebaseController(svc, s.db, s.Configuration)
 }
 
-func (s *TestCodebaseREST) TestSuccessShowCodebaseWithoutAuth() {
+func (s *CodebaseControllerTestSuite) TestShowCodebase() {
 	resetFn := s.DisableGormCallbacks()
 	defer resetFn()
 
-	s.T().Run("success without auth", func(t *testing.T) {
-		resource.Require(t, resource.Database)
-
-		// Create space and codebase with sticky IDs
-		spaceID := uuid.FromStringOrNil("a8bee527-12d2-4aff-9823-3511c1c8e6b9")
-		codebaseID := uuid.FromStringOrNil("d7a282f6-1c10-459e-bb44-55a1a6d48bdd")
-		stackId := "golang-default"
-		cb := requireSpaceAndCodebase(t, s.db, codebaseID, spaceID, &stackId)
-
+	s.T().Run("success without stackId", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.Codebases(1))
 		svc, ctrl := s.UnsecuredController()
-		_, cbresp := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, cb.ID)
-		require.NotNil(t, cbresp)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_without_auth.golden.json"), cbresp)
+		// when
+		_, result := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
+		// then
+		require.NotNil(t, result)
+		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_without_stackId.golden.json"), result)
+	})
+
+	s.T().Run("success with stackId", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.Codebases(1, func(fxt *tf.TestFixture, idx int) error {
+			stackID := "golang-default"
+			fxt.Codebases[idx].StackID = &stackID
+			return nil
+		}))
+		svc, ctrl := s.UnsecuredController()
+		// when
+		_, result := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
+		// then
+		require.NotNil(t, result)
+		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_with_stackId.golden.json"), result)
 	})
 }
 
-func (s *TestCodebaseREST) TestSuccessCreateCodebaseWithoutStackID() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
-	s.T().Run("success with stackId nil", func(t *testing.T) {
-		resource.Require(t, resource.Database)
-
-		spaceID := uuid.FromStringOrNil("a8bee527-12d2-4aff-9823-3511c1c8e6b9")
-		codebaseID := uuid.FromStringOrNil("d7a282f6-1c10-459e-bb44-55a1a6d48bdd")
-		cb := requireSpaceAndCodebase(t, s.db, codebaseID, spaceID, nil)
-
-		svc, ctrl := s.UnsecuredController()
-		_, cbresp := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, cb.ID)
-		require.NotNil(t, cbresp)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_without_stackId.golden.json"), cbresp)
-	})
-}
-
-func (s *TestCodebaseREST) TestDeleteCodebase() {
+func (s *CodebaseControllerTestSuite) TestDeleteCodebase() {
 	resetFn := s.DisableGormCallbacks()
 	defer resetFn()
 
 	s.T().Run("OK", func(t *testing.T) {
-		resource.Require(t, resource.Database)
-
-		// Create space and codebase
-		cb := minimalCodebaseWithSpace(t, s.db, testsupport.TestIdentity.ID)
-
+		// given
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.Spaces(1, func(fxt *tf.TestFixture, idx int) error {
+				fxt.Spaces[idx].OwnerID = testsupport.TestIdentity.ID
+				return nil
+			}),
+			tf.Codebases(1))
+		// when/then
 		svc, ctrl := s.SecuredControllers(testsupport.TestIdentity)
-		test.DeleteCodebaseOK(t, svc.Context, svc, ctrl, cb.ID)
+		test.DeleteCodebaseNoContent(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
 	})
 
 	s.T().Run("NotFound", func(t *testing.T) {
-		resource.Require(t, resource.Database)
-
-		codebaseID := uuid.FromStringOrNil("d7a282f6-1c10-459e-bb44-55a1a6d48bdd")
-
+		// given
+		codebaseID := uuid.NewV4()
+		// when/then (codebase does not exist)
 		svc, ctrl := s.SecuredControllers(testsupport.TestIdentity)
 		test.DeleteCodebaseNotFound(t, svc.Context, svc, ctrl, codebaseID)
 	})
 
-	s.T().Run("Unauthorized", func(t *testing.T) {
-		resource.Require(t, resource.Database)
-
-		codebaseID := uuid.FromStringOrNil("d7a282f6-1c10-459e-bb44-55a1a6d48bdd")
-
+	s.T().Run("Unauthorized on non-existing codebase", func(t *testing.T) {
+		// given
+		codebaseID := uuid.NewV4()
+		// when/then (user is not authenticated)
 		svc, ctrl := s.UnsecuredController()
 		test.DeleteCodebaseUnauthorized(t, svc.Context, svc, ctrl, codebaseID)
 	})
 
+	s.T().Run("Unauthorized on existing codebase", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.Spaces(1, func(fxt *tf.TestFixture, idx int) error {
+				fxt.Spaces[idx].OwnerID = testsupport.TestIdentity2.ID
+				return nil
+			}),
+			tf.Codebases(1))
+		// when/then (user is not authenticated)
+		svc, ctrl := s.UnsecuredController()
+		test.DeleteCodebaseUnauthorized(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
+	})
+
 	s.T().Run("Forbidden", func(t *testing.T) {
-		resource.Require(t, resource.Database)
-
-		// Create space and codebase
-		cb := minimalCodebaseWithSpace(t, s.db, testsupport.TestIdentity.ID)
-
+		// given
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.Spaces(1, func(fxt *tf.TestFixture, idx int) error {
+				fxt.Spaces[idx].OwnerID = testsupport.TestIdentity.ID
+				return nil
+			}),
+			tf.Codebases(1))
+		// when/then (user is not space owner)
 		svc, ctrl := s.SecuredControllers(testsupport.TestIdentity2)
-		test.DeleteCodebaseForbidden(t, svc.Context, svc, ctrl, cb.ID)
+		test.DeleteCodebaseForbidden(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
 	})
 
-}
-
-func requireSpaceAndCodebase(t *testing.T, db *gormapplication.GormDB, ID, spaceID uuid.UUID, stackId *string) *codebase.Codebase {
-	var c *codebase.Codebase
-	application.Transactional(db, func(appl application.Application) error {
-
-		s := &space.Space{
-			ID:   spaceID,
-			Name: "Test Space " + spaceID.String(),
-		}
-		_, err := appl.Spaces().Create(context.Background(), s)
-		require.Nil(t, err)
-		c = &codebase.Codebase{
-			ID:                ID,
-			SpaceID:           spaceID,
-			Type:              "git",
-			URL:               "https://github.com/fabric8-services/fabric8-wit.git",
-			StackID:           stackId,
-			LastUsedWorkspace: "my-last-used-workspace",
-		}
-		err = appl.Codebases().Create(context.Background(), c)
-		require.Nil(t, err)
-		return nil
-	})
-	return c
-}
-
-func minimalCodebaseWithSpace(t *testing.T, db *gormapplication.GormDB, ownerID uuid.UUID) *codebase.Codebase {
-	var c *codebase.Codebase
-	application.Transactional(db, func(appl application.Application) error {
-		s := &space.Space{
-			Name:    "Test Space " + testsupport.CreateRandomValidTestName("CodebaseBlackboxTest-"),
-			OwnerId: ownerID,
-		}
-		_, err := appl.Spaces().Create(context.Background(), s)
-		require.Nil(t, err)
-		stackId := "golanRg-default"
-		c = &codebase.Codebase{
-			SpaceID:           s.ID,
-			Type:              "git",
-			URL:               "https://github.com/fabric8-services/fabric8-wit.git",
-			StackID:           &stackId,
-			LastUsedWorkspace: "my-last-used-workspace",
-		}
-		err = appl.Codebases().Create(context.Background(), c)
-		require.Nil(t, err)
-		return nil
-	})
-	return c
 }

--- a/controller/test-files/codebase/show/ok_with_stackId.golden.json
+++ b/controller/test-files/codebase/show/ok_with_stackId.golden.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "attributes": {
+      "createdAt": "0001-01-01T00:00:00Z",
+      "last_used_workspace": "my-used-last-workspace",
+      "stackId": "golang-default",
+      "type": "git",
+      "url": "git@github.com:fabric8-services/fabric8-wit.git"
+    },
+    "id": "cf4c1254-e624-40b4-ba2f-2a461659a4e2",
+    "links": {
+      "edit": "http:///api/codebases/cf4c1254-e624-40b4-ba2f-2a461659a4e2/edit",
+      "related": "http:///api/codebases/cf4c1254-e624-40b4-ba2f-2a461659a4e2",
+      "self": "http:///api/codebases/cf4c1254-e624-40b4-ba2f-2a461659a4e2"
+    },
+    "relationships": {
+      "space": {
+        "data": {
+          "id": "657fb163-777c-4a31-b9e9-c215947cea0c",
+          "type": "spaces"
+        },
+        "links": {
+          "related": "http:///api/spaces/657fb163-777c-4a31-b9e9-c215947cea0c",
+          "self": "http:///api/spaces/657fb163-777c-4a31-b9e9-c215947cea0c"
+        }
+      }
+    },
+    "type": "codebases"
+  }
+}

--- a/controller/test-files/codebase/show/ok_without_stackId.golden.json
+++ b/controller/test-files/codebase/show/ok_without_stackId.golden.json
@@ -2,25 +2,26 @@
   "data": {
     "attributes": {
       "createdAt": "0001-01-01T00:00:00Z",
-      "last_used_workspace": "my-last-used-workspace",
+      "last_used_workspace": "my-used-last-workspace",
+      "stackId": "golang-default",
       "type": "git",
-      "url": "https://github.com/fabric8-services/fabric8-wit.git"
+      "url": "git@github.com:fabric8-services/fabric8-wit.git"
     },
-    "id": "d7a282f6-1c10-459e-bb44-55a1a6d48bdd",
+    "id": "7ffb4b6d-7db6-4dd9-981f-991c14cf61c9",
     "links": {
-      "edit": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd/edit",
-      "related": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd",
-      "self": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd"
+      "edit": "http:///api/codebases/7ffb4b6d-7db6-4dd9-981f-991c14cf61c9/edit",
+      "related": "http:///api/codebases/7ffb4b6d-7db6-4dd9-981f-991c14cf61c9",
+      "self": "http:///api/codebases/7ffb4b6d-7db6-4dd9-981f-991c14cf61c9"
     },
     "relationships": {
       "space": {
         "data": {
-          "id": "a8bee527-12d2-4aff-9823-3511c1c8e6b9",
+          "id": "703a5a0d-3885-42aa-948d-e03303d6ab2c",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/a8bee527-12d2-4aff-9823-3511c1c8e6b9",
-          "self": "http:///api/spaces/a8bee527-12d2-4aff-9823-3511c1c8e6b9"
+          "related": "http:///api/spaces/703a5a0d-3885-42aa-948d-e03303d6ab2c",
+          "self": "http:///api/spaces/703a5a0d-3885-42aa-948d-e03303d6ab2c"
         }
       }
     },

--- a/design/codebases.go
+++ b/design/codebases.go
@@ -164,7 +164,7 @@ var _ = a.Resource("codebase", func() {
 		a.Params(func() {
 			a.Param("codebaseID", d.UUID, "ID of the codebase to delete")
 		})
-		a.Response(d.OK)
+		a.Response(d.NoContent)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)

--- a/design/codebases.go
+++ b/design/codebases.go
@@ -155,6 +155,22 @@ var _ = a.Resource("codebase", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
+	a.Action("delete", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.DELETE("/:codebaseID"),
+		)
+		a.Description("Delete a codebase with the given ID.")
+		a.Params(func() {
+			a.Param("codebaseID", d.UUID, "ID of the codebase to delete")
+		})
+		a.Response(d.OK)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
+	})
 	a.Action("create", func() {
 		a.Security("jwt")
 		a.Routing(


### PR DESCRIPTION
Endpoint and repository method to remove a codebase given its `ID`.

Fixes #1673
