### PR TITLE
Use DBTestSuite cleanup

### DIFF
--- a/application/transaction_test.go
+++ b/application/transaction_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 
@@ -17,8 +16,7 @@ import (
 
 type TestTransaction struct {
 	gormtestsupport.DBTestSuite
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunTransaction(t *testing.T) {
@@ -27,12 +25,8 @@ func TestRunTransaction(t *testing.T) {
 }
 
 func (test *TestTransaction) SetupTest() {
+	test.DBTestSuite.SetupTest()
 	test.db = gormapplication.NewGormDB(test.DB)
-	test.clean = cleaner.DeleteCreatedEntities(test.DB)
-}
-
-func (test *TestTransaction) TearDownTest() {
-	test.clean()
 }
 
 func (test *TestTransaction) TestTransactionInTime() {

--- a/area/area_blackbox_test.go
+++ b/area/area_blackbox_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/area"
 	errs "github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/path"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -22,20 +21,11 @@ import (
 
 type TestAreaRepository struct {
 	gormtestsupport.DBTestSuite
-	clean func()
 }
 
 func TestRunAreaRepository(t *testing.T) {
 	resource.Require(t, resource.Database)
 	suite.Run(t, &TestAreaRepository{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
-}
-
-func (s *TestAreaRepository) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-
-func (s *TestAreaRepository) TearDownTest() {
-	s.clean()
 }
 
 func (s *TestAreaRepository) TestCreateAreaWithSameNameFail() {

--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/codebase"
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
@@ -156,20 +155,11 @@ func TestRepoValidURL(t *testing.T) {
 
 type TestCodebaseRepository struct {
 	gormtestsupport.DBTestSuite
-	clean func()
 }
 
 func TestRunCodebaseRepository(t *testing.T) {
 	resource.Require(t, resource.Database)
 	suite.Run(t, &TestCodebaseRepository{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
-}
-
-func (test *TestCodebaseRepository) SetupTest() {
-	test.clean = cleaner.DeleteCreatedEntities(test.DB)
-}
-
-func (test *TestCodebaseRepository) TearDownTest() {
-	test.clean()
 }
 
 func (test *TestCodebaseRepository) TestListCodebases() {

--- a/controller/area_blackbox_test.go
+++ b/controller/area_blackbox_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -32,8 +31,7 @@ import (
 
 type TestAreaREST struct {
 	gormtestsupport.DBTestSuite
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunAreaREST(t *testing.T) {
@@ -44,12 +42,8 @@ func TestRunAreaREST(t *testing.T) {
 }
 
 func (rest *TestAreaREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestAreaREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestAreaREST) SecuredController() (*goa.Service, *AreaController) {

--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/controller"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
@@ -31,18 +30,13 @@ func TestCodebaseController(t *testing.T) {
 type CodebaseControllerTestSuite struct {
 	gormtestsupport.DBTestSuite
 	db      *gormapplication.GormDB
-	clean   func()
 	testDir string
 }
 
 func (s *CodebaseControllerTestSuite) SetupTest() {
+	s.DBTestSuite.SetupTest()
 	s.db = gormapplication.NewGormDB(s.DB)
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 	s.testDir = filepath.Join("test-files", "codebase")
-}
-
-func (s *CodebaseControllerTestSuite) TearDownTest() {
-	s.clean()
 }
 
 func (s *CodebaseControllerTestSuite) UnsecuredController() (*goa.Service, *CodebaseController) {

--- a/controller/filters_blackbox_test.go
+++ b/controller/filters_blackbox_test.go
@@ -19,8 +19,7 @@ type TestFiltersREST struct {
 	// composing with the DBTestSuite to get the Configuration out-of-the-box, even though this particular Controller
 	// does not need an access to the DB.
 	gormtestsupport.DBTestSuite
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunFiltersREST(t *testing.T) {

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/space"
@@ -38,7 +37,6 @@ import (
 type TestIterationREST struct {
 	gormtestsupport.DBTestSuite
 	db      *gormapplication.GormDB
-	clean   func()
 	testDir string
 }
 
@@ -48,13 +46,9 @@ func TestRunIterationREST(t *testing.T) {
 }
 
 func (rest *TestIterationREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
 	rest.testDir = filepath.Join("test-files", "iteration")
-}
-
-func (rest *TestIterationREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestIterationREST) SecuredController() (*goa.Service, *IterationController) {

--- a/controller/label_blackbox_test.go
+++ b/controller/label_blackbox_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/label"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -23,8 +22,7 @@ import (
 
 type TestLabelREST struct {
 	gormtestsupport.DBTestSuite
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunLabelREST(t *testing.T) {
@@ -35,12 +33,8 @@ func TestRunLabelREST(t *testing.T) {
 }
 
 func (rest *TestLabelREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestLabelREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestLabelREST) TestCreateLabel() {

--- a/controller/namedspaces_test.go
+++ b/controller/namedspaces_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
@@ -19,8 +18,7 @@ import (
 
 type TestNamedSpaceREST struct {
 	gormtestsupport.DBTestSuite
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunNamedSpacesREST(t *testing.T) {
@@ -28,12 +26,8 @@ func TestRunNamedSpacesREST(t *testing.T) {
 }
 
 func (rest *TestNamedSpaceREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestNamedSpaceREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestNamedSpaceREST) SecuredNamedSpaceController(identity account.Identity) (*goa.Service, *NamedspacesController) {

--- a/controller/search_spaces_blackbox_test.go
+++ b/controller/search_spaces_blackbox_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/application"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
@@ -43,8 +42,7 @@ type okScenario struct {
 
 type TestSearchSpacesREST struct {
 	gormtestsupport.DBTestSuite
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunSearchSpacesREST(t *testing.T) {
@@ -53,12 +51,8 @@ func TestRunSearchSpacesREST(t *testing.T) {
 }
 
 func (rest *TestSearchSpacesREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestSearchSpacesREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestSearchSpacesREST) SecuredController() (*goa.Service, *SearchController) {

--- a/controller/space_codebases_test.go
+++ b/controller/space_codebases_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/application"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -28,9 +27,7 @@ import (
 
 type TestSpaceCodebaseREST struct {
 	gormtestsupport.DBTestSuite
-
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunSpaceCodebaseREST(t *testing.T) {
@@ -42,12 +39,8 @@ func TestRunSpaceCodebaseREST(t *testing.T) {
 }
 
 func (rest *TestSpaceCodebaseREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestSpaceCodebaseREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestSpaceCodebaseREST) SecuredController() (*goa.Service, *SpaceCodebasesController) {

--- a/controller/status_test.go
+++ b/controller/status_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	. "github.com/fabric8-services/fabric8-wit/controller"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
@@ -17,20 +16,10 @@ import (
 
 type TestStatusREST struct {
 	gormtestsupport.DBTestSuite
-
-	clean func()
 }
 
 func TestRunStatusREST(t *testing.T) {
 	suite.Run(t, &TestStatusREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
-}
-
-func (rest *TestStatusREST) SetupTest() {
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestStatusREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestStatusREST) SecuredController() (*goa.Service, *StatusController) {

--- a/controller/trackerquery_blackbox_test.go
+++ b/controller/trackerquery_blackbox_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/remoteworkitem"
@@ -30,11 +29,8 @@ import (
 
 type TestTrackerQueryREST struct {
 	gormtestsupport.DBTestSuite
-
 	RwiScheduler *remoteworkitem.Scheduler
-
-	db    *gormapplication.GormDB
-	clean func()
+	db           *gormapplication.GormDB
 }
 
 func TestRunTrackerQueryREST(t *testing.T) {
@@ -42,13 +38,9 @@ func TestRunTrackerQueryREST(t *testing.T) {
 }
 
 func (rest *TestTrackerQueryREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.RwiScheduler = remoteworkitem.NewScheduler(rest.DB)
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestTrackerQueryREST) TearDownTest() {
-	rest.clean()
 }
 
 func (rest *TestTrackerQueryREST) SecuredController() (*goa.Service, *TrackerController, *TrackerqueryController) {

--- a/controller/workitem_whitebox_test.go
+++ b/controller/workitem_whitebox_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -140,9 +139,7 @@ func TestConvertWorkItemWithoutDescription(t *testing.T) {
 
 type TestWorkItemREST struct {
 	gormtestsupport.DBTestSuite
-
-	db    *gormapplication.GormDB
-	clean func()
+	db *gormapplication.GormDB
 }
 
 func TestRunWorkItemREST(t *testing.T) {
@@ -154,12 +151,8 @@ func TestRunWorkItemREST(t *testing.T) {
 }
 
 func (rest *TestWorkItemREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-}
-
-func (rest *TestWorkItemREST) TearDownTest() {
-	rest.clean()
 }
 
 func prepareWI2(attributes map[string]interface{}) app.WorkItem {

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -21,23 +20,13 @@ import (
 
 type TestIterationRepository struct {
 	gormtestsupport.DBTestSuite
-
-	clean func()
 }
 
 func TestRunIterationRepository(t *testing.T) {
 	suite.Run(t, &TestIterationRepository{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-func (s *TestIterationRepository) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-
-func (s *TestIterationRepository) TearDownTest() {
-	s.clean()
-}
-
-func (s *TestIterationRepository) TestCreate() {
+func (s *TestIterationRepository) TestCreateIteration() {
 	t := s.T()
 	resource.Require(t, resource.Database)
 	repo := iteration.NewIterationRepository(s.DB)

--- a/label/label_blackbox_test.go
+++ b/label/label_blackbox_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	errs "github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/label"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -20,20 +19,11 @@ import (
 
 type TestLabelRepository struct {
 	gormtestsupport.DBTestSuite
-	clean func()
 }
 
 func TestRunLabelRepository(t *testing.T) {
 	resource.Require(t, resource.Database)
 	suite.Run(t, &TestLabelRepository{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
-}
-
-func (s *TestLabelRepository) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-
-func (s *TestLabelRepository) TearDownTest() {
-	s.clean()
 }
 
 func (s *TestLabelRepository) TestCreateLabel() {

--- a/remoteworkitem/tracker_repository_test.go
+++ b/remoteworkitem/tracker_repository_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	errors "github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/remoteworkitem"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -20,10 +19,7 @@ import (
 
 type TestTrackerRepository struct {
 	gormtestsupport.DBTestSuite
-
 	repo remoteworkitem.TrackerRepository
-
-	clean func()
 }
 
 func TestRunTrackerRepository(t *testing.T) {
@@ -31,12 +27,8 @@ func TestRunTrackerRepository(t *testing.T) {
 }
 
 func (test *TestTrackerRepository) SetupTest() {
+	test.DBTestSuite.SetupTest()
 	test.repo = remoteworkitem.NewTrackerRepository(test.DB)
-	test.clean = cleaner.DeleteCreatedEntities(test.DB)
-}
-
-func (test *TestTrackerRepository) TearDownTest() {
-	test.clean()
 }
 
 func (test *TestTrackerRepository) TestTrackerCreate() {

--- a/remoteworkitem/trackeritem_test.go
+++ b/remoteworkitem/trackeritem_test.go
@@ -3,7 +3,6 @@ package remoteworkitem
 import (
 	"testing"
 
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/stretchr/testify/suite"
@@ -11,20 +10,10 @@ import (
 
 type TestTrackerItemRepository struct {
 	gormtestsupport.DBTestSuite
-
-	clean func()
 }
 
 func TestRunTrackerItemRepository(t *testing.T) {
 	suite.Run(t, &TestTrackerItemRepository{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
-}
-
-func (test *TestTrackerItemRepository) SetupTest() {
-	test.clean = cleaner.DeleteCreatedEntities(test.DB)
-}
-
-func (test *TestTrackerItemRepository) TearDownTest() {
-	test.clean()
 }
 
 func (test *TestTrackerItemRepository) TestUpload() {

--- a/remoteworkitem/trackerquery_repository_test.go
+++ b/remoteworkitem/trackerquery_repository_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	errs "github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
@@ -25,8 +24,6 @@ type TestTrackerQueryRepository struct {
 
 	trackerRepo TrackerRepository
 	queryRepo   TrackerQueryRepository
-
-	clean func()
 }
 
 func TestRunTrackerQueryRepository(t *testing.T) {
@@ -34,14 +31,9 @@ func TestRunTrackerQueryRepository(t *testing.T) {
 }
 
 func (test *TestTrackerQueryRepository) SetupTest() {
+	test.DBTestSuite.SetupTest()
 	test.trackerRepo = NewTrackerRepository(test.DB)
 	test.queryRepo = NewTrackerQueryRepository(test.DB)
-
-	test.clean = cleaner.DeleteCreatedEntities(test.DB)
-}
-
-func (test *TestTrackerQueryRepository) TearDownTest() {
-	test.clean()
 }
 
 func (test *TestTrackerQueryRepository) TestTrackerQueryCreate() {

--- a/test/testfixture/testfixture_test.go
+++ b/test/testfixture/testfixture_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/workitem/link"
 
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
@@ -22,14 +21,6 @@ func TestRunTestFixtureSuite(t *testing.T) {
 
 type testFixtureSuite struct {
 	gormtestsupport.DBTestSuite
-	clean func()
-}
-
-func (s *testFixtureSuite) SetupTest() {
-	s.clean = cleaner.DeleteCreatedEntities(s.DB)
-}
-func (s *testFixtureSuite) TearDownTest() {
-	s.clean()
 }
 
 func (s *testFixtureSuite) TestNewFixture_Advanced() {


### PR DESCRIPTION
Test suites don't need to define the own `clean` function. The `DBTestSuite` takes care of this in setup and teardown phase.