### PR TITLE
pcp pmcd implant: add prometheus consumer agent for localhost:8080/me…

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -14,7 +14,7 @@ COPY config.yaml ${F8_INSTALL_PREFIX}/etc/config.yaml
 # Install little pcp pmcd server for metrics collection
 # would prefer only pmcd, and not the /bin/pm*tools etc.
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
-RUN yum install -y pcp && yum clean all && \
+RUN yum install -y pcp pcp-pmda-prometheus && yum clean all && \
     mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
     chown -R ${F8_USER_NAME} /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
     chmod -R ug+rw /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp

--- a/wit+pmcd.sh
+++ b/wit+pmcd.sh
@@ -9,13 +9,18 @@ set -eu
 # Setup pmcd to run in unprivileged mode of operation
 . /etc/pcp.conf
 
+PATH=$PATH:$PCP_BINADM_DIR
+export PATH
+
 # Configure pmcd with a minimal set of DSO agents
 rm -f $PCP_PMCDCONF_PATH; # start empty
 echo "# Name  ID  IPC  IPC Params  File/Cmd" >> $PCP_PMCDCONF_PATH;
 echo "pmcd     2  dso  pmcd_init   $PCP_PMDAS_DIR/pmcd/pmda_pmcd.so"   >> $PCP_PMCDCONF_PATH;
 echo "proc     3  dso  proc_init   $PCP_PMDAS_DIR/proc/pmda_proc.so"   >> $PCP_PMCDCONF_PATH;
 echo "linux   60  dso  linux_init  $PCP_PMDAS_DIR/linux/pmda_linux.so" >> $PCP_PMCDCONF_PATH;
+echo "prometheus 144 pipe binary python $PCP_PMDAS_DIR/prometheus/pmdaprometheus.python" >> $PCP_PMCDCONF_PATH;
 rm -f $PCP_VAR_DIR/pmns/root_xfs $PCP_VAR_DIR/pmns/root_jbd2 $PCP_VAR_DIR/pmns/root_root $PCP_VAR_DIR/pmns/root
+echo 'prometheus	144:*:*' > $PCP_VAR_DIR/pmns/prometheus
 touch $PCP_VAR_DIR/pmns/.NeedRebuild
 
 # allow unauthenticated access to proc.* metrics (default is false)
@@ -25,6 +30,12 @@ export PMCD_ROOT_AGENT=0
 # NB: we can't use the rc.pmcd script.  It assumes that it's run as root.
 cd $PCP_VAR_DIR/pmns
 ./Rebuild
+pmnsadd -n root prometheus
+
+# Add our lone prometheus source
+URLSD=$PCP_PMDAS_DIR/prometheus/urls.d
+mkdir -p $URLSD
+echo 'http://localhost:8080/metrics' > $URLSD/wit.url
 
 cd $PCP_LOG_DIR
 
@@ -33,7 +44,7 @@ cd $PCP_LOG_DIR
 
 # We can log in plaintext to stdout also, even though WIT uses
 # JSON.  pmcd is not chatty and only speaks up during errors.
-exec /usr/libexec/pcp/bin/pmcd -l /dev/no-such-file -f -A -H $PCP_HOSTNAME
+exec /usr/libexec/pcp/bin/pmcd -l /dev/force-logging-to-stderr -f -A -H $PCP_HOSTNAME
 ) &
 sleep 5 # give time for pmcd's startup messages, so it doesn't intermix with WIT's
 


### PR DESCRIPTION
Enable pulling prometheus metrics within the wip binary into the pcp data stream.