### PR TITLE
codebase's workspace deletion (#1749)

### DIFF
--- a/account/init_tenant.go
+++ b/account/init_tenant.go
@@ -39,8 +39,11 @@ func NewCleanTenant(config tenantConfig) func(context.Context) error {
 	}
 }
 
+// CodebaseInitTenantProvider the function that provides a `tenant.TenantSingle`
+type CodebaseInitTenantProvider func(context.Context) (*tenant.TenantSingle, error)
+
 // NewShowTenant view an existing tenant in oso
-func NewShowTenant(config tenantConfig) func(context.Context) (*tenant.TenantSingle, error) {
+func NewShowTenant(config tenantConfig) CodebaseInitTenantProvider {
 	return func(ctx context.Context) (*tenant.TenantSingle, error) {
 		return ShowTenant(ctx, config)
 	}

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/fabric8-services/fabric8-wit/account/tenant"
 	"github.com/fabric8-services/fabric8-wit/app"
@@ -14,6 +15,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/login"
 	"github.com/fabric8-services/fabric8-wit/rest"
+	"github.com/fabric8-services/fabric8-wit/space"
 
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/goadesign/goa"
@@ -36,9 +38,10 @@ type codebaseConfiguration interface {
 // CodebaseController implements the codebase resource.
 type CodebaseController struct {
 	*goa.Controller
-	db         application.DB
-	config     codebaseConfiguration
-	ShowTenant func(context.Context) (*tenant.TenantSingle, error)
+	db           application.DB
+	config       codebaseConfiguration
+	ShowTenant   func(context.Context) (*tenant.TenantSingle, error)
+	NewCheClient func(ctx context.Context, ns string) (che.Client, error)
 }
 
 // NewCodebaseController creates a codebase controller.
@@ -84,7 +87,10 @@ func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
-	cheClient := che.NewStarterClient(c.config.GetCheStarterURL(), c.config.GetOpenshiftTenantMasterURL(), ns)
+	cheClient, err := c.NewCheClient(ctx, ns)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
 	workspaces, err := cheClient.ListWorkspaces(ctx, cb.URL)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -126,29 +132,62 @@ func (c *CodebaseController) Delete(ctx *app.DeleteCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
-
+	var cb *codebase.Codebase
+	var cbSpace *space.Space
 	err = application.Transactional(c.db, func(appl application.Application) error {
-		cb, err := appl.Codebases().Load(ctx.Context, ctx.CodebaseID)
+		var err error
+		cb, err = appl.Codebases().Load(ctx.Context, ctx.CodebaseID)
 		if err != nil {
 			return err
 		}
-		s, err := appl.Spaces().Load(ctx.Context, cb.SpaceID)
-		if err != nil {
-			return err
+		cbSpace, err = appl.Spaces().Load(ctx.Context, cb.SpaceID)
+		return err
+	})
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	if !uuid.Equal(*currentUser, cbSpace.OwnerID) {
+		log.Warn(ctx, map[string]interface{}{
+			"codebase_id":  ctx.CodebaseID,
+			"space_id":     cbSpace.ID,
+			"space_owner":  cbSpace.OwnerID,
+			"current_user": *currentUser,
+		}, "user is not the space owner")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError("user is not the space owner"))
+	}
+	// attempt to remotely delete the Che workspaces
+	ns, err := c.getCheNamespace(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	cheClient, err := c.NewCheClient(ctx, ns)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	workspaces, err := cheClient.ListWorkspaces(ctx, cb.URL)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	for _, workspace := range workspaces {
+		for _, link := range workspace.Links {
+			if strings.ToLower(link.Method) == "delete" {
+				err = cheClient.DeleteWorkspace(ctx.Context, workspace.Config.Name)
+				if err != nil {
+					log.Error(ctx,
+						map[string]interface{}{
+							"codebase_url":  cb.URL,
+							"che_namespace": ns,
+							"workspace":     workspace.Config.Name},
+						"failed to delete Che workspace: %s", err.Error())
+				}
+			}
 		}
-		if !uuid.Equal(*currentUser, s.OwnerID) {
-			log.Warn(ctx, map[string]interface{}{
-				"codebase_id":  ctx.CodebaseID,
-				"space_id":     cb.SpaceID,
-				"space_owner":  s.OwnerID,
-				"current_user": *currentUser,
-			}, "user is not the space owner")
-			return errors.NewForbiddenError("user is not the space owner")
-		}
+	}
 
+	// delete the local codebase data
+	err = application.Transactional(c.db, func(appl application.Application) error {
 		return appl.Codebases().Delete(ctx, ctx.CodebaseID)
 	})
-
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -179,7 +218,10 @@ func (c *CodebaseController) Create(ctx *app.CreateCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
-	cheClient := che.NewStarterClient(c.config.GetCheStarterURL(), c.config.GetOpenshiftTenantMasterURL(), ns)
+	cheClient, err := c.NewCheClient(ctx, ns)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
 
 	stackID := "java-centos"
 	if cb.StackID != nil && *cb.StackID != "" {
@@ -252,7 +294,10 @@ func (c *CodebaseController) Open(ctx *app.OpenCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
-	cheClient := che.NewStarterClient(c.config.GetCheStarterURL(), c.config.GetOpenshiftTenantMasterURL(), ns)
+	cheClient, err := c.NewCheClient(ctx, ns)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
 	workspaceResp, err := cheClient.StartExistingWorkspace(ctx, ctx.WorkspaceID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -350,7 +395,10 @@ func (c *CodebaseController) CheState(ctx *app.CheStateCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
-	cheClient := che.NewStarterClient(c.config.GetCheStarterURL(), c.config.GetOpenshiftTenantMasterURL(), ns)
+	cheClient, err := c.NewCheClient(ctx, ns)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
 	cheState, err := cheClient.GetCheServerState(ctx)
 
 	if err != nil {
@@ -378,8 +426,10 @@ func (c *CodebaseController) CheStart(ctx *app.CheStartCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
-
-	cheClient := che.NewStarterClient(c.config.GetCheStarterURL(), c.config.GetOpenshiftTenantMasterURL(), ns)
+	cheClient, err := c.NewCheClient(ctx, ns)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
 	cheState, err := cheClient.StartCheServer(ctx)
 
 	if err != nil {
@@ -410,7 +460,6 @@ func (c *CodebaseController) getCheNamespace(ctx context.Context) (string, error
 	if err != nil {
 		return "", err
 	}
-
 	if t.Data != nil && t.Data.Attributes != nil && t.Data.Attributes.Namespaces != nil {
 		for _, ns := range t.Data.Attributes.Namespaces {
 			if ns.Type != nil && *ns.Type == "che" && ns.Name != nil {
@@ -423,4 +472,12 @@ func (c *CodebaseController) getCheNamespace(ctx context.Context) (string, error
 	}, "unable to locate che namespace")
 
 	return "", fmt.Errorf("unable to resolve user service che namespace")
+}
+
+// NewDefaultCheClient returns the default function to initialize a new Che client with a "regular" http client
+func NewDefaultCheClient(config codebaseConfiguration) func(ctx context.Context, ns string) (che.Client, error) {
+	return func(ctx context.Context, ns string) (che.Client, error) {
+		cheClient := che.NewStarterClient(config.GetCheStarterURL(), config.GetOpenshiftTenantMasterURL(), ns, http.DefaultClient)
+		return cheClient, nil
+	}
 }

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
+
 	"github.com/fabric8-services/fabric8-wit/account/tenant"
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
@@ -168,9 +170,16 @@ func (c *CodebaseController) Delete(ctx *app.DeleteCodebaseContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
+	log.Warn(ctx, nil, "Found %d workspaces to delete", len(workspaces))
 	for _, workspace := range workspaces {
+		log.Warn(ctx, nil, "Checking workspace links: %v", spew.Sdump(workspace.Links))
 		for _, link := range workspace.Links {
 			if strings.ToLower(link.Method) == "delete" {
+				log.Warn(ctx,
+					map[string]interface{}{"codebase_url": cb.URL,
+						"che_namespace": ns,
+						"workspace":     workspace.Config.Name,
+					}, "About to delete Che workspace")
 				err = cheClient.DeleteWorkspace(ctx.Context, workspace.Config.Name)
 				if err != nil {
 					log.Error(ctx,

--- a/main.go
+++ b/main.go
@@ -341,6 +341,8 @@ func main() {
 	// Mount "codebase" controller
 	codebaseCtrl := controller.NewCodebaseController(service, appDB, config)
 	codebaseCtrl.ShowTenant = account.NewShowTenant(config)
+	codebaseCtrl.NewCheClient = controller.NewDefaultCheClient(config)
+
 	app.MountCodebaseController(service, codebaseCtrl)
 
 	// Mount "spacecodebases" controller

--- a/test/data/che/che_delete_codebase_workspaces.failure.yaml
+++ b/test/data/che/che_delete_codebase_workspaces.failure.yaml
@@ -1,0 +1,97 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo
+    method: GET
+  response:
+    body: '[
+  {
+    "config": {
+      "commands": [
+        {
+          "attributes": {
+            "goal": "string",
+            "previewUrl": "string"
+          },
+          "commandLine": "string",
+          "name": "string",
+          "type": "string"
+        }
+      ],
+      "defaultEnv": "string",
+      "description": "string",
+      "environments": {
+        "default": {
+          "machines": {},
+          "recipe": {
+            "content": "string",
+            "contentType": "string",
+            "location": "string",
+            "type": "string"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo",
+          "method": "DELETE",
+          "rel": "delete"
+        }
+      ],
+      "name": "string",
+      "projects": [
+        {
+          "attributes": {},
+          "description": "string",
+          "links": [
+            {}
+          ],
+          "mixins": [
+            "string"
+          ],
+          "name": "string",
+          "path": "string",
+          "source": {
+            "location": "string",
+            "parameters": {},
+            "type": "string"
+          },
+          "type": "string"
+        }
+      ]
+    },
+    "id": "string",
+    "links": [
+      {
+        "href": "string",
+        "method": "string",
+        "rel": "string"
+      }
+    ],
+    "runtime": {
+      "devMachine": {
+        "runtime": {
+          "servers": {}
+        }
+      }
+    },
+    "status": "string"
+  }
+]'
+    # headers:
+
+    status: 200 OK
+    code: 200
+---
+version: 1
+interactions:
+- request:
+    url: che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo
+    method: DELETE
+  response:
+    # headers:
+    status: 500 Internal Server Error
+    code: 500

--- a/test/data/che/che_delete_codebase_workspaces.failure.yaml
+++ b/test/data/che/che_delete_codebase_workspaces.failure.yaml
@@ -36,9 +36,9 @@ interactions:
       },
       "links": [
         {
-          "href": "che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo",
-          "method": "DELETE",
-          "rel": "delete"
+          "href": "string",
+          "method": "string",
+          "rel": "string"
         }
       ],
       "name": "string",
@@ -66,9 +66,9 @@ interactions:
     "id": "string",
     "links": [
       {
-        "href": "string",
-        "method": "string",
-        "rel": "string"
+        "href": "che-server/workspace/string?masterUrl=https://tsrv.devshift.net:8443&namespace=foo",
+        "method": "DELETE",
+        "rel": "delete"
       }
     ],
     "runtime": {
@@ -85,11 +85,8 @@ interactions:
 
     status: 200 OK
     code: 200
----
-version: 1
-interactions:
 - request:
-    url: che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo
+    url: che-server/workspace/string?masterUrl=https://tsrv.devshift.net:8443&namespace=foo
     method: DELETE
   response:
     # headers:

--- a/test/data/che/che_delete_codebase_workspaces.ok.yaml
+++ b/test/data/che/che_delete_codebase_workspaces.ok.yaml
@@ -36,9 +36,9 @@ interactions:
       },
       "links": [
         {
-          "href": "che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo",
-          "method": "DELETE",
-          "rel": "delete"
+          "href": "string",
+          "method": "string",
+          "rel": "string"
         }
       ],
       "name": "string",
@@ -66,9 +66,9 @@ interactions:
     "id": "string",
     "links": [
       {
-        "href": "string",
-        "method": "string",
-        "rel": "string"
+        "href": "che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo",
+        "method": "DELETE",
+        "rel": "delete"
       }
     ],
     "runtime": {
@@ -85,11 +85,8 @@ interactions:
 
     status: 200 OK
     code: 200
----
-version: 1
-interactions:
 - request:
-    url: che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo
+    url: che-server/workspace/string?masterUrl=https://tsrv.devshift.net:8443&namespace=foo
     method: DELETE
   response:
     # headers:

--- a/test/data/che/che_delete_codebase_workspaces.ok.yaml
+++ b/test/data/che/che_delete_codebase_workspaces.ok.yaml
@@ -1,0 +1,97 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo
+    method: GET
+  response:
+    body: '[
+  {
+    "config": {
+      "commands": [
+        {
+          "attributes": {
+            "goal": "string",
+            "previewUrl": "string"
+          },
+          "commandLine": "string",
+          "name": "string",
+          "type": "string"
+        }
+      ],
+      "defaultEnv": "string",
+      "description": "string",
+      "environments": {
+        "default": {
+          "machines": {},
+          "recipe": {
+            "content": "string",
+            "contentType": "string",
+            "location": "string",
+            "type": "string"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo",
+          "method": "DELETE",
+          "rel": "delete"
+        }
+      ],
+      "name": "string",
+      "projects": [
+        {
+          "attributes": {},
+          "description": "string",
+          "links": [
+            {}
+          ],
+          "mixins": [
+            "string"
+          ],
+          "name": "string",
+          "path": "string",
+          "source": {
+            "location": "string",
+            "parameters": {},
+            "type": "string"
+          },
+          "type": "string"
+        }
+      ]
+    },
+    "id": "string",
+    "links": [
+      {
+        "href": "string",
+        "method": "string",
+        "rel": "string"
+      }
+    ],
+    "runtime": {
+      "devMachine": {
+        "runtime": {
+          "servers": {}
+        }
+      }
+    },
+    "status": "string"
+  }
+]'
+    # headers:
+
+    status: 200 OK
+    code: 200
+---
+version: 1
+interactions:
+- request:
+    url: che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200

--- a/test/http_monitor/http_transport_monitor.go
+++ b/test/http_monitor/http_transport_monitor.go
@@ -1,0 +1,60 @@
+package httpmonitor
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// TransportMonitor is a wrapper around the HTTP client's transport
+// It collects usage stats of the request/responses, to be able to verify what how the HTTP client was actually used.
+type TransportMonitor struct {
+	transport http.RoundTripper
+	Exchanges []Exchange
+}
+
+// Exchange a type to store the request's method and URL and the response's status code
+type Exchange struct {
+	RequestMethod string
+	RequestURL    string
+	StatusCode    int
+	Error         error
+}
+
+// NewTransportMonitor returns a new Transport monitor
+func NewTransportMonitor(t http.RoundTripper) *TransportMonitor {
+	return &TransportMonitor{transport: t}
+}
+
+// ValidateExchanges verifies that the transport monitor contains the exact given sequence of exchanges
+func (t *TransportMonitor) ValidateExchanges(exchanges ...Exchange) error {
+	if len(t.Exchanges) != len(exchanges) {
+		return fmt.Errorf("unexpected number of exchanges to compare: %d (actual) vs %d (expected)", len(t.Exchanges), len(exchanges))
+	}
+	for i, e := range exchanges {
+		if t.Exchanges[i] != e {
+			return fmt.Errorf("unexpected number of exchange at index #%d: %v vs %v", i, spew.Sdump(t.Exchanges[i]), spew.Sdump(e))
+		}
+	}
+	return nil
+}
+
+// RoundTrip implements the http.RoundTripper#RoundTrip(*http.Request) (*http.Response, error) function,
+// It delegates the call to the underlying RoundTripper of this monitor, and keps track of the request/response
+// exhanges data.
+func (t *TransportMonitor) RoundTrip(request *http.Request) (*http.Response, error) {
+	e := Exchange{
+		RequestMethod: request.Method,
+		RequestURL:    request.URL.String(),
+	}
+	response, err := t.transport.RoundTrip(request)
+	// collect stats about the request and the response
+	if err != nil {
+		e.Error = err
+	} else {
+		e.StatusCode = response.StatusCode
+	}
+	t.Exchanges = append(t.Exchanges, e)
+	return response, err
+}

--- a/test/http_monitor/http_transport_monitor.go
+++ b/test/http_monitor/http_transport_monitor.go
@@ -40,6 +40,14 @@ func (t *TransportMonitor) ValidateExchanges(exchanges ...Exchange) error {
 	return nil
 }
 
+// ValidateNoExchanges verifies that the transport monitor does not contain any record of exchanges
+func (t *TransportMonitor) ValidateNoExchanges() error {
+	if len(t.Exchanges) != 0 {
+		return fmt.Errorf("unexpected number of exchanges: %d (actual)", len(t.Exchanges))
+	}
+	return nil
+}
+
 // RoundTrip implements the http.RoundTripper#RoundTrip(*http.Request) (*http.Response, error) function,
 // It delegates the call to the underlying RoundTripper of this monitor, and keps track of the request/response
 // exhanges data.


### PR DESCRIPTION
refactored the code to be able to use a custom/mock HTTP client
in the tests, using `go-vcr` to respond to HTTP requests with a
predefined response.

Fixes #1749

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>