### PR TITLE
Check only for 'fabric8-auth' service account

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -142,7 +142,7 @@ func (mgm *tokenManager) IsServiceAccount(ctx context.Context) bool {
 	accountNameTyped, isString := accountName.(string)
 
 	// https://github.com/fabric8-services/fabric8-auth/commit/8d7f5a3646974ae8820893d75c29f3f5e9b1ff66#diff-6b1a7621961d1f6fe7463db59c5afef5R379
-	return isString && (accountNameTyped == "auth" || accountNameTyped == "fabric8-auth")
+	return isString && (accountNameTyped == "fabric8-auth")
 }
 
 // ParseToken parses token claims

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -126,7 +126,7 @@ func TestIsServiceAccountTokenInContextClaimAbsent(t *testing.T) {
 
 func TestIsServiceAccountTokenInContextClaimIncorrect(t *testing.T) {
 	tk := jwt.New(jwt.SigningMethodRS256)
-	tk.Claims.(jwt.MapClaims)["service_accountname"] = "Not-auth"
+	tk.Claims.(jwt.MapClaims)["service_accountname"] = "Not-fabric8-auth"
 	ctx := goajwt.WithJWT(context.Background(), tk)
 
 	isServiceAccount := tokenManager.IsServiceAccount(ctx)

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -126,7 +126,7 @@ func TestIsServiceAccountTokenInContextClaimAbsent(t *testing.T) {
 
 func TestIsServiceAccountTokenInContextClaimIncorrect(t *testing.T) {
 	tk := jwt.New(jwt.SigningMethodRS256)
-	tk.Claims.(jwt.MapClaims)["service_accountname"] = "Not-fabric8-auth"
+	tk.Claims.(jwt.MapClaims)["service_accountname"] = "auth"
 	ctx := goajwt.WithJWT(context.Background(), tk)
 
 	isServiceAccount := tokenManager.IsServiceAccount(ctx)


### PR DESCRIPTION
Allows only "fabric8-auth" service account for AUTH to talk to WIT, removing support for "auth" service account (#1763)
