### PR TITLE
pcp-prom implant: fix filesystem permissions

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -15,9 +15,9 @@ COPY config.yaml ${F8_INSTALL_PREFIX}/etc/config.yaml
 # would prefer only pmcd, and not the /bin/pm*tools etc.
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
 RUN yum install -y pcp pcp-pmda-prometheus && yum clean all && \
-    mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
-    chown -R ${F8_USER_NAME} /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
-    chmod -R ug+rw /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+    mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp  && \
+    chgrp -R root /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chmod -R g+rwX /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
 COPY ./wit+pmcd.sh /wit+pmcd.sh
 EXPOSE 44321
 


### PR DESCRIPTION
The prometheus receiving agent needs write permissions into the
container filesystem for some transient data storage.
