### PR TITLE
Avoid having to manually disable gorm callbacks

### DIFF
--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -50,9 +50,6 @@ func (s *CodebaseControllerTestSuite) SecuredControllers(identity account.Identi
 }
 
 func (s *CodebaseControllerTestSuite) TestShowCodebase() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("success without stackId", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.Codebases(1))

--- a/controller/filters_blackbox_test.go
+++ b/controller/filters_blackbox_test.go
@@ -30,9 +30,6 @@ func TestRunFiltersREST(t *testing.T) {
 }
 
 func (rest *TestFiltersREST) TestListFiltersOK() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
-
 	// given
 	svc := goa.New("filterService")
 	ctrl := controller.NewFilterController(svc, rest.Configuration)

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -67,9 +67,6 @@ func (rest *TestIterationREST) UnSecuredController() (*goa.Service, *IterationCo
 }
 
 func (rest *TestIterationREST) TestCreateChildIteration() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
-
 	rest.T().Run("success - create child iteration", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, rest.DB,
 			tf.CreateWorkItemEnvironment(),

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -949,9 +949,6 @@ func (s *searchControllerTestSuite) TestIncludedParents() {
 }
 
 func (s *searchControllerTestSuite) TestUpdateWorkItem() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("assignees", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
@@ -1011,9 +1008,6 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 }
 
 func (s *searchControllerTestSuite) TestSearchCodebases() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("Single match", func(t *testing.T) {
 		// given
 		tf.NewTestFixture(s.T(), s.DB,

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -243,9 +243,6 @@ func lookupWorkItemTypes(witCollection app.WorkItemTypeList, workItemTypes ...ap
 //-----------------------------------------------------------------------------
 
 func (s *workItemTypeSuite) TestCreate() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("ok", func(t *testing.T) {
 		res, animal := s.createWorkItemTypeAnimal()
 		compareWithGolden(t, filepath.Join(s.testDir, "create", "animal.wit.golden.json"), animal)
@@ -257,9 +254,6 @@ func (s *workItemTypeSuite) TestCreate() {
 }
 
 func (s *workItemTypeSuite) TestCreateByNotOwnerForbidden() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("forbidden", func(t *testing.T) {
 		idn := &account.Identity{
 			ID:           uuid.NewV4(),
@@ -345,9 +339,6 @@ func (s *workItemTypeSuite) TestValidate() {
 }
 
 func (s *workItemTypeSuite) TestShow() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	// given
 	_, wit := s.createWorkItemTypeAnimal()
 	require.NotNil(s.T(), wit)


### PR DESCRIPTION
Instead every test must opt-in (by calling `s.RestoreGormCallbacks()`) in order to have `created_at` and `updated_at` columns automatically set to the current time.
