### PR TITLE
Rename auth Service Account to 'fabric8-auth'

### DIFF
--- a/test/login.go
+++ b/test/login.go
@@ -52,7 +52,7 @@ func WithAuthz(ctx context.Context, key interface{}, ident account.Identity, aut
 // Token is filled using input Identity object and resource authorization information
 func WithServiceAccountAuthz(ctx context.Context, key interface{}, ident account.Identity) context.Context {
 	token := fillClaimsWithIdentity(ident) // irrelavant for service account , but keeping it anyway.
-	token.Claims.(jwt.MapClaims)["service_accountname"] = "auth"
+	token.Claims.(jwt.MapClaims)["service_accountname"] = "fabric8-auth"
 	token.Header["kid"] = "test-key"
 	t, err := token.SignedString(key)
 	if err != nil {

--- a/token/token.go
+++ b/token/token.go
@@ -142,7 +142,7 @@ func (mgm *tokenManager) IsServiceAccount(ctx context.Context) bool {
 	accountNameTyped, isString := accountName.(string)
 
 	// https://github.com/fabric8-services/fabric8-auth/commit/8d7f5a3646974ae8820893d75c29f3f5e9b1ff66#diff-6b1a7621961d1f6fe7463db59c5afef5R379
-	return isString && accountNameTyped == "auth"
+	return isString && (accountNameTyped == "auth" || accountNameTyped == "fabric8-auth")
 }
 
 // ParseToken parses token claims

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -109,7 +109,7 @@ func TestLocateTokenInContex(t *testing.T) {
 
 func TestIsServiceAccountTokenInContextClaimPresent(t *testing.T) {
 	tk := jwt.New(jwt.SigningMethodRS256)
-	tk.Claims.(jwt.MapClaims)["service_accountname"] = "auth"
+	tk.Claims.(jwt.MapClaims)["service_accountname"] = "fabric8-auth"
 	ctx := goajwt.WithJWT(context.Background(), tk)
 
 	isServiceAccount := tokenManager.IsServiceAccount(ctx)


### PR DESCRIPTION
For consistency sake.
We are using github repo name as service account names.