### PR TITLE
Fix failing test for create-iteration

### DIFF
--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -86,9 +86,9 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		name := "Sprint #21"
 		childItr := fxt.IterationByName("child iteration")
 		ci := getChildIterationPayload(&name)
-		startAt, err := time.Parse(time.RFC3339, "2017-11-04T15:08:41+00:00")
+		startAt, err := time.Parse(time.RFC3339, "2016-11-04T15:08:41+00:00")
 		require.Nil(t, err)
-		endAt, err := time.Parse(time.RFC3339, "2017-11-25T15:08:41+00:00")
+		endAt, err := time.Parse(time.RFC3339, "2016-11-25T15:08:41+00:00")
 		require.Nil(t, err)
 		ci.Data.Attributes.StartAt = &startAt
 		ci.Data.Attributes.EndAt = &endAt

--- a/controller/test-files/iteration/create/ok_create_child.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child.golden.json
@@ -4,44 +4,44 @@
       "active_status": false,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2017-11-25T15:08:41Z",
+      "endAt": "2016-11-25T15:08:41Z",
       "name": "Sprint #21",
-      "parent_path": "/e6a4dd3b-f086-43e8-9acd-121f3d269c30/3caa683e-7392-4909-a82a-5c04b0f46c69",
+      "parent_path": "/58c5f839-8127-4f48-92d2-29cde9e3833b/db101168-6452-46a0-a951-a622945d8648",
       "resolved_parent_path": "/root iteration/child iteration",
-      "startAt": "2017-11-04T15:08:41Z",
+      "startAt": "2016-11-04T15:08:41Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false
     },
-    "id": "4533dd4e-0c67-4cc6-8dfa-94e6b6c9e26c",
+    "id": "90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab",
     "links": {
-      "related": "http:///api/iterations/4533dd4e-0c67-4cc6-8dfa-94e6b6c9e26c",
-      "self": "http:///api/iterations/4533dd4e-0c67-4cc6-8dfa-94e6b6c9e26c"
+      "related": "http:///api/iterations/90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab",
+      "self": "http:///api/iterations/90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab"
     },
     "relationships": {
       "parent": {
         "data": {
-          "id": "3caa683e-7392-4909-a82a-5c04b0f46c69",
+          "id": "db101168-6452-46a0-a951-a622945d8648",
           "type": "iterations"
         },
         "links": {
-          "related": "http:///api/iterations/3caa683e-7392-4909-a82a-5c04b0f46c69",
-          "self": "http:///api/iterations/3caa683e-7392-4909-a82a-5c04b0f46c69"
+          "related": "http:///api/iterations/db101168-6452-46a0-a951-a622945d8648",
+          "self": "http:///api/iterations/db101168-6452-46a0-a951-a622945d8648"
         }
       },
       "space": {
         "data": {
-          "id": "826db44e-142b-4796-8140-54a4aef7759e",
+          "id": "85124ecc-1080-439a-92df-01d68a75f1d7",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/826db44e-142b-4796-8140-54a4aef7759e",
-          "self": "http:///api/spaces/826db44e-142b-4796-8140-54a4aef7759e"
+          "related": "http:///api/spaces/85124ecc-1080-439a-92df-01d68a75f1d7",
+          "self": "http:///api/spaces/85124ecc-1080-439a-92df-01d68a75f1d7"
         }
       },
       "workitems": {
         "links": {
-          "related": "http:///api/workitems/?filter[iteration]=4533dd4e-0c67-4cc6-8dfa-94e6b6c9e26c"
+          "related": "http:///api/workitems/?filter[iteration]=90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab"
         },
         "meta": {
           "closed": 0,


### PR DESCRIPTION
`Use old date for test case`

There was a test having `startAt` and `endAt` with 4th Nov and 25th Nov 2017 respectively. We added a logic that returns `User Active` flag calculated on the fly using those dates and hence it started giving value as `True` since 4th Nov 2017. But the golden file was created with value `False`, hence the failure.

Lesson learned: Use old dates while writing tests.
