### PR TITLE
`auth` docker container cannot connect to `wit` running on host on macOS (#1707)

### DIFF
--- a/.make/Makefile.lnx
+++ b/.make/Makefile.lnx
@@ -24,3 +24,5 @@ GO_BIN_NAME := go
 HG_BIN_NAME := hg
 
 CHECK_GOPATH_BIN := $(INSTALL_PREFIX)/check_gopath
+
+UNAME_S := $(shell uname -s)

--- a/Makefile
+++ b/Makefile
@@ -268,9 +268,19 @@ generate: app/controllers.go assets/js/client.js bindata_assetfs.go migration/sq
 regenerate: clean-generated generate
 
 .PHONY: dev
-dev: prebuild-check deps generate $(FRESH_BIN)
-	docker-compose up -d db auth
+dev: prebuild-check deps generate $(FRESH_BIN) docker-compose-up
 	F8_DEVELOPER_MODE_ENABLED=true $(FRESH_BIN)
+
+.PHONY: docker-compose-up
+docker-compose-up:
+ifeq ($(UNAME_S),Darwin)
+	@echo "Running docker-compose with macOS network settings"
+	docker-compose -f docker-compose.macos.yml up -d db auth
+else
+	@echo "Running docker-compose with Linux network settings"
+	docker-compose up -d db auth
+endif
+
 
 include ./.make/test.mk
 

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -29,7 +29,7 @@ services:
     image: docker.io/fabric8/fabric8-auth:latest
 #    command: -config /usr/local/auth/etc/config.yaml
     environment:
-      AUTH_WIT_URL: "http://localhost:8080"
+      AUTH_WIT_URL: "http://docker.for.mac.localhost:8080"
       AUTH_DEVELOPER_MODE_ENABLED: "true"
       AUTH_POSTGRES_HOST: db-auth
       AUTH_POSTGRES_PORT: 5432


### PR DESCRIPTION
Using `docker.for.mac.localhost` as the hostname to connect from a container (auth)
to the WIT service running on the host machine, when running on macOS.

Also, use the `docker-compose.macos.yml` in `make dev` when `uname -r` is `Darwin` (macOS).

Fixes #1707

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>