### PR TITLE
`relationships.owned-by.related` URL must be absolute when showing a space (openshiftio/openshift.io#1310)

### DIFF
--- a/controller/namedspaces_test.go
+++ b/controller/namedspaces_test.go
@@ -66,8 +66,7 @@ func (rest *TestNamedSpaceREST) TestSuccessQuerySpace() {
 
 	name := testsupport.CreateRandomValidTestName("Test 24")
 
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
+	p := newCreateSpacePayload(&name, nil)
 
 	_, created := test.CreateSpaceCreated(t, spaceSvc.Context, spaceSvc, spaceCtrl, p)
 	assert.NotNil(t, created.Data)
@@ -108,8 +107,7 @@ func (rest *TestNamedSpaceREST) TestSuccessListSpaces() {
 
 	name := testsupport.CreateRandomValidTestName("Test 24")
 
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
+	p := newCreateSpacePayload(&name, nil)
 
 	_, created := test.CreateSpaceCreated(t, spaceSvc.Context, spaceSvc, spaceCtrl, p)
 	assert.NotNil(t, created.Data)

--- a/controller/space.go
+++ b/controller/space.go
@@ -401,7 +401,7 @@ func ConvertSpaceFromModel(request *http.Request, sp space.Space, options ...Spa
 	relatedWorkItems := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/workitems", spaceIDStr))
 	relatedWorkItemTypes := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/workitemtypes", spaceIDStr))
 	relatedWorkItemLinkTypes := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/workitemlinktypes", spaceIDStr))
-	relatedOwners := app.UsersHref(sp.OwnerID.String())
+	relatedOwners := rest.AbsoluteURL(request, app.UsersHref(sp.OwnerID.String()))
 	relatedCollaborators := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/collaborators", spaceIDStr))
 	relatedFilters := rest.AbsoluteURL(request, "/api/filters")
 	relatedLabels := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/labels", spaceIDStr))

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/configuration"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
-	"github.com/fabric8-services/fabric8-wit/gormsupport/cleaner"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -48,633 +48,534 @@ func init() {
 	}
 }
 
-type TestSpaceREST struct {
+type SpaceControllerTestSuite struct {
 	gormtestsupport.DBTestSuite
 	db            *gormapplication.GormDB
-	clean         func()
 	iterationRepo iteration.Repository
+	testDir       string
 }
 
-func TestRunSpaceREST(t *testing.T) {
+func TestSpaceController(t *testing.T) {
 	resource.Require(t, resource.Database)
-	suite.Run(t, &TestSpaceREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &SpaceControllerTestSuite{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-func (rest *TestSpaceREST) SetupTest() {
-	rest.db = gormapplication.NewGormDB(rest.DB)
-	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-	rest.iterationRepo = iteration.NewIterationRepository(rest.DB)
+func (s *SpaceControllerTestSuite) SetupTest() {
+	s.DBTestSuite.SetupTest()
+	s.db = gormapplication.NewGormDB(s.DB)
+	s.iterationRepo = iteration.NewIterationRepository(s.DB)
+	s.testDir = filepath.Join("test-files", "space")
 }
 
-func (rest *TestSpaceREST) TearDownTest() {
-	rest.clean()
-}
-
-func (rest *TestSpaceREST) SecuredController(identity account.Identity) (*goa.Service, *SpaceController) {
+func (s *SpaceControllerTestSuite) SecuredController(identity account.Identity) (*goa.Service, *SpaceController) {
 	svc := testsupport.ServiceAsUser("Space-Service", identity)
-	return svc, NewSpaceController(svc, rest.db, spaceConfiguration, &DummyResourceManager{})
+	return svc, NewSpaceController(svc, s.db, spaceConfiguration, &DummyResourceManager{})
 }
 
-func (rest *TestSpaceREST) UnSecuredController() (*goa.Service, *SpaceController) {
+func (s *SpaceControllerTestSuite) UnSecuredController() (*goa.Service, *SpaceController) {
 	svc := goa.New("Space-Service")
-	return svc, NewSpaceController(svc, rest.db, spaceConfiguration, &DummyResourceManager{})
+	return svc, NewSpaceController(svc, s.db, spaceConfiguration, &DummyResourceManager{})
 }
 
-func (rest *TestSpaceREST) TestFailCreateSpaceUnsecure() {
-	// given
-	p := minimumRequiredCreateSpace()
-	svc, ctrl := rest.UnSecuredController()
-	// when/then
-	test.CreateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, p)
-}
-
-func (rest *TestSpaceREST) TestFailValidationSpaceNameLength() {
-	// given
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &testsupport.TestOversizedNameObj
-
-	err := p.Validate()
-	// Validate payload function returns an error
-	assert.NotNil(rest.T(), err)
-	assert.Contains(rest.T(), err.Error(), "length of type.name must be less than or equal to 62 but got")
-}
-
-func (rest *TestSpaceREST) TestFailValidationSpaceNameStartWith() {
-	// given
-	p := minimumRequiredCreateSpace()
-	invalidSpaceName := "_TestSpace"
-	p.Data.Attributes.Name = &invalidSpaceName
-
-	err := p.Validate()
-	// Validate payload function returns an error
-	assert.NotNil(rest.T(), err)
-	assert.Contains(rest.T(), err.Error(), "type.name must match the regexp")
-}
-
-func (rest *TestSpaceREST) TestSuccessCreateSpace() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestSuccessCreateSpace-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	// when
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// then
-	require.NotNil(rest.T(), created.Data)
-	require.NotNil(rest.T(), created.Data.Attributes)
-	assert.NotNil(rest.T(), created.Data.Attributes.CreatedAt)
-	assert.NotNil(rest.T(), created.Data.Attributes.UpdatedAt)
-	require.NotNil(rest.T(), created.Data.Attributes.Name)
-	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
-	require.NotNil(rest.T(), created.Data.Links)
-	assert.NotNil(rest.T(), created.Data.Links.Self)
-}
-
-func (rest *TestSpaceREST) SecuredSpaceAreaController(identity account.Identity) (*goa.Service, *SpaceAreasController) {
+func (s *SpaceControllerTestSuite) SecuredSpaceAreaController(identity account.Identity) (*goa.Service, *SpaceAreasController) {
 	svc := testsupport.ServiceAsUser("Area-Service", identity)
-	return svc, NewSpaceAreasController(svc, rest.db, rest.Configuration)
+	return svc, NewSpaceAreasController(svc, s.db, s.Configuration)
 }
 
-func (rest *TestSpaceREST) SecuredSpaceIterationController(identity account.Identity) (*goa.Service, *SpaceIterationsController) {
+func (s *SpaceControllerTestSuite) SecuredSpaceIterationController(identity account.Identity) (*goa.Service, *SpaceIterationsController) {
 	svc := testsupport.ServiceAsUser("Iteration-Service", identity)
-	return svc, NewSpaceIterationsController(svc, rest.db, rest.Configuration)
+	return svc, NewSpaceIterationsController(svc, s.db, s.Configuration)
 }
 
-func (rest *TestSpaceREST) TestSuccessCreateSpaceAndDefaultArea() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestSuccessCreateSpaceAndDefaultArea-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	// when
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	require.NotNil(rest.T(), created.Data)
-	spaceAreaSvc, spaceAreaCtrl := rest.SecuredSpaceAreaController(testsupport.TestIdentity)
-	_, areaList := test.ListSpaceAreasOK(rest.T(), spaceAreaSvc.Context, spaceAreaSvc, spaceAreaCtrl, *created.Data.ID, nil, nil)
-	// then
-	// only 1 default gets created.
-	assert.Len(rest.T(), areaList.Data, 1)
-	assert.Equal(rest.T(), name, *areaList.Data[0].Attributes.Name)
+func (s *SpaceControllerTestSuite) TestValidateSpaceName() {
 
-	// verify if root iteration is created or not
-	spaceIterationSvc, spaceIterationCtrl := rest.SecuredSpaceIterationController(testsupport.TestIdentity)
-	_, iterationList := test.ListSpaceIterationsOK(rest.T(), spaceIterationSvc.Context, spaceIterationSvc, spaceIterationCtrl, *created.Data.ID, nil, nil)
-	require.Len(rest.T(), iterationList.Data, 1)
-	assert.Equal(rest.T(), name, *iterationList.Data[0].Attributes.Name)
+	s.T().Run("Fail - length", func(t *testing.T) {
+		// given
+		p := newCreateSpacePayload(&testsupport.TestOversizedNameObj, nil)
+		// when
+		err := p.Validate()
+		// Validate payload function returns an error
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "length of type.name must be less than or equal to 62 but got")
+	})
+
+	s.T().Run("Fail - prefix", func(t *testing.T) {
+		// given
+		invalidSpaceName := "_TestSpace"
+		p := newCreateSpacePayload(&invalidSpaceName, nil)
+		// when
+		err := p.Validate()
+		// Validate payload function returns an error
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "type.name must match the regexp")
+	})
+}
+
+func (s *SpaceControllerTestSuite) TestCreateSpace() {
+
+	s.T().Run("Fail - unsecure", func(t *testing.T) {
+		// given
+		p := newCreateSpacePayload(nil, nil)
+		svc, ctrl := s.UnSecuredController()
+		// when/then
+		test.CreateSpaceUnauthorized(t, svc.Context, svc, ctrl, p)
+	})
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestSuccessCreateSpace-")
+		p := newCreateSpacePayload(&name, nil)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		// when
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// then
+		require.NotNil(t, created.Data)
+		require.NotNil(t, created.Data.Attributes)
+		assert.NotNil(t, created.Data.Attributes.CreatedAt)
+		assert.NotNil(t, created.Data.Attributes.UpdatedAt)
+		require.NotNil(t, created.Data.Attributes.Name)
+		assert.Equal(t, name, *created.Data.Attributes.Name)
+		require.NotNil(t, created.Data.Links)
+		assert.NotNil(t, created.Data.Links.Self)
+	})
+
+	s.T().Run("ok with default area", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestSuccessCreateSpaceAndDefaultArea-")
+		p := newCreateSpacePayload(&name, nil)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		// when
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		require.NotNil(t, created.Data)
+		spaceAreaSvc, spaceAreaCtrl := s.SecuredSpaceAreaController(testsupport.TestIdentity)
+		_, areaList := test.ListSpaceAreasOK(t, spaceAreaSvc.Context, spaceAreaSvc, spaceAreaCtrl, *created.Data.ID, nil, nil)
+		// then
+		// only 1 default gets created.
+		assert.Len(t, areaList.Data, 1)
+		assert.Equal(t, name, *areaList.Data[0].Attributes.Name)
+
+		// verify if root iteration is created or not
+		spaceIterationSvc, spaceIterationCtrl := s.SecuredSpaceIterationController(testsupport.TestIdentity)
+		_, iterationList := test.ListSpaceIterationsOK(t, spaceIterationSvc.Context, spaceIterationSvc, spaceIterationCtrl, *created.Data.ID, nil, nil)
+		require.Len(t, iterationList.Data, 1)
+		assert.Equal(t, name, *iterationList.Data[0].Attributes.Name)
+	})
+
+	s.T().Run("ok with description", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestSuccessCreateSpaceWithDescription-")
+		description := "Space for TestSuccessCreateSpaceWithDescription"
+		p := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		// when
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// then
+		assert.NotNil(t, created.Data)
+		assert.NotNil(t, created.Data.Attributes)
+		assert.NotNil(t, created.Data.Attributes.CreatedAt)
+		assert.NotNil(t, created.Data.Attributes.UpdatedAt)
+		assert.NotNil(t, created.Data.Attributes.Name)
+		assert.Equal(t, name, *created.Data.Attributes.Name)
+		assert.NotNil(t, created.Data.Attributes.Description)
+		assert.Equal(t, description, *created.Data.Attributes.Description)
+		assert.NotNil(t, created.Data.Links)
+		assert.NotNil(t, created.Data.Links.Self)
+	})
+
+	s.T().Run("ok same name but different owner", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("SameName-")
+		description := "Space for TestSuccessCreateSameSpaceNameDifferentOwners"
+		newDescription := "Space for TestSuccessCreateSameSpaceNameDifferentOwners2"
+		a := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, a)
+		// when
+		b := newCreateSpacePayload(&name, &newDescription)
+		svc2, ctrl2 := s.SecuredController(testsupport.TestIdentity2)
+		_, created2 := test.CreateSpaceCreated(t, svc2.Context, svc2, ctrl2, b)
+		// then
+		assert.NotNil(t, created.Data)
+		assert.NotNil(t, created.Data.Attributes)
+		assert.NotNil(t, created.Data.Attributes.Name)
+		assert.Equal(t, name, *created.Data.Attributes.Name)
+		assert.NotNil(t, created2.Data)
+		assert.NotNil(t, created2.Data.Attributes)
+		assert.NotNil(t, created2.Data.Attributes.Name)
+		assert.Equal(t, name, *created2.Data.Attributes.Name)
+		assert.NotEqual(t, created.Data.Relationships.OwnedBy.Data.ID, created2.Data.Relationships.OwnedBy.Data.ID)
+	})
+
+	s.T().Run("fail same name and same owner", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("SameName-")
+		description := "Space for TestSuccessCreateSameSpaceNameDifferentOwners"
+		newDescription := "Space for TestSuccessCreateSameSpaceNameDifferentOwners2"
+		// when
+		a := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, a)
+		// then
+		assert.NotNil(t, created.Data)
+		assert.NotNil(t, created.Data.Attributes)
+		assert.NotNil(t, created.Data.Attributes.Name)
+		assert.Equal(t, name, *created.Data.Attributes.Name)
+
+		// when
+		b := newCreateSpacePayload(&name, &newDescription)
+		b.Data.Attributes.Name = &name
+		b.Data.Attributes.Description = &newDescription
+		test.CreateSpaceConflict(t, svc.Context, svc, ctrl, b)
+	})
 
 }
 
-func (rest *TestSpaceREST) TestSuccessCreateSpaceWithDescription() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestSuccessCreateSpaceWithDescription-")
-	description := "Space for TestSuccessCreateSpaceWithDescription"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	// when
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// then
-	assert.NotNil(rest.T(), created.Data)
-	assert.NotNil(rest.T(), created.Data.Attributes)
-	assert.NotNil(rest.T(), created.Data.Attributes.CreatedAt)
-	assert.NotNil(rest.T(), created.Data.Attributes.UpdatedAt)
-	assert.NotNil(rest.T(), created.Data.Attributes.Name)
-	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
-	assert.NotNil(rest.T(), created.Data.Attributes.Description)
-	assert.Equal(rest.T(), description, *created.Data.Attributes.Description)
-	assert.NotNil(rest.T(), created.Data.Links)
-	assert.NotNil(rest.T(), created.Data.Links.Self)
+func (s *SpaceControllerTestSuite) TestDeleteSpace() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestFailDeleteSpaceDifferentOwner-")
+		description := "Space for TestFailDeleteSpaceDifferentOwner"
+		p := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// when
+		svc2, ctrl2 := s.SecuredController(testsupport.TestIdentity)
+		test.DeleteSpaceOK(t, svc2.Context, svc2, ctrl2, *created.Data.ID)
+	})
+
+	s.T().Run("fail - different owner", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestFailDeleteSpaceDifferentOwner-")
+		description := "Space for TestFailDeleteSpaceDifferentOwner"
+		p := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// when
+		svc2, ctrl2 := s.SecuredController(testsupport.TestIdentity2)
+		_, errors := test.DeleteSpaceForbidden(t, svc2.Context, svc2, ctrl2, *created.Data.ID)
+		// then
+		assert.NotEmpty(t, errors.Errors)
+		assert.Contains(t, errors.Errors[0].Detail, "user is not the space owner")
+	})
 }
 
-func (rest *TestSpaceREST) TestFailDeleteSpaceDifferentOwner() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestFailDeleteSpaceDifferentOwner-")
-	description := "Space for TestFailDeleteSpaceDifferentOwner"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
-	_, errors := test.DeleteSpaceForbidden(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID)
-	// then
-	assert.NotEmpty(rest.T(), errors.Errors)
-	assert.Contains(rest.T(), errors.Errors[0].Detail, "user is not the space owner")
+func (s *SpaceControllerTestSuite) TestUpdateSpace() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace-")
+		description := "Space for TestSuccessUpdateSpace"
+		newName := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace")
+		newDescription := "Space for TestSuccessUpdateSpace2"
+		p := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		u := newUpdateSpacePayload()
+		u.Data.ID = created.Data.ID
+		u.Data.Attributes.Version = created.Data.Attributes.Version
+		u.Data.Attributes.Name = &newName
+		u.Data.Attributes.Description = &newDescription
+		// when
+		_, updated := test.UpdateSpaceOK(t, svc.Context, svc, ctrl, *created.Data.ID, u)
+		// then
+		assert.Equal(t, newName, *updated.Data.Attributes.Name)
+		assert.Equal(t, newDescription, *updated.Data.Attributes.Description)
+	})
+
+	s.T().Run("fail - version conflict", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace-")
+		description := "Space for TestSuccessUpdateSpace"
+		newName := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace")
+		newDescription := "Space for TestSuccessUpdateSpace2"
+		p := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		u := newUpdateSpacePayload()
+		u.Data.ID = created.Data.ID
+		u.Data.Attributes.Version = created.Data.Attributes.Version
+		u.Data.Attributes.Name = &newName
+		u.Data.Attributes.Description = &newDescription
+		version := 123456
+		u.Data.Attributes.Version = &version
+		// when/then
+		test.UpdateSpaceConflict(t, svc.Context, svc, ctrl, *created.Data.ID, u)
+	})
+
+	s.T().Run("fail - name length", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceNameLength-")
+		p := newCreateSpacePayload(&name, nil)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// when / then
+		u := newUpdateSpacePayload()
+		u.Data.ID = created.Data.ID
+		u.Data.Attributes.Version = created.Data.Attributes.Version
+		p.Data.Attributes.Name = &testsupport.TestOversizedNameObj
+		svc2, ctrl2 := s.SecuredController(testsupport.TestIdentity2)
+		test.UpdateSpaceBadRequest(t, svc2.Context, svc2, ctrl2, *created.Data.ID, u)
+	})
+
+	s.T().Run("fail - different owner", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceDifferentOwner-")
+		description := "Space for TestFailUpdateSpaceDifferentOwner"
+		newName := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceDifferentOwner-")
+		newDescription := "Space for TestFailUpdateSpaceDifferentOwner2"
+		p := newCreateSpacePayload(&name, &description)
+		p.Data.Attributes.Name = &name
+		p.Data.Attributes.Description = &description
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// when
+		u := newUpdateSpacePayload()
+		u.Data.ID = created.Data.ID
+		u.Data.Attributes.Version = created.Data.Attributes.Version
+		u.Data.Attributes.Name = &newName
+		u.Data.Attributes.Description = &newDescription
+		svc2, ctrl2 := s.SecuredController(testsupport.TestIdentity2)
+		_, errors := test.UpdateSpaceForbidden(t, svc2.Context, svc2, ctrl2, *created.Data.ID, u)
+		// then
+		assert.NotEmpty(t, errors.Errors)
+		assert.Contains(t, errors.Errors[0].Detail, "User is not the space owner")
+	})
+
+	s.T().Run("fail - unsecured", func(t *testing.T) {
+		// given
+		u := newUpdateSpacePayload()
+		svc, ctrl := s.UnSecuredController()
+		// when/then
+		test.UpdateSpaceUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4(), u)
+	})
+
+	s.T().Run("fail - not found", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceNotFound-")
+		version := 0
+		id := uuid.NewV4()
+		u := newUpdateSpacePayload()
+		u.Data.Attributes.Name = &name
+		u.Data.Attributes.Version = &version
+		u.Data.ID = &id
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		// when/then
+		test.UpdateSpaceNotFound(t, svc.Context, svc, ctrl, id, u)
+	})
+
+	s.T().Run("fail - missing name", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceMissingName-")
+		p := newCreateSpacePayload(&name, nil)
+		p.Data.Attributes.Name = &name
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		u := newUpdateSpacePayload()
+		u.Data.ID = created.Data.ID
+		u.Data.Attributes.Version = created.Data.Attributes.Version
+		// when/then
+		test.UpdateSpaceBadRequest(t, svc.Context, svc, ctrl, *created.Data.ID, u)
+	})
+
+	s.T().Run("fail - missing version", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceMissingVersion-")
+		newName := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceMissingVersion-")
+		p := newCreateSpacePayload(&name, nil)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		u := newUpdateSpacePayload()
+		u.Data.ID = created.Data.ID
+		u.Data.Attributes.Name = &newName
+		// when/then
+		test.UpdateSpaceBadRequest(t, svc.Context, svc, ctrl, *created.Data.ID, u)
+	})
+
 }
 
-func (rest *TestSpaceREST) TestSuccessDeleteSpaceSameOwner() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestFailDeleteSpaceDifferentOwner-")
-	description := "Space for TestFailDeleteSpaceDifferentOwner"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity)
-	test.DeleteSpaceOK(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID)
+func (s *SpaceControllerTestSuite) TestShowSpace() {
+
+	// needed to valid comparison with golden files
+	resetFn := s.DisableGormCallbacks()
+	defer resetFn()
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestShowSpaceOK-")
+		description := "Space for TestShowSpaceOK"
+		p := newCreateSpacePayload(&name, &description)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// when
+		res, fetched := test.ShowSpaceOK(t, svc.Context, svc, ctrl, *created.Data.ID, nil, nil)
+		// then
+		eTag, lastModified, _ := assertResponseHeaders(t, res)
+		assert.Equal(t, app.ToHTTPTime(getSpaceUpdatedAt(*created)), lastModified)
+		assert.Equal(t, generateSpaceTag(*created), eTag)
+		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show_space_ok.golden.json"), fetched)
+	})
+
+	s.T().Run("conditional request", func(t *testing.T) {
+		t.Run("ok with expired modified-since header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestShowSpaceOKUsingExpiredIfModifiedSinceHeader-")
+			description := "Space for TestShowSpaceOKUsingExpiredIfModifiedSinceHeader"
+			p := newCreateSpacePayload(&name, &description)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			// when
+			ifModifiedSince := app.ToHTTPTime(created.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
+			res, _ := test.ShowSpaceOK(t, svc.Context, svc, ctrl, *created.Data.ID, &ifModifiedSince, nil)
+			// then
+			eTag, lastModified, _ := assertResponseHeaders(t, res)
+			assert.Equal(t, app.ToHTTPTime(getSpaceUpdatedAt(*created)), lastModified)
+			assert.Equal(t, generateSpaceTag(*created), eTag)
+		})
+
+		t.Run("ok with expired if-none-match header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestShowSpaceOKUsingExpiredIfNoneMatchHeader-")
+			description := "Space for TestShowSpaceOKUsingExpiredIfNoneMatchHeader"
+			p := newCreateSpacePayload(&name, &description)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			// when
+			ifNoneMatch := "foo_etag"
+			res, _ := test.ShowSpaceOK(t, svc.Context, svc, ctrl, *created.Data.ID, nil, &ifNoneMatch)
+			// then
+			eTag, lastModified, _ := assertResponseHeaders(t, res)
+			assert.Equal(t, app.ToHTTPTime(getSpaceUpdatedAt(*created)), lastModified)
+			assert.Equal(t, generateSpaceTag(*created), eTag)
+		})
+
+		t.Run("not modified with modified-since header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestShowSpaceNotModifiedUsingIfModifiedSinceHeader-")
+			description := "Space for TestShowSpaceNotModifiedUsingIfModifiedSinceHeader"
+			p := newCreateSpacePayload(&name, &description)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			// when/then
+			ifModifiedSince := app.ToHTTPTime(getSpaceUpdatedAt(*created))
+			test.ShowSpaceNotModified(t, svc.Context, svc, ctrl, *created.Data.ID, &ifModifiedSince, nil)
+		})
+
+		t.Run("not modified with if-none-match header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestShowSpaceNotModifiedUsingIfNoneMatchHeader-")
+			description := "Space for TestShowSpaceNotModifiedUsingIfNoneMatchHeader"
+			p := newCreateSpacePayload(&name, &description)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			// when/then
+			ifNoneMatch := generateSpaceTag(*created)
+			test.ShowSpaceNotModified(t, svc.Context, svc, ctrl, *created.Data.ID, nil, &ifNoneMatch)
+
+		})
+	})
+
+	s.T().Run("fail - not found", func(t *testing.T) {
+		// given
+		svc, ctrl := s.UnSecuredController()
+		// when/then
+		test.ShowSpaceNotFound(t, svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
+	})
+
 }
 
-func (rest *TestSpaceREST) TestUpdateSpaceOK() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace-")
-	description := "Space for TestSuccessUpdateSpace"
-	newName := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace")
-	newDescription := "Space for TestSuccessUpdateSpace2"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	u := minimumRequiredUpdateSpace()
-	u.Data.ID = created.Data.ID
-	u.Data.Attributes.Version = created.Data.Attributes.Version
-	u.Data.Attributes.Name = &newName
-	u.Data.Attributes.Description = &newDescription
-	// when
-	_, updated := test.UpdateSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, u)
-	// then
-	assert.Equal(rest.T(), newName, *updated.Data.Attributes.Name)
-	assert.Equal(rest.T(), newDescription, *updated.Data.Attributes.Description)
+func (s *SpaceControllerTestSuite) TestListSpaces() {
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		name := testsupport.CreateRandomValidTestName("TestListSpacesOK-")
+		p := newCreateSpacePayload(&name, nil)
+		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+		test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+		// when
+		_, list := test.ListSpaceOK(t, svc.Context, svc, ctrl, nil, nil, nil, nil)
+		// then
+		require.NotNil(t, list)
+		require.NotEmpty(t, list.Data)
+	})
+
+	s.T().Run("fail - unauthorized", func(t *testing.T) {
+		// given
+		svc, ctrl := s.UnSecuredController()
+		// then
+		test.ListSpaceUnauthorized(t, svc.Context, svc, ctrl, nil, nil, nil, nil)
+	})
+
+	s.T().Run("conditional request", func(t *testing.T) {
+
+		t.Run("ok with expired modified-since header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestListSpacesOKUsingExpiredIfModifiedSinceHeader-")
+			p := newCreateSpacePayload(&name, nil)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			_, createdSpace := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			// when
+			t.Logf("space created at=%s", createdSpace.Data.Attributes.CreatedAt.UTC().String())
+			ifModifiedSince := app.ToHTTPTime(createdSpace.Data.Attributes.CreatedAt.Add(-1 * time.Hour))
+			t.Logf("requesting with `If-Modified-Since`=%s", ifModifiedSince)
+			_, list := test.ListSpaceOK(t, svc.Context, svc, ctrl, nil, nil, &ifModifiedSince, nil)
+			// then
+			require.NotNil(t, list)
+			require.NotEmpty(t, list.Data)
+		})
+
+		t.Run("ok with expired if-none-match header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestListSpacesOKUsingExpiredIfNoneMatchHeader-")
+			p := newCreateSpacePayload(&name, nil)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			// when
+			ifNoneMatch := "foo-spaces"
+			_, list := test.ListSpaceOK(t, svc.Context, svc, ctrl, nil, nil, nil, &ifNoneMatch)
+			// then
+			require.NotNil(t, list)
+			require.NotEmpty(t, list.Data)
+		})
+
+		t.Run("not modified with modified-since header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestListSpacesNotModifiedUsingIfModifiedSinceHeader-")
+			p := newCreateSpacePayload(&name, nil)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			_, createdSpace := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			// when/then
+			ifModifiedSince := app.ToHTTPTime(*createdSpace.Data.Attributes.UpdatedAt)
+			test.ListSpaceNotModified(t, svc.Context, svc, ctrl, nil, nil, &ifModifiedSince, nil)
+		})
+
+		t.Run("not modified with if-none-match header", func(t *testing.T) {
+			// given
+			name := testsupport.CreateRandomValidTestName("TestListSpacesNotModifiedUsingIfNoneMatchHeader-")
+			p := newCreateSpacePayload(&name, nil)
+			svc, ctrl := s.SecuredController(testsupport.TestIdentity)
+			test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+			_, spaceList := test.ListSpaceOK(t, svc.Context, svc, ctrl, nil, nil, nil, nil)
+			// when/then
+			ifNoneMatch := generateSpacesTag(*spaceList)
+			test.ListSpaceNotModified(t, svc.Context, svc, ctrl, nil, nil, nil, &ifNoneMatch)
+		})
+	})
 }
 
-func (rest *TestSpaceREST) TestUpdateSpaceConflict() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace-")
-	description := "Space for TestSuccessUpdateSpace"
-	newName := testsupport.CreateRandomValidTestName("TestSuccessUpdateSpace")
-	newDescription := "Space for TestSuccessUpdateSpace2"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	u := minimumRequiredUpdateSpace()
-	u.Data.ID = created.Data.ID
-	u.Data.Attributes.Version = created.Data.Attributes.Version
-	u.Data.Attributes.Name = &newName
-	u.Data.Attributes.Description = &newDescription
-	version := 123456
-	u.Data.Attributes.Version = &version
-	// when/then
-	test.UpdateSpaceConflict(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, u)
-}
-
-func (rest *TestSpaceREST) TestFailUpdateSpaceNameLength() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceNameLength-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	u := minimumRequiredUpdateSpace()
-	u.Data.ID = created.Data.ID
-	u.Data.Attributes.Version = created.Data.Attributes.Version
-	p.Data.Attributes.Name = &testsupport.TestOversizedNameObj
-	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
-
-	test.UpdateSpaceBadRequest(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID, u)
-}
-
-func (rest *TestSpaceREST) TestFailUpdateSpaceDifferentOwner() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceDifferentOwner-")
-	description := "Space for TestFailUpdateSpaceDifferentOwner"
-	newName := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceDifferentOwner-")
-	newDescription := "Space for TestFailUpdateSpaceDifferentOwner2"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	u := minimumRequiredUpdateSpace()
-	u.Data.ID = created.Data.ID
-	u.Data.Attributes.Version = created.Data.Attributes.Version
-	u.Data.Attributes.Name = &newName
-	u.Data.Attributes.Description = &newDescription
-	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
-	_, errors := test.UpdateSpaceForbidden(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID, u)
-	// then
-	assert.NotEmpty(rest.T(), errors.Errors)
-	assert.Contains(rest.T(), errors.Errors[0].Detail, "User is not the space owner")
-}
-
-func (rest *TestSpaceREST) TestFailUpdateSpaceUnSecure() {
-	// given
-	u := minimumRequiredUpdateSpace()
-	svc, ctrl := rest.UnSecuredController()
-	// when/then
-	test.UpdateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), u)
-}
-
-func (rest *TestSpaceREST) TestFailUpdateSpaceNotFound() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceNotFound-")
-	version := 0
-	id := uuid.NewV4()
-	u := minimumRequiredUpdateSpace()
-	u.Data.Attributes.Name = &name
-	u.Data.Attributes.Version = &version
-	u.Data.ID = &id
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	// when/then
-	test.UpdateSpaceNotFound(rest.T(), svc.Context, svc, ctrl, id, u)
-}
-
-func (rest *TestSpaceREST) TestFailUpdateSpaceMissingName() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceMissingName-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	u := minimumRequiredUpdateSpace()
-	u.Data.ID = created.Data.ID
-	u.Data.Attributes.Version = created.Data.Attributes.Version
-	// when/then
-	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, u)
-}
-
-func (rest *TestSpaceREST) TestFailUpdateSpaceMissingVersion() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceMissingVersion-")
-	newName := testsupport.CreateRandomValidTestName("TestFailUpdateSpaceMissingVersion-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	u := minimumRequiredUpdateSpace()
-	u.Data.ID = created.Data.ID
-	u.Data.Attributes.Name = &newName
-	// when/then
-	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, u)
-}
-
-func (rest *TestSpaceREST) TestShowSpaceOK() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestShowSpaceOK-")
-	description := "Space for TestShowSpaceOK"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, nil, nil)
-	// then
-	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
-	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
-	assert.Equal(rest.T(), *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
-	assert.Equal(rest.T(), *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
-	require.NotNil(rest.T(), res.Header()[app.LastModified])
-	assert.Equal(rest.T(), app.ToHTTPTime(getSpaceUpdatedAt(*created)), res.Header()[app.LastModified][0])
-	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.NotNil(rest.T(), res.Header()[app.CacheControl][0])
-	require.NotNil(rest.T(), res.Header()[app.ETag])
-	assert.Equal(rest.T(), app.GenerateEntityTag(ConvertSpaceToModel(*created.Data)), res.Header()[app.ETag][0])
-	// Test that it contains the right link for backlog items
-	subStringBacklogUrl := fmt.Sprintf("/%s/backlog", fetched.Data.ID.String())
-	assert.Contains(rest.T(), *fetched.Data.Links.Backlog.Self, subStringBacklogUrl)
-	assert.Equal(rest.T(), fetched.Data.Links.Backlog.Meta.TotalCount, 0)
-
-	// Test that it contains the right relationship values
-	subString := fmt.Sprintf("/%s/iterations", fetched.Data.ID.String())
-	assert.Contains(rest.T(), *fetched.Data.Relationships.Iterations.Links.Related, subString)
-	subStringAreaUrl := fmt.Sprintf("/%s/areas", fetched.Data.ID.String())
-	assert.Contains(rest.T(), *fetched.Data.Relationships.Areas.Links.Related, subStringAreaUrl)
-}
-
-func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfModifiedSinceHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestShowSpaceOKUsingExpiredIfModifiedSinceHeader-")
-	description := "Space for TestShowSpaceOKUsingExpiredIfModifiedSinceHeader"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	ifModifiedSince := app.ToHTTPTime(created.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
-	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, &ifModifiedSince, nil)
-	// then
-	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
-	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
-	assert.Equal(rest.T(), *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
-	assert.Equal(rest.T(), *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
-	require.NotNil(rest.T(), res.Header()[app.LastModified])
-	assert.Equal(rest.T(), app.ToHTTPTime(getSpaceUpdatedAt(*created)), res.Header()[app.LastModified][0])
-	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.NotNil(rest.T(), res.Header()[app.CacheControl][0])
-	require.NotNil(rest.T(), res.Header()[app.ETag])
-	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
-}
-
-func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfNoneMatchHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestShowSpaceOKUsingExpiredIfNoneMatchHeader-")
-	description := "Space for TestShowSpaceOKUsingExpiredIfNoneMatchHeader"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	ifNoneMatch := "foo_etag"
-	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, nil, &ifNoneMatch)
-	// then
-	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
-	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
-	assert.Equal(rest.T(), *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
-	assert.Equal(rest.T(), *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
-	require.NotNil(rest.T(), res.Header()[app.LastModified])
-	assert.Equal(rest.T(), app.ToHTTPTime(getSpaceUpdatedAt(*created)), res.Header()[app.LastModified][0])
-	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.NotNil(rest.T(), res.Header()[app.CacheControl][0])
-	require.NotNil(rest.T(), res.Header()[app.ETag])
-	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
-}
-
-func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfModifiedSinceHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestShowSpaceNotModifiedUsingIfModifiedSinceHeader-")
-	description := "Space for TestShowSpaceNotModifiedUsingIfModifiedSinceHeader"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when/then
-	ifModifiedSince := app.ToHTTPTime(getSpaceUpdatedAt(*created))
-	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, &ifModifiedSince, nil)
-}
-
-func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfNoneMatchHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestShowSpaceNotModifiedUsingIfNoneMatchHeader-")
-	description := "Space for TestShowSpaceNotModifiedUsingIfNoneMatchHeader"
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	p.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when/then
-	ifNoneMatch := generateSpaceTag(*created)
-	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, nil, &ifNoneMatch)
-
-	t := rest.T()
-	_, fetched := test.ShowSpaceOK(t, svc.Context, svc, ctrl, *created.Data.ID, nil, nil)
-	assert.Equal(t, created.Data.ID, fetched.Data.ID)
-	assert.Equal(t, *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
-	assert.Equal(t, *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
-	assert.Equal(t, *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
-
-	// verify list-WI URL exists in Relationships.Links
-	require.NotNil(t, fetched.Data.Relationships.Workitems)
-	require.NotNil(t, fetched.Data.Relationships.Workitems.Links)
-	require.NotNil(t, fetched.Data.Relationships.Workitems.Links.Related)
-	subStringWI := fmt.Sprintf("/%s/workitems", created.Data.ID.String())
-	assert.Contains(t, *fetched.Data.Relationships.Workitems.Links.Related, subStringWI)
-
-	// verify list-WIT URL exists in Relationships.Links
-	require.NotNil(t, fetched.Data.Links)
-	require.NotNil(t, fetched.Data.Links.Workitemtypes)
-	subStringWIL := fmt.Sprintf("/%s/workitemtypes", created.Data.ID.String())
-	assert.Contains(t, *fetched.Data.Links.Workitemtypes, subStringWIL)
-
-	// verify list-WILT URL exists in Relationships.Links
-	require.NotNil(t, fetched.Data.Links)
-	require.NotNil(t, fetched.Data.Links.Workitemlinktypes)
-	subStringWILT := fmt.Sprintf("/%s/workitemlinktypes", created.Data.ID.String())
-	assert.Contains(t, *fetched.Data.Links.Workitemlinktypes, subStringWILT)
-
-	// verify list-filters URL exists in Links
-	require.NotNil(t, fetched.Data.Links.Filters)
-	assert.Contains(t, *fetched.Data.Links.Filters, "/filters")
-
-	// verify list-Collaborators URL exists in Relationships.Links
-	require.NotNil(t, fetched.Data.Relationships.Collaborators)
-	require.NotNil(t, fetched.Data.Relationships.Collaborators.Links)
-	require.NotNil(t, fetched.Data.Relationships.Collaborators.Links.Related)
-	subStringCollaborators := fmt.Sprintf("/%s/collaborators", created.Data.ID.String())
-	assert.Contains(t, *fetched.Data.Relationships.Collaborators.Links.Related, subStringCollaborators)
-
-	// verify list-WITG URL exists in Relationships.Links
-	require.NotNil(t, fetched.Data.Links.Workitemtypegroups)
-	subStringWITG := fmt.Sprintf("/%s/workitemtypegroups", created.Data.ID.String())
-	assert.Contains(t, *fetched.Data.Links.Workitemtypegroups, subStringWITG)
-
-	// verify list-Label URL exists in Relationships.Links
-	require.NotNil(t, fetched.Data.Relationships.Labels)
-	require.NotNil(t, fetched.Data.Relationships.Labels.Links)
-	require.NotNil(t, fetched.Data.Relationships.Labels.Links.Related)
-	subStringLabels := fmt.Sprintf("/%s/labels", created.Data.ID.String())
-	assert.Contains(t, *fetched.Data.Relationships.Labels.Links.Related, subStringLabels)
-}
-
-func (rest *TestSpaceREST) TestFailShowSpaceNotFound() {
-	// given
-	svc, ctrl := rest.UnSecuredController()
-	// when/then
-	test.ShowSpaceNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
-}
-
-func (rest *TestSpaceREST) TestListSpacesOK() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestListSpacesOK-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	_, list := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, nil)
-	// then
-	require.NotNil(rest.T(), list)
-	require.NotEmpty(rest.T(), list.Data)
-}
-
-func (rest *TestSpaceREST) TestListSpacesUnauthorized() {
-	// given
-	svc, ctrl := rest.UnSecuredController()
-	// then
-	test.ListSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, nil)
-}
-
-func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfModifiedSinceHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestListSpacesOKUsingExpiredIfModifiedSinceHeader-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, createdSpace := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	rest.T().Logf("space created at=%s", createdSpace.Data.Attributes.CreatedAt.UTC().String())
-	ifModifiedSince := app.ToHTTPTime(createdSpace.Data.Attributes.CreatedAt.Add(-1 * time.Hour))
-	rest.T().Logf("requesting with `If-Modified-Since`=%s", ifModifiedSince)
-	_, list := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, &ifModifiedSince, nil)
-	// then
-	require.NotNil(rest.T(), list)
-	require.NotEmpty(rest.T(), list.Data)
-}
-
-func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfNoneMatchHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestListSpacesOKUsingExpiredIfNoneMatchHeader-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when
-	ifNoneMatch := "fooo-spaces"
-	_, list := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, &ifNoneMatch)
-	// then
-	require.NotNil(rest.T(), list)
-	require.NotEmpty(rest.T(), list.Data)
-}
-
-func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfModifiedSinceHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestListSpacesNotModifiedUsingIfModifiedSinceHeader-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, createdSpace := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	// when/then
-	ifModifiedSince := app.ToHTTPTime(*createdSpace.Data.Attributes.UpdatedAt)
-	test.ListSpaceNotModified(rest.T(), svc.Context, svc, ctrl, nil, nil, &ifModifiedSince, nil)
-}
-
-func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfNoneMatchHeader() {
-	// given
-	name := testsupport.CreateRandomValidTestName("TestListSpacesNotModifiedUsingIfNoneMatchHeader-")
-	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &name
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
-	_, spaceList := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, nil)
-	// when/then
-	ifNoneMatch := generateSpacesTag(*spaceList)
-	test.ListSpaceNotModified(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, &ifNoneMatch)
-}
-
-func (rest *TestSpaceREST) TestSuccessCreateSameSpaceNameDifferentOwners() {
-	// given
-	name := testsupport.CreateRandomValidTestName("SameName-")
-	description := "Space for TestSuccessCreateSameSpaceNameDifferentOwners"
-	newDescription := "Space for TestSuccessCreateSameSpaceNameDifferentOwners2"
-	a := minimumRequiredCreateSpace()
-	a.Data.Attributes.Name = &name
-	a.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, a)
-	// when
-	b := minimumRequiredCreateSpace()
-	b.Data.Attributes.Name = &name
-	b.Data.Attributes.Description = &newDescription
-	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
-	_, created2 := test.CreateSpaceCreated(rest.T(), svc2.Context, svc2, ctrl2, b)
-	// then
-	assert.NotNil(rest.T(), created.Data)
-	assert.NotNil(rest.T(), created.Data.Attributes)
-	assert.NotNil(rest.T(), created.Data.Attributes.Name)
-	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
-	assert.NotNil(rest.T(), created2.Data)
-	assert.NotNil(rest.T(), created2.Data.Attributes)
-	assert.NotNil(rest.T(), created2.Data.Attributes.Name)
-	assert.Equal(rest.T(), name, *created2.Data.Attributes.Name)
-	assert.NotEqual(rest.T(), created.Data.Relationships.OwnedBy.Data.ID, created2.Data.Relationships.OwnedBy.Data.ID)
-}
-
-func (rest *TestSpaceREST) TestFailCreateSameSpaceNameSameOwner() {
-	// given
-	name := testsupport.CreateRandomValidTestName("SameName-")
-	description := "Space for TestSuccessCreateSameSpaceNameDifferentOwners"
-	newDescription := "Space for TestSuccessCreateSameSpaceNameDifferentOwners2"
-	// when
-	a := minimumRequiredCreateSpace()
-	a.Data.Attributes.Name = &name
-	a.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, a)
-	// then
-	assert.NotNil(rest.T(), created.Data)
-	assert.NotNil(rest.T(), created.Data.Attributes)
-	assert.NotNil(rest.T(), created.Data.Attributes.Name)
-	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
-
-	// when
-	b := minimumRequiredCreateSpace()
-	b.Data.Attributes.Name = &name
-	b.Data.Attributes.Description = &newDescription
-	test.CreateSpaceConflict(rest.T(), svc.Context, svc, ctrl, b)
-}
-
-func minimumRequiredCreateSpace() *app.CreateSpacePayload {
-	return &app.CreateSpacePayload{
-		Data: &app.Space{
-			Type:       "spaces",
-			Attributes: &app.SpaceAttributes{},
-		},
-	}
-}
-
-func CreateSpacePayload(name, description string) *app.CreateSpacePayload {
+func newCreateSpacePayload(name, description *string) *app.CreateSpacePayload {
 	return &app.CreateSpacePayload{
 		Data: &app.Space{
 			Type: "spaces",
 			Attributes: &app.SpaceAttributes{
-				Name:        &name,
-				Description: &description,
+				Name:        name,
+				Description: description,
 			},
 		},
 	}
 }
 
-func minimumRequiredUpdateSpace() *app.UpdateSpacePayload {
+func newUpdateSpacePayload() *app.UpdateSpacePayload {
 	return &app.UpdateSpacePayload{
 		Data: &app.Space{
 			Type:       "spaces",

--- a/controller/test-files/search/search_codebase_per_url_multi_match.json
+++ b/controller/test-files/search/search_codebase_per_url_multi_match.json
@@ -8,21 +8,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "3bd4d12f-fc2a-42dd-bcde-329fc69ef98c",
+      "id": "6003af1d-05dd-4089-a85b-2b7f1898a5a4",
       "links": {
-        "edit": "http:///api/codebases/3bd4d12f-fc2a-42dd-bcde-329fc69ef98c/edit",
-        "related": "http:///api/codebases/3bd4d12f-fc2a-42dd-bcde-329fc69ef98c",
-        "self": "http:///api/codebases/3bd4d12f-fc2a-42dd-bcde-329fc69ef98c"
+        "edit": "http:///api/codebases/6003af1d-05dd-4089-a85b-2b7f1898a5a4/edit",
+        "related": "http:///api/codebases/6003af1d-05dd-4089-a85b-2b7f1898a5a4",
+        "self": "http:///api/codebases/6003af1d-05dd-4089-a85b-2b7f1898a5a4"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "262de8f6-1e88-492b-b357-1768db5647e5",
+            "id": "95c18030-9087-4db8-a456-583cac5576e4",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5",
-            "self": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4",
+            "self": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4"
           }
         }
       },
@@ -36,21 +36,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "dc2d9c8a-0842-43a1-922a-00a1ae76313f",
+      "id": "932dcc48-23ef-496e-b5a2-e112cef716f0",
       "links": {
-        "edit": "http:///api/codebases/dc2d9c8a-0842-43a1-922a-00a1ae76313f/edit",
-        "related": "http:///api/codebases/dc2d9c8a-0842-43a1-922a-00a1ae76313f",
-        "self": "http:///api/codebases/dc2d9c8a-0842-43a1-922a-00a1ae76313f"
+        "edit": "http:///api/codebases/932dcc48-23ef-496e-b5a2-e112cef716f0/edit",
+        "related": "http:///api/codebases/932dcc48-23ef-496e-b5a2-e112cef716f0",
+        "self": "http:///api/codebases/932dcc48-23ef-496e-b5a2-e112cef716f0"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "478b96bb-68e2-4285-9b77-e47d10ed83cd",
+            "id": "a8c3bd45-c124-44dc-95a5-9613567cbfb7",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd",
-            "self": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7",
+            "self": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7"
           }
         }
       },
@@ -64,21 +64,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "9edc1dfe-f845-4abc-831f-a90cd06ec4d3",
+      "id": "3aa39498-cf74-4ee4-bf78-5d792e7fd2b9",
       "links": {
-        "edit": "http:///api/codebases/9edc1dfe-f845-4abc-831f-a90cd06ec4d3/edit",
-        "related": "http:///api/codebases/9edc1dfe-f845-4abc-831f-a90cd06ec4d3",
-        "self": "http:///api/codebases/9edc1dfe-f845-4abc-831f-a90cd06ec4d3"
+        "edit": "http:///api/codebases/3aa39498-cf74-4ee4-bf78-5d792e7fd2b9/edit",
+        "related": "http:///api/codebases/3aa39498-cf74-4ee4-bf78-5d792e7fd2b9",
+        "self": "http:///api/codebases/3aa39498-cf74-4ee4-bf78-5d792e7fd2b9"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "59848f9f-b5bd-4183-8325-465f8ec384f6",
+            "id": "a91074a8-406b-4e78-8765-eb2fdf28e720",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6",
-            "self": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720",
+            "self": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720"
           }
         }
       },
@@ -92,21 +92,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "e93f8371-93d9-47cd-910b-eb1157a126db",
+      "id": "b92d0db4-1154-4a3b-9013-7926c9af1925",
       "links": {
-        "edit": "http:///api/codebases/e93f8371-93d9-47cd-910b-eb1157a126db/edit",
-        "related": "http:///api/codebases/e93f8371-93d9-47cd-910b-eb1157a126db",
-        "self": "http:///api/codebases/e93f8371-93d9-47cd-910b-eb1157a126db"
+        "edit": "http:///api/codebases/b92d0db4-1154-4a3b-9013-7926c9af1925/edit",
+        "related": "http:///api/codebases/b92d0db4-1154-4a3b-9013-7926c9af1925",
+        "self": "http:///api/codebases/b92d0db4-1154-4a3b-9013-7926c9af1925"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "9829d8fb-cba6-4338-8cba-dab08bea5a13",
+            "id": "d78c9c5a-060a-490a-85ef-3403f2719ea2",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13",
-            "self": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2",
+            "self": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2"
           }
         }
       },
@@ -120,21 +120,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "4484cf74-c6d0-4eff-a15e-96d3d64c1774",
+      "id": "43d72950-0733-4289-8a8b-0ec15c32aeca",
       "links": {
-        "edit": "http:///api/codebases/4484cf74-c6d0-4eff-a15e-96d3d64c1774/edit",
-        "related": "http:///api/codebases/4484cf74-c6d0-4eff-a15e-96d3d64c1774",
-        "self": "http:///api/codebases/4484cf74-c6d0-4eff-a15e-96d3d64c1774"
+        "edit": "http:///api/codebases/43d72950-0733-4289-8a8b-0ec15c32aeca/edit",
+        "related": "http:///api/codebases/43d72950-0733-4289-8a8b-0ec15c32aeca",
+        "self": "http:///api/codebases/43d72950-0733-4289-8a8b-0ec15c32aeca"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "ee37762e-f9b3-49f1-b317-b29a69e1ab53",
+            "id": "e8026936-16cc-4f7c-9cf6-97b30916d6ba",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53",
-            "self": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba",
+            "self": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba"
           }
         }
       },
@@ -146,41 +146,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 455bc143-0032-4323-a88c-f1f44be60961",
+        "name": "space 1c8cfb75-bd4c-4025-9a81-8ce8302e37a6",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "262de8f6-1e88-492b-b357-1768db5647e5",
+      "id": "95c18030-9087-4db8-a456-583cac5576e4",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/backlog"
+          "self": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5",
-        "self": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5",
-        "workitemlinktypes": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypes"
+        "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4",
+        "self": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4",
+        "workitemlinktypes": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/95c18030-9087-4db8-a456-583cac5576e4/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/areas"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/backlog"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/codebases"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/collaborators"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/collaborators"
           }
         },
         "filters": {
@@ -190,41 +190,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/iterations"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/labels"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemlinktypes"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitems"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/95c18030-9087-4db8-a456-583cac5576e4/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/262de8f6-1e88-492b-b357-1768db5647e5/workitemtypes"
+            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemtypes"
           }
         }
       },
@@ -234,41 +234,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 9a8affd8-5527-47c5-b274-1969733c1094",
+        "name": "space abad46b1-f4ff-4876-9293-d6874efb6c07",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "478b96bb-68e2-4285-9b77-e47d10ed83cd",
+      "id": "a8c3bd45-c124-44dc-95a5-9613567cbfb7",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/backlog"
+          "self": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd",
-        "self": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd",
-        "workitemlinktypes": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypes"
+        "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7",
+        "self": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7",
+        "workitemlinktypes": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/areas"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/backlog"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/codebases"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/collaborators"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/collaborators"
           }
         },
         "filters": {
@@ -278,41 +278,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/iterations"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/labels"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemlinktypes"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitems"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/478b96bb-68e2-4285-9b77-e47d10ed83cd/workitemtypes"
+            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypes"
           }
         }
       },
@@ -322,41 +322,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 26fd2428-49cf-4b31-a21e-9e5e7e464c34",
+        "name": "space e9138690-e996-405e-8396-fbc1ea0da3de",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "59848f9f-b5bd-4183-8325-465f8ec384f6",
+      "id": "a91074a8-406b-4e78-8765-eb2fdf28e720",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/backlog"
+          "self": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6",
-        "self": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6",
-        "workitemlinktypes": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypes"
+        "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720",
+        "self": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720",
+        "workitemlinktypes": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/areas"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/backlog"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/codebases"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/collaborators"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/collaborators"
           }
         },
         "filters": {
@@ -366,41 +366,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/iterations"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/labels"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemlinktypes"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitems"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/59848f9f-b5bd-4183-8325-465f8ec384f6/workitemtypes"
+            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypes"
           }
         }
       },
@@ -410,41 +410,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 9fb71213-122b-4c74-9c86-58cbe2801a4e",
+        "name": "space 39c7f11b-8356-47ff-b149-97e661712d9d",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "9829d8fb-cba6-4338-8cba-dab08bea5a13",
+      "id": "d78c9c5a-060a-490a-85ef-3403f2719ea2",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/backlog"
+          "self": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13",
-        "self": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13",
-        "workitemlinktypes": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypes"
+        "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2",
+        "self": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2",
+        "workitemlinktypes": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/areas"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/backlog"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/codebases"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/collaborators"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/collaborators"
           }
         },
         "filters": {
@@ -454,41 +454,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/iterations"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/labels"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemlinktypes"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitems"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/9829d8fb-cba6-4338-8cba-dab08bea5a13/workitemtypes"
+            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypes"
           }
         }
       },
@@ -498,41 +498,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 69cad477-00f6-4551-9af3-c44c0ab6f5cd",
+        "name": "space 4875c49d-9d98-4c47-94fb-f7ec7f4a61b7",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "ee37762e-f9b3-49f1-b317-b29a69e1ab53",
+      "id": "e8026936-16cc-4f7c-9cf6-97b30916d6ba",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/backlog"
+          "self": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53",
-        "self": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53",
-        "workitemlinktypes": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypes"
+        "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba",
+        "self": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba",
+        "workitemlinktypes": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/areas"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/backlog"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/codebases"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/collaborators"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/collaborators"
           }
         },
         "filters": {
@@ -542,41 +542,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/iterations"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/labels"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "697dd898-a2d3-4712-bcf1-9d94b7ae259b",
+            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/697dd898-a2d3-4712-bcf1-9d94b7ae259b"
+            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemlinktypes"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitems"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/ee37762e-f9b3-49f1-b317-b29a69e1ab53/workitemtypes"
+            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypes"
           }
         }
       },

--- a/controller/test-files/search/search_codebase_per_url_single_match.json
+++ b/controller/test-files/search/search_codebase_per_url_single_match.json
@@ -8,21 +8,21 @@
         "type": "git",
         "url": "http://foo.com/single/0"
       },
-      "id": "1c69481d-963c-4aca-8ffe-0e3d066f9e27",
+      "id": "ae5712e0-b4ad-43bb-9774-5c92fae85eb1",
       "links": {
-        "edit": "http:///api/codebases/1c69481d-963c-4aca-8ffe-0e3d066f9e27/edit",
-        "related": "http:///api/codebases/1c69481d-963c-4aca-8ffe-0e3d066f9e27",
-        "self": "http:///api/codebases/1c69481d-963c-4aca-8ffe-0e3d066f9e27"
+        "edit": "http:///api/codebases/ae5712e0-b4ad-43bb-9774-5c92fae85eb1/edit",
+        "related": "http:///api/codebases/ae5712e0-b4ad-43bb-9774-5c92fae85eb1",
+        "self": "http:///api/codebases/ae5712e0-b4ad-43bb-9774-5c92fae85eb1"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
+            "id": "8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
-            "self": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
+            "self": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605"
           }
         }
       },
@@ -34,41 +34,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 133a3acd-dbdb-4a9f-a43c-a98cefc79e06",
+        "name": "space 276fe7ea-2f36-4153-befa-19e455ed08d6",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
+      "id": "8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/backlog"
+          "self": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
-        "self": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3",
-        "workitemlinktypes": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypes"
+        "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
+        "self": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
+        "workitemlinktypes": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/areas"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/backlog"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/codebases"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/collaborators"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/collaborators"
           }
         },
         "filters": {
@@ -78,41 +78,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/iterations"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/labels"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "c81703af-3c37-4fdf-bb27-87783faa9c3b",
+            "id": "f0f62def-b76a-4fd0-87d5-b1ce8b885196",
             "type": "identities"
           },
           "links": {
-            "related": "/api/users/c81703af-3c37-4fdf-bb27-87783faa9c3b"
+            "related": "http:///api/users/f0f62def-b76a-4fd0-87d5-b1ce8b885196"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemlinktypes"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitems"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/3e1ec7ab-767d-4663-ada9-cfc5c326f0a3/workitemtypes"
+            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypes"
           }
         }
       },

--- a/controller/test-files/space/show_space_ok.golden.json
+++ b/controller/test-files/space/show_space_ok.golden.json
@@ -1,0 +1,96 @@
+{
+  "data": {
+    "attributes": {
+      "created-at": "0001-01-01T00:00:00Z",
+      "description": "Space for TestShowSpaceOK",
+      "name": "TestShowSpaceOK-f0e5f5ba-aae4-46eb-9ab3-6354ac535aef",
+      "updated-at": "0001-01-01T00:00:00Z",
+      "version": 0
+    },
+    "id": "52b39f33-62c4-4f9a-be4c-58d8cab4b346",
+    "links": {
+      "backlog": {
+        "meta": {
+          "totalCount": 0
+        },
+        "self": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/backlog"
+      },
+      "filters": "http:///api/filters",
+      "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346",
+      "self": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346",
+      "workitemlinktypes": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemlinktypes",
+      "workitemtypegroups": "http:///api/spacetemplates/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypegroups/",
+      "workitemtypes": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypes"
+    },
+    "relationships": {
+      "areas": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/areas"
+        }
+      },
+      "backlog": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/backlog"
+        },
+        "meta": {
+          "totalCount": 0
+        }
+      },
+      "codebases": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/codebases"
+        }
+      },
+      "collaborators": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/collaborators"
+        }
+      },
+      "filters": {
+        "links": {
+          "related": "http:///api/filters"
+        }
+      },
+      "iterations": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/iterations"
+        }
+      },
+      "labels": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/labels"
+        }
+      },
+      "owned-by": {
+        "data": {
+          "id": "1025eeda-cb95-4546-be43-c6c27ba59d28",
+          "type": "identities"
+        },
+        "links": {
+          "related": "http:///api/users/1025eeda-cb95-4546-be43-c6c27ba59d28"
+        }
+      },
+      "workitemlinktypes": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemlinktypes"
+        }
+      },
+      "workitems": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitems"
+        }
+      },
+      "workitemtypegroups": {
+        "links": {
+          "related": "http:///api/spacetemplates/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypegroups/"
+        }
+      },
+      "workitemtypes": {
+        "links": {
+          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypes"
+        }
+      }
+    },
+    "type": "spaces"
+  }
+}

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -120,7 +120,9 @@ func (s *workItemChildSuite) SetupTest() {
 	require.NotNil(s.T(), s.svc)
 
 	// Create a work item link space
-	createSpacePayload := CreateSpacePayload("test-space"+uuid.NewV4().String(), "description")
+	name := "test-space" + uuid.NewV4().String()
+	description := "description"
+	createSpacePayload := newCreateSpacePayload(&name, &description)
 	_, space := test.CreateSpaceCreated(s.T(), s.svc.Context, s.svc, s.spaceCtrl, createSpacePayload)
 	s.userSpaceID = *space.Data.ID
 	s.T().Logf("Created link space with ID: %s\n", *space.Data.ID)
@@ -145,10 +147,10 @@ func (s *workItemChildSuite) SetupTest() {
 	s.T().Logf("Created bug3 with ID: %s\n", *s.bug3.Data.ID)
 
 	// Create a work item link category
-	description := "This work item link category is managed by an admin user."
+	linkCategoryDescription := "This work item link category is managed by an admin user."
 	userLinkCategoryID := createWorkItemLinkCategoryInRepo(s.T(), s.db, s.svc.Context, link.WorkItemLinkCategory{
 		Name:        "test-user",
-		Description: &description,
+		Description: &linkCategoryDescription,
 	})
 	s.T().Logf("Created link category with ID: %s\n", userLinkCategoryID)
 

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -130,7 +130,9 @@ func (s *workItemLinkSuite) SetupTest() {
 	s.workItemsCtrl = NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	require.NotNil(s.T(), s.workItemsCtrl)
 	// Create a work item link space
-	createSpacePayload := CreateSpacePayload("test-space", "description")
+	name := "test-space"
+	description := "description"
+	createSpacePayload := newCreateSpacePayload(&name, &description)
 	_, space := test.CreateSpaceCreated(s.T(), s.svc.Context, s.svc, s.spaceCtrl, createSpacePayload)
 	s.userSpaceID = *space.Data.ID
 	s.T().Logf("Created link space with ID: %s\n", *space.Data.ID)
@@ -148,10 +150,10 @@ func (s *workItemLinkSuite) SetupTest() {
 	s.feature1ID = s.createWorkItem(*wit2.Data.ID, "feature1")
 
 	// Create a work item link category
-	description := "This work item link category is managed by an admin user."
+	linkCategoryDescription := "This work item link category is managed by an admin user."
 	s.userLinkCategoryID = createWorkItemLinkCategoryInRepo(s.T(), s.appDB, s.svc.Context, link.WorkItemLinkCategory{
 		Name:        "test-user",
-		Description: &description,
+		Description: &linkCategoryDescription,
 	})
 	s.T().Logf("Created link category with ID: %s\n", s.userLinkCategoryID)
 

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -100,7 +100,9 @@ func (s *workItemLinkTypeSuite) SetupTest() {
 // createDemoType creates a demo work item link type of type "name"
 func (s *workItemLinkTypeSuite) createDemoLinkType(name string) *app.CreateWorkItemLinkTypePayload {
 	//   1. Create a space
-	createSpacePayload := CreateSpacePayload(s.spaceName, "description")
+	spaceName := s.spaceName
+	spaceDescription := "description"
+	createSpacePayload := newCreateSpacePayload(&spaceName, &spaceDescription)
 	_, space := test.CreateSpaceCreated(s.T(), s.svc.Context, s.svc, s.spaceCtrl, createSpacePayload)
 	s.spaceID = space.Data.ID
 
@@ -110,10 +112,10 @@ func (s *workItemLinkTypeSuite) createDemoLinkType(name string) *app.CreateWorkI
 	require.NotNil(s.T(), workItemType)
 
 	//   3. Create a work item link category
-	description := "This work item link category is managed by an admin user."
+	linkCategoryDescription := "This work item link category is managed by an admin user."
 	catID := createWorkItemLinkCategoryInRepo(s.T(), s.appDB, s.svc.Context, link.WorkItemLinkCategory{
 		Name:        s.categoryName,
-		Description: &description,
+		Description: &linkCategoryDescription,
 	})
 
 	// 4. Create work item link type payload

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -1924,7 +1924,9 @@ func (s *WorkItem2Suite) xTestWI2DeleteLinksOnWIDeletionOK() {
 	require.NotNil(s.T(), linkCat)
 
 	// Create link space
-	spacePayload := CreateSpacePayload("test-space"+uuid.NewV4().String(), "description")
+	spaceName := "test-space" + uuid.NewV4().String()
+	spaceDescription := "description"
+	spacePayload := newCreateSpacePayload(&spaceName, &spaceDescription)
 	_, space := test.CreateSpaceCreated(s.T(), s.svc.Context, s.svc, s.spaceCtrl, spacePayload)
 
 	// Create work item link type payload

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -506,7 +506,9 @@ func (s *workItemTypeSuite) createWorkitemtypeLinks() (app.WorkItemLinkTypeSingl
 	require.NotNil(s.T(), linkCat)
 	s.T().Log("Created work item link category")
 	// Create work item link space
-	spacePayload := CreateSpacePayload("some-link-space-"+uuid.NewV4().String(), "description")
+	spaceName := "some-link-space-" + uuid.NewV4().String()
+	spaceDescription := "description"
+	spacePayload := newCreateSpacePayload(&spaceName, &spaceDescription)
 	_, sp := test.CreateSpaceCreated(s.T(), s.svc.Context, s.svc, s.spaceCtrl, spacePayload)
 	s.T().Log("Created space")
 	// Create work item link type


### PR DESCRIPTION
Added a call to `rest.AbsoluteURL()` when generating the `owned-by` relationship's relative URL

Refactored the test on the space controller to organize tests with subtests, using a "golden file"
to validate the response to "show" a space, which includes the verification that all relationships'URL
are absolute.

Fixes openshiftio/openshift.io#1310

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>