### PR TITLE
Rework controller link tests

### DIFF
--- a/controller/test-files/work_item_link/create/ok.golden.json
+++ b/controller/test-files/work_item_link/create/ok.golden.json
@@ -1,8 +1,8 @@
 {
   "data": {
     "attributes": {
-      "created-at": "2017-11-20T18:28:12.238336+01:00",
-      "updated-at": "2017-11-20T18:28:12.238336+01:00",
+      "created-at": "0001-01-01T00:00:00Z",
+      "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
     "id": "00000000-0000-0000-0000-000000000001",
@@ -43,13 +43,13 @@
   "included": [
     {
       "attributes": {
-        "created-at": "2017-11-20T17:28:12.217406Z",
+        "created-at": "0001-01-01T00:00:00Z",
         "description": "some description",
         "forward_name": "forward name (e.g. blocks)",
         "name": "work item link type 00000000-0000-0000-0000-000000000006",
         "reverse_name": "reverse name (e.g. blocked by)",
         "topology": "tree",
-        "updated-at": "2017-11-20T17:28:12.217406Z",
+        "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
       "id": "00000000-0000-0000-0000-000000000002",
@@ -79,13 +79,13 @@
     },
     {
       "attributes": {
-        "system.created_at": "2017-11-20T17:28:12.22401Z",
+        "system.created_at": "0001-01-01T00:00:00Z",
         "system.number": 1,
         "system.order": 1000,
         "system.remote_item_id": null,
         "system.state": "new",
         "system.title": "work item 00000000-0000-0000-0000-000000000009",
-        "system.updated_at": "2017-11-20T17:28:12.22401Z",
+        "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
       "id": "00000000-0000-0000-0000-000000000004",
@@ -152,13 +152,13 @@
     },
     {
       "attributes": {
-        "system.created_at": "2017-11-20T17:28:12.22773Z",
+        "system.created_at": "0001-01-01T00:00:00Z",
         "system.number": 2,
         "system.order": 2000,
         "system.remote_item_id": null,
         "system.state": "new",
         "system.title": "work item 00000000-0000-0000-0000-000000000012",
-        "system.updated_at": "2017-11-20T17:28:12.22773Z",
+        "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
       "id": "00000000-0000-0000-0000-000000000005",

--- a/controller/test-files/work_item_link/create/ok.golden.json
+++ b/controller/test-files/work_item_link/create/ok.golden.json
@@ -1,0 +1,227 @@
+{
+  "data": {
+    "attributes": {
+      "created-at": "2017-11-20T18:28:12.238336+01:00",
+      "updated-at": "2017-11-20T18:28:12.238336+01:00",
+      "version": 0
+    },
+    "id": "00000000-0000-0000-0000-000000000001",
+    "links": {
+      "self": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001"
+    },
+    "relationships": {
+      "link_type": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000002",
+          "type": "workitemlinktypes"
+        },
+        "links": {
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemlinktypes/00000000-0000-0000-0000-000000000002"
+        }
+      },
+      "source": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000004",
+          "type": "workitems"
+        },
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004"
+        }
+      },
+      "target": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000005",
+          "type": "workitems"
+        },
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
+        }
+      }
+    },
+    "type": "workitemlinks"
+  },
+  "included": [
+    {
+      "attributes": {
+        "created-at": "2017-11-20T17:28:12.217406Z",
+        "description": "some description",
+        "forward_name": "forward name (e.g. blocks)",
+        "name": "work item link type 00000000-0000-0000-0000-000000000006",
+        "reverse_name": "reverse name (e.g. blocked by)",
+        "topology": "tree",
+        "updated-at": "2017-11-20T17:28:12.217406Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000002",
+      "relationships": {
+        "link_category": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000007",
+            "type": "workitemlinkcategories"
+          },
+          "links": {
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000007"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000008",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
+          }
+        }
+      },
+      "type": "workitemlinktypes"
+    },
+    {
+      "attributes": {
+        "system.created_at": "2017-11-20T17:28:12.22401Z",
+        "system.number": 1,
+        "system.order": 1000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000009",
+        "system.updated_at": "2017-11-20T17:28:12.22401Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000004"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000004/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000008",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/links"
+          }
+        }
+      },
+      "type": "workitems"
+    },
+    {
+      "attributes": {
+        "system.created_at": "2017-11-20T17:28:12.22773Z",
+        "system.number": 2,
+        "system.order": 2000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000012",
+        "system.updated_at": "2017-11-20T17:28:12.22773Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000005",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000008",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/links"
+          }
+        }
+      },
+      "type": "workitems"
+    }
+  ]
+}

--- a/controller/test-files/work_item_link/create/ok.headers.golden.json
+++ b/controller/test-files/work_item_link/create/ok.headers.golden.json
@@ -1,0 +1,16 @@
+{
+  "Code": 201,
+  "HeaderMap": {
+    "Content-Type": [
+      "application/vnd.api+json"
+    ],
+    "Etag": [
+      "0icd7ov5CqwDXN6Fx9z18g=="
+    ],
+    "Location": [
+      "/api/workitemlinks/00000000-0000-0000-0000-000000000001"
+    ]
+  },
+  "Body": {},
+  "Flushed": false
+}

--- a/controller/test-files/work_item_link/list/ok.golden.json
+++ b/controller/test-files/work_item_link/list/ok.golden.json
@@ -8,7 +8,6 @@
       },
       "id": "00000000-0000-0000-0000-000000000001",
       "links": {
-        "related": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001",
         "self": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001"
       },
       "relationships": {
@@ -16,18 +15,27 @@
           "data": {
             "id": "00000000-0000-0000-0000-000000000002",
             "type": "workitemlinktypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemlinktypes/00000000-0000-0000-0000-000000000002"
           }
         },
         "source": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000004",
             "type": "workitems"
+          },
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004"
           }
         },
         "target": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
+            "id": "00000000-0000-0000-0000-000000000005",
             "type": "workitems"
+          },
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
           }
         }
       },
@@ -40,7 +48,7 @@
         "created-at": "0001-01-01T00:00:00Z",
         "description": "some description",
         "forward_name": "forward name (e.g. blocks)",
-        "name": "work item link type 00000000-0000-0000-0000-000000000005",
+        "name": "work item link type 00000000-0000-0000-0000-000000000006",
         "reverse_name": "reverse name (e.g. blocked by)",
         "topology": "tree",
         "updated-at": "0001-01-01T00:00:00Z",
@@ -50,22 +58,22 @@
       "relationships": {
         "link_category": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000006",
+            "id": "00000000-0000-0000-0000-000000000007",
             "type": "workitemlinkcategories"
           },
           "links": {
-            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006",
-            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006"
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000007"
           }
         },
         "space": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000007",
+            "id": "00000000-0000-0000-0000-000000000008",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
           }
         }
       },
@@ -73,89 +81,12 @@
     },
     {
       "attributes": {
-        "description": "some description",
-        "name": "link category 00000000-0000-0000-0000-000000000008",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000006",
-      "type": "workitemlinkcategories"
-    },
-    {
-      "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 2,
-        "system.order": 2,
+        "system.number": 1,
+        "system.order": 1,
         "system.remote_item_id": null,
         "system.state": "new",
         "system.title": "work item 00000000-0000-0000-0000-000000000009",
-        "system.updated_at": "0001-01-01T00:00:00Z",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000003",
-      "links": {
-        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003",
-        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003"
-      },
-      "relationships": {
-        "area": {},
-        "assignees": {},
-        "baseType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000010",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
-          }
-        },
-        "children": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/children"
-          }
-        },
-        "comments": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/comments",
-            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003/relationships/comments"
-          }
-        },
-        "creator": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000011",
-            "links": {
-              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
-              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
-            },
-            "type": "users"
-          }
-        },
-        "iteration": {},
-        "labels": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/labels"
-          }
-        },
-        "space": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000007",
-            "type": "spaces"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
-          }
-        }
-      },
-      "type": "workitems"
-    },
-    {
-      "attributes": {
-        "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 3,
-        "system.order": 3,
-        "system.remote_item_id": null,
-        "system.state": "new",
-        "system.title": "work item 00000000-0000-0000-0000-000000000012",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -173,7 +104,7 @@
             "type": "workitemtypes"
           },
           "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes/00000000-0000-0000-0000-000000000010"
           }
         },
         "children": {
@@ -205,12 +136,90 @@
         },
         "space": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000007",
+            "id": "00000000-0000-0000-0000-000000000008",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/links"
+          }
+        }
+      },
+      "type": "workitems"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 2,
+        "system.order": 2,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000012",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000005",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000008",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/links"
           }
         }
       },

--- a/controller/test-files/work_item_link/list/ok.golden.json
+++ b/controller/test-files/work_item_link/list/ok.golden.json
@@ -1,0 +1,223 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "links": {
+        "related": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001",
+        "self": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001"
+      },
+      "relationships": {
+        "link_type": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "workitemlinktypes"
+          }
+        },
+        "source": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitems"
+          }
+        },
+        "target": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "type": "workitems"
+          }
+        }
+      },
+      "type": "workitemlinks"
+    }
+  ],
+  "included": [
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "some description",
+        "forward_name": "forward name (e.g. blocks)",
+        "name": "work item link type 00000000-0000-0000-0000-000000000005",
+        "reverse_name": "reverse name (e.g. blocked by)",
+        "topology": "tree",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000002",
+      "relationships": {
+        "link_category": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000006",
+            "type": "workitemlinkcategories"
+          },
+          "links": {
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000007",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+          }
+        }
+      },
+      "type": "workitemlinktypes"
+    },
+    {
+      "attributes": {
+        "description": "some description",
+        "name": "link category 00000000-0000-0000-0000-000000000008",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "type": "workitemlinkcategories"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 2,
+        "system.order": 2,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000009",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000003",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000007",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+          }
+        }
+      },
+      "type": "workitems"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 3,
+        "system.order": 3,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000012",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000004"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000004/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000007",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+          }
+        }
+      },
+      "type": "workitems"
+    }
+  ],
+  "meta": {
+    "totalCount": 1
+  }
+}

--- a/controller/test-files/work_item_link/show/not_found.errors.golden.json
+++ b/controller/test-files/work_item_link/show/not_found.errors.golden.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "code": "not_found",
+      "detail": "work item link with id '00000000-0000-0000-0000-000000000001' not found",
+      "id": "IGNOREME",
+      "status": "404",
+      "title": "Not found error"
+    }
+  ]
+}

--- a/controller/test-files/work_item_link/show/ok.golden.json
+++ b/controller/test-files/work_item_link/show/ok.golden.json
@@ -1,0 +1,218 @@
+{
+  "data": {
+    "attributes": {
+      "created-at": "0001-01-01T00:00:00Z",
+      "updated-at": "0001-01-01T00:00:00Z",
+      "version": 0
+    },
+    "id": "00000000-0000-0000-0000-000000000001",
+    "links": {
+      "related": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001",
+      "self": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001"
+    },
+    "relationships": {
+      "link_type": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000002",
+          "type": "workitemlinktypes"
+        }
+      },
+      "source": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000003",
+          "type": "workitems"
+        }
+      },
+      "target": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000004",
+          "type": "workitems"
+        }
+      }
+    },
+    "type": "workitemlinks"
+  },
+  "included": [
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "some description",
+        "forward_name": "forward name (e.g. blocks)",
+        "name": "work item link type 00000000-0000-0000-0000-000000000005",
+        "reverse_name": "reverse name (e.g. blocked by)",
+        "topology": "tree",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000002",
+      "relationships": {
+        "link_category": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000006",
+            "type": "workitemlinkcategories"
+          },
+          "links": {
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000007",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+          }
+        }
+      },
+      "type": "workitemlinktypes"
+    },
+    {
+      "attributes": {
+        "description": "some description",
+        "name": "link category 00000000-0000-0000-0000-000000000008",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "type": "workitemlinkcategories"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 1,
+        "system.order": 1000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000009",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000003",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000007",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+          }
+        }
+      },
+      "type": "workitems"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 2,
+        "system.order": 2000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000012",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000004"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000004/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000007",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+          }
+        }
+      },
+      "type": "workitems"
+    }
+  ]
+}

--- a/controller/test-files/work_item_link/show/ok.golden.json
+++ b/controller/test-files/work_item_link/show/ok.golden.json
@@ -7,7 +7,6 @@
     },
     "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "related": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001",
       "self": "http:///api/workitemlinks/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
@@ -15,18 +14,27 @@
         "data": {
           "id": "00000000-0000-0000-0000-000000000002",
           "type": "workitemlinktypes"
+        },
+        "links": {
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemlinktypes/00000000-0000-0000-0000-000000000002"
         }
       },
       "source": {
         "data": {
-          "id": "00000000-0000-0000-0000-000000000003",
+          "id": "00000000-0000-0000-0000-000000000004",
           "type": "workitems"
+        },
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004"
         }
       },
       "target": {
         "data": {
-          "id": "00000000-0000-0000-0000-000000000004",
+          "id": "00000000-0000-0000-0000-000000000005",
           "type": "workitems"
+        },
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
         }
       }
     },
@@ -38,7 +46,7 @@
         "created-at": "0001-01-01T00:00:00Z",
         "description": "some description",
         "forward_name": "forward name (e.g. blocks)",
-        "name": "work item link type 00000000-0000-0000-0000-000000000005",
+        "name": "work item link type 00000000-0000-0000-0000-000000000006",
         "reverse_name": "reverse name (e.g. blocked by)",
         "topology": "tree",
         "updated-at": "0001-01-01T00:00:00Z",
@@ -48,35 +56,26 @@
       "relationships": {
         "link_category": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000006",
+            "id": "00000000-0000-0000-0000-000000000007",
             "type": "workitemlinkcategories"
           },
           "links": {
-            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006",
-            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000006"
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000007",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000007"
           }
         },
         "space": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000007",
+            "id": "00000000-0000-0000-0000-000000000008",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
           }
         }
       },
       "type": "workitemlinktypes"
-    },
-    {
-      "attributes": {
-        "description": "some description",
-        "name": "link category 00000000-0000-0000-0000-000000000008",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000006",
-      "type": "workitemlinkcategories"
     },
     {
       "attributes": {
@@ -86,74 +85,6 @@
         "system.remote_item_id": null,
         "system.state": "new",
         "system.title": "work item 00000000-0000-0000-0000-000000000009",
-        "system.updated_at": "0001-01-01T00:00:00Z",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000003",
-      "links": {
-        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003",
-        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003"
-      },
-      "relationships": {
-        "area": {},
-        "assignees": {},
-        "baseType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000010",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
-          }
-        },
-        "children": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/children"
-          }
-        },
-        "comments": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/comments",
-            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000003/relationships/comments"
-          }
-        },
-        "creator": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000011",
-            "links": {
-              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
-              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
-            },
-            "type": "users"
-          }
-        },
-        "iteration": {},
-        "labels": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000003/labels"
-          }
-        },
-        "space": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000007",
-            "type": "spaces"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
-          }
-        }
-      },
-      "type": "workitems"
-    },
-    {
-      "attributes": {
-        "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 2,
-        "system.order": 2000,
-        "system.remote_item_id": null,
-        "system.state": "new",
-        "system.title": "work item 00000000-0000-0000-0000-000000000012",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -171,7 +102,7 @@
             "type": "workitemtypes"
           },
           "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007/workitemtypes/00000000-0000-0000-0000-000000000010"
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes/00000000-0000-0000-0000-000000000010"
           }
         },
         "children": {
@@ -203,12 +134,90 @@
         },
         "space": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000007",
+            "id": "00000000-0000-0000-0000-000000000008",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000007",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000007"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000004/links"
+          }
+        }
+      },
+      "type": "workitems"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 2,
+        "system.order": 2000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "work item 00000000-0000-0000-0000-000000000012",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000005",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000011",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000011"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/labels"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000008",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/links"
           }
         }
       },

--- a/controller/test-files/work_item_link/show/ok.headers.golden.json
+++ b/controller/test-files/work_item_link/show/ok.headers.golden.json
@@ -1,0 +1,19 @@
+{
+  "Code": 200,
+  "HeaderMap": {
+    "Cache-Control": [
+      "private,max-age=120"
+    ],
+    "Content-Type": [
+      "application/vnd.api+json"
+    ],
+    "Etag": [
+      "0icd7ov5CqwDXN6Fx9z18g=="
+    ],
+    "Last-Modified": [
+      "Mon, 01 Jan 0001 00:00:00 GMT"
+    ]
+  },
+  "Body": {},
+  "Flushed": false
+}

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -144,6 +144,8 @@ func (s *workItemLinkSuite) SecuredController(identity account.Identity) (*goa.S
 }
 
 func (s *workItemLinkSuite) TestCreate() {
+	resetFn := s.DisableGormCallbacks()
+	defer resetFn()
 	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
 		// helper function used in all ok-cases
 		createOK := func(t *testing.T, fxt *tf.TestFixture, svc *goa.Service, ctrl *WorkItemLinkController) {

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -757,7 +757,7 @@ func newCreateWorkItemLinkPayload(sourceID, targetID, linkTypeID uuid.UUID) *app
 		TargetID:   targetID,
 		LinkTypeID: linkTypeID,
 	}
-	payload := ConvertLinkFromModel(lt)
+	payload := ConvertLinkFromModel(&http.Request{Host: "api.service.domain.org"}, lt)
 	// The create payload is required during creation. Simply copy data over.
 	return &app.CreateWorkItemLinkPayload{
 		Data: payload.Data,
@@ -772,7 +772,7 @@ func newUpdateWorkItemLinkPayload(linkID, sourceID, targetID, linkTypeID uuid.UU
 		TargetID:   targetID,
 		LinkTypeID: linkTypeID,
 	}
-	payload := ConvertLinkFromModel(lt)
+	payload := ConvertLinkFromModel(&http.Request{Host: "api.service.domain.org"}, lt)
 	// The create payload is required during creation. Simply copy data over.
 	return &app.UpdateWorkItemLinkPayload{
 		Data: payload.Data,

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -4,654 +4,439 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/app/test"
-	"github.com/fabric8-services/fabric8-wit/application"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
-	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
+	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	testtoken "github.com/fabric8-services/fabric8-wit/test/token"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/fabric8-services/fabric8-wit/workitem/link"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-//-----------------------------------------------------------------------------
-// Test Suite setup
-//-----------------------------------------------------------------------------
-
-// The workItemLinkSuite has state the is relevant to all tests.
-// It implements these interfaces from the suite package: SetupAllSuite, SetupTestSuite, TearDownAllSuite, TearDownTestSuite
 type workItemLinkSuite struct {
 	gormtestsupport.DBTestSuite
-	svc                      *goa.Service
-	workItemLinkTypeCtrl     *WorkItemLinkTypeController
-	workItemLinkCategoryCtrl *WorkItemLinkCategoryController
-	workItemLinkCtrl         *WorkItemLinkController
-	workItemCtrl             *WorkitemController
-	workItemsCtrl            *WorkitemsController
-	workItemRelsLinksCtrl    *WorkItemRelationshipsLinksController
-	spaceCtrl                *SpaceController
-	typeCtrl                 *WorkitemtypeController
-	// These IDs can safely be used by all tests
-	bug1ID               uuid.UUID
-	bug2ID               uuid.UUID
-	bug3ID               uuid.UUID
-	feature1ID           uuid.UUID
-	userLinkCategoryID   uuid.UUID
-	bugBlockerLinkTypeID uuid.UUID
-	userSpaceID          uuid.UUID
-	appDB                application.DB
+	testDir string
 }
 
-// cleanup removes all DB entries that will be created or have been created
-// with this test suite. We need to remove them completely and not only set the
-// "deleted_at" field, which is why we need the Unscoped() function.
-func (s *workItemLinkSuite) cleanup() {
-	// Delete all work item links for now
-	db := s.DB.Unscoped().Delete(&link.WorkItemLink{})
-	require.Nil(s.T(), db.Error)
-
-	// Delete work item link types and categories by name.
-	// They will be created during the tests but have to be deleted by name
-	// rather than ID, unlike the work items or work item links.
-	db = db.Unscoped().Delete(&link.WorkItemLinkType{Name: "test-bug-blocker"})
-	require.Nil(s.T(), db.Error)
-	db = db.Unscoped().Delete(&link.WorkItemLinkCategory{Name: "test-user"})
-	require.Nil(s.T(), db.Error)
-	if s.userSpaceID != uuid.Nil {
-		db = db.Unscoped().Delete(&space.Space{ID: s.userSpaceID})
-		require.Nil(s.T(), db.Error)
-	}
-}
-
-// The SetupSuite method will run before the tests in the suite are run.
-// It sets up a database connection for all the tests in this suite without polluting global space.
-func (s *workItemLinkSuite) SetupSuite() {
-	s.DBTestSuite.SetupSuite()
-	s.appDB = gormapplication.NewGormDB(s.DB)
-}
-
-// The SetupTest method will be run before every test in the suite.
-// SetupTest ensures that none of the work item links that we will create already exist.
-// It will also make sure that some resources that we rely on do exists.
-func (s *workItemLinkSuite) SetupTest() {
-	s.DBTestSuite.SetupTest()
-	svc := goa.New("TestWorkItemLinkType-Service")
-	require.NotNil(s.T(), svc)
-	s.workItemLinkTypeCtrl = NewWorkItemLinkTypeController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-	require.NotNil(s.T(), s.workItemLinkTypeCtrl)
-
-	svc = goa.New("TestWorkItemLinkCategory-Service")
-	require.NotNil(s.T(), svc)
-	s.workItemLinkCategoryCtrl = NewWorkItemLinkCategoryController(svc, gormapplication.NewGormDB(s.DB))
-	require.NotNil(s.T(), s.workItemLinkCategoryCtrl)
-
-	svc = goa.New("TestWorkItemLinkSpace-Service")
-	require.NotNil(s.T(), svc)
-	s.spaceCtrl = NewSpaceController(svc, gormapplication.NewGormDB(s.DB), s.Configuration, &DummyResourceManager{})
-	require.NotNil(s.T(), s.spaceCtrl)
-
-	svc = goa.New("TestWorkItemType-Service")
-	s.typeCtrl = NewWorkitemtypeController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-	require.NotNil(s.T(), s.typeCtrl)
-
-	svc = goa.New("TestWorkItemLink-Service")
-	require.NotNil(s.T(), svc)
-	s.workItemLinkCtrl = NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-	require.NotNil(s.T(), s.workItemLinkCtrl)
-
-	svc = goa.New("TestWorkItemRelationshipsLinks-Service")
-	require.NotNil(s.T(), svc)
-	s.workItemRelsLinksCtrl = NewWorkItemRelationshipsLinksController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-	require.NotNil(s.T(), s.workItemRelsLinksCtrl)
-
-	// create a test identity
-	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "test user", "test provider")
-	require.Nil(s.T(), err)
-	s.svc = testsupport.ServiceAsUser("TestWorkItem-Service", *testIdentity)
-	require.NotNil(s.T(), s.svc)
-	s.workItemCtrl = NewWorkitemController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-	require.NotNil(s.T(), s.workItemCtrl)
-	s.workItemsCtrl = NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-	require.NotNil(s.T(), s.workItemsCtrl)
-	// Create a work item link space
-	name := "test-space"
-	description := "description"
-	createSpacePayload := newCreateSpacePayload(&name, &description)
-	_, space := test.CreateSpaceCreated(s.T(), s.svc.Context, s.svc, s.spaceCtrl, createSpacePayload)
-	s.userSpaceID = *space.Data.ID
-	s.T().Logf("Created link space with ID: %s\n", *space.Data.ID)
-
-	payload := newCreateWorkItemTypePayload(uuid.NewV4(), *space.Data.ID)
-	_, wit := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID, &payload)
-
-	payload2 := newCreateWorkItemTypePayload(uuid.NewV4(), *space.Data.ID)
-	_, wit2 := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID, &payload2)
-
-	// Create 3 work items (bug1, bug2, and feature1)
-	s.bug1ID = s.createWorkItem(*wit.Data.ID, "bug1")
-	s.bug2ID = s.createWorkItem(*wit.Data.ID, "bug2")
-	s.bug3ID = s.createWorkItem(*wit.Data.ID, "bug3")
-	s.feature1ID = s.createWorkItem(*wit2.Data.ID, "feature1")
-
-	// Create a work item link category
-	linkCategoryDescription := "This work item link category is managed by an admin user."
-	s.userLinkCategoryID = createWorkItemLinkCategoryInRepo(s.T(), s.appDB, s.svc.Context, link.WorkItemLinkCategory{
-		Name:        "test-user",
-		Description: &linkCategoryDescription,
-	})
-	s.T().Logf("Created link category with ID: %s\n", s.userLinkCategoryID)
-
-	// Create work item link type payload
-	createLinkTypePayload := newCreateWorkItemLinkTypePayload("test-bug-blocker", s.userLinkCategoryID, s.userSpaceID)
-	workItemLinkType := createWorkItemLinkTypeInRepo(s.T(), s.appDB, s.svc.Context, createLinkTypePayload)
-	require.NotNil(s.T(), workItemLinkType)
-	//s.deleteWorkItemLinkTypes = append(s.deleteWorkItemLinkTypes, *workItemLinkType.Data.ID)
-	s.bugBlockerLinkTypeID = *workItemLinkType.Data.ID
-	s.T().Logf("Created link type with ID: %s\n", *workItemLinkType.Data.ID)
-}
-
-// creates a work item with the given name and type and returns its ID
-func (s *workItemLinkSuite) createWorkItem(typeID uuid.UUID, name string) uuid.UUID {
-	payload := newCreateWorkItemPayload(s.userSpaceID, typeID, name)
-	_, wi := test.CreateWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.workItemsCtrl, *payload.Data.Relationships.Space.Data.ID, payload)
-	require.NotNil(s.T(), wi)
-	s.T().Logf("Created bug with ID: %d\n", *wi.Data.ID)
-	return *wi.Data.ID
-}
-
-//-----------------------------------------------------------------------------
-// helper method
-//-----------------------------------------------------------------------------
-
-// CreateWorkItemLinkCategory creates a work item link category
-func newCreateWorkItemLinkCategoryPayload(name string) *app.CreateWorkItemLinkCategoryPayload {
-	description := "This work item link category is managed by an admin user."
-	// Use the goa generated code to create a work item link category
-	return &app.CreateWorkItemLinkCategoryPayload{
-		Data: &app.WorkItemLinkCategoryData{
-			Type: link.EndpointWorkItemLinkCategories,
-			Attributes: &app.WorkItemLinkCategoryAttributes{
-				Name:        &name,
-				Description: &description,
-			},
-		},
-	}
-}
-
-// CreateWorkItem defines a work item link
-func newCreateWorkItemPayload(spaceID uuid.UUID, workItemType uuid.UUID, title string) *app.CreateWorkitemsPayload {
-	spaceRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
-	witRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.WorkitemtypeHref(spaceID.String(), workItemType))
-	payload := app.CreateWorkitemsPayload{
-		Data: &app.WorkItem{
-			Attributes: map[string]interface{}{
-				workitem.SystemTitle: title,
-				workitem.SystemState: workitem.SystemStateClosed,
-			},
-			Relationships: &app.WorkItemRelationships{
-				BaseType: &app.RelationBaseType{
-					Data: &app.BaseTypeData{
-						ID:   workItemType,
-						Type: "workitemtypes",
-					},
-					Links: &app.GenericLinks{
-						Self:    &witRelatedURL,
-						Related: &witRelatedURL,
-					},
-				},
-				Space: app.NewSpaceRelation(spaceID, spaceRelatedURL),
-			},
-			Type: "workitems",
-		},
-	}
-	return &payload
-}
-
-// CreateWorkItemLinkType defines a work item link type
-func newCreateWorkItemLinkTypePayload(name string, categoryID, spaceID uuid.UUID) *app.CreateWorkItemLinkTypePayload {
-	description := "Specify that one bug blocks another one."
-	lt := link.WorkItemLinkType{
-		Name:           name,
-		Description:    &description,
-		Topology:       link.TopologyNetwork,
-		ForwardName:    "forward name string for " + name,
-		ReverseName:    "reverse name string for " + name,
-		LinkCategoryID: categoryID,
-		SpaceID:        spaceID,
-	}
-	reqLong := &http.Request{Host: "api.service.domain.org"}
-	payload := ConvertWorkItemLinkTypeFromModel(reqLong, lt)
-	// The create payload is required during creation. Simply copy data over.
-	return &app.CreateWorkItemLinkTypePayload{
-		Data: payload.Data,
-	}
-}
-
-// newCreateWorkItemLinkPayload returns the payload to create a work item link
-func newCreateWorkItemLinkPayload(sourceID, targetID, linkTypeID uuid.UUID) *app.CreateWorkItemLinkPayload {
-	lt := link.WorkItemLink{
-		SourceID:   sourceID,
-		TargetID:   targetID,
-		LinkTypeID: linkTypeID,
-	}
-	payload := ConvertLinkFromModel(lt)
-	// The create payload is required during creation. Simply copy data over.
-	return &app.CreateWorkItemLinkPayload{
-		Data: payload.Data,
-	}
-}
-
-// newUpdateWorkItemLinkPayload returns the payload to update a work item link
-func newUpdateWorkItemLinkPayload(linkID, sourceID, targetID, linkTypeID uuid.UUID) *app.UpdateWorkItemLinkPayload {
-	lt := link.WorkItemLink{
-		ID:         linkID,
-		SourceID:   sourceID,
-		TargetID:   targetID,
-		LinkTypeID: linkTypeID,
-	}
-	payload := ConvertLinkFromModel(lt)
-	// The create payload is required during creation. Simply copy data over.
-	return &app.UpdateWorkItemLinkPayload{
-		Data: payload.Data,
-	}
-}
-
-//-----------------------------------------------------------------------------
-// Actual tests
-//-----------------------------------------------------------------------------
-
-// In order for 'go test' to run this suite, we need to create
-// a normal test function and pass our suite to suite.Run
 func TestSuiteWorkItemLinks(t *testing.T) {
 	resource.Require(t, resource.Database)
 	suite.Run(t, new(workItemLinkSuite))
 }
 
-func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLink() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-	require.NotNil(s.T(), workItemLink)
+func (s *workItemLinkSuite) SetupTest() {
+	s.DBTestSuite.SetupTest()
+	s.testDir = filepath.Join("test-files", "work_item_link")
+}
 
-	// Test if related resources are included in the response
-	toBeFound := 2
-	for i := 0; i < len(workItemLink.Included) && toBeFound > 0; i++ {
-		switch v := workItemLink.Included[i].(type) {
-		case *app.WorkItemLinkCategoryData:
-			if *v.ID == s.userLinkCategoryID {
-				s.T().Log("Found work item link category in \"included\" element: ", *v.ID)
-				toBeFound--
+func (s *workItemLinkSuite) SecuredController(identity account.Identity) (*goa.Service, *WorkItemLinkController) {
+	svc := testsupport.ServiceAsUser("WorkItemLink-Service", identity)
+	return svc, NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+}
+
+func (s *workItemLinkSuite) TestCreate() {
+	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
+		// helper function used in all ok-cases
+		createOK := func(t *testing.T, fxt *tf.TestFixture, svc *goa.Service, ctrl *WorkItemLinkController) {
+			// when
+			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, fxt.WorkItems[1].ID, fxt.WorkItemLinkTypes[0].ID)
+			_, workItemLink := test.CreateWorkItemLinkCreated(t, svc.Context, svc, ctrl, createPayload)
+			// then
+			require.NotNil(t, workItemLink)
+			// ensure some relations are included in the response
+			expectedIDs := map[uuid.UUID]struct{}{
+				fxt.WorkItemLinkCategories[0].ID: {},
+				fxt.Spaces[0].ID:                 {},
+				fxt.WorkItemLinkTypes[0].ID:      {},
+				fxt.WorkItems[0].ID:              {},
+				fxt.WorkItems[1].ID:              {},
 			}
-		case *app.Space:
-			if *v.ID == s.userSpaceID {
-				s.T().Log("Found work item link space in \"included\" element: ", *v.ID)
-				toBeFound--
+			for _, obj := range workItemLink.Included {
+				var id uuid.UUID
+				switch v := obj.(type) {
+				case *app.WorkItemLinkCategoryData:
+					id = *v.ID
+				case *app.Space:
+					id = *v.ID
+				case *app.WorkItemLinkTypeData:
+					id = *v.ID
+				case *app.WorkItem:
+					id = *v.ID
+				default:
+					t.Errorf("object of unknown type included in work item link list response: %T", obj)
+				}
+				_, ok := expectedIDs[id]
+				if ok {
+					delete(expectedIDs, id)
+				}
 			}
-		case *app.WorkItemLinkTypeData:
-			if *v.ID == s.bugBlockerLinkTypeID {
-				s.T().Log("Found work item link type in \"included\" element: ", *v.ID)
-				toBeFound--
-			}
-		// TODO(kwk): Check for source WI (once #559 is merged)
-		// TODO(kwk): Check for target WI (once #559 is merged)
-		// case *app.WorkItemData:
-		// TODO(kwk): Check for WITs (once #559 is merged)
-		// case *app.WorkItemTypeData:
-		default:
-			s.T().Errorf("Object of unknown type included in work item link list response: %T", workItemLink.Included[i])
-		}
-	}
-	require.Exactly(s.T(), 0, toBeFound, "Not all required included elements where found.")
-
-	_ = test.DeleteWorkItemLinkOK(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *workItemLink.Data.ID)
-}
-
-func (s *workItemLinkSuite) TestDeleteOrUpdateWorkItemLinkByNotSpaceCollaboratorForbidden() {
-	collaborator, err := testsupport.CreateTestIdentity(s.DB, "test"+uuid.NewV4().String(), "test provider")
-	require.Nil(s.T(), err)
-	svc := testsupport.ServiceAsUser("TestWorkItem-Service", *collaborator)
-
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), svc.Context, svc, s.workItemLinkCtrl, createPayload)
-	require.NotNil(s.T(), workItemLink)
-
-	anotherTestIdentity, err := testsupport.CreateTestIdentity(s.DB, "test"+uuid.NewV4().String(), "test provider")
-	require.Nil(s.T(), err)
-	svc = testsupport.ServiceAsSpaceUser("TestWorkItem-Service", *anotherTestIdentity, &TestSpaceAuthzService{*collaborator, ""})
-	test.DeleteWorkItemLinkForbidden(s.T(), svc.Context, svc, s.workItemLinkCtrl, *workItemLink.Data.ID)
-
-	updateLinkPayload := newUpdateWorkItemLinkPayload(*workItemLink.Data.ID, s.bug1ID, s.bug3ID, s.bugBlockerLinkTypeID)
-	test.UpdateWorkItemLinkForbidden(s.T(), svc.Context, svc, s.workItemLinkCtrl, *workItemLink.Data.ID, updateLinkPayload)
-}
-
-func (s *workItemLinkSuite) TestDeleteOrUpdateWorkItemLinkBySpaceCollaboratorOK() {
-	collaborator, err := testsupport.CreateTestIdentity(s.DB, "test"+uuid.NewV4().String(), "test provider")
-	require.Nil(s.T(), err)
-	svc := testsupport.ServiceAsSpaceUser("TestWorkItem-Service", *collaborator, &TestSpaceAuthzService{*collaborator, ""})
-
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), svc.Context, svc, s.workItemLinkCtrl, createPayload)
-	require.NotNil(s.T(), workItemLink)
-
-	updateLinkPayload := newUpdateWorkItemLinkPayload(*workItemLink.Data.ID, s.bug1ID, s.bug3ID, s.bugBlockerLinkTypeID)
-	test.UpdateWorkItemLinkOK(s.T(), svc.Context, svc, s.workItemLinkCtrl, *workItemLink.Data.ID, updateLinkPayload)
-	test.DeleteWorkItemLinkOK(s.T(), svc.Context, svc, s.workItemLinkCtrl, *workItemLink.Data.ID)
-}
-
-// Check if #586 is fixed.
-func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLinkConflictDueToUniqueViolation() {
-	createPayload1 := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink1 := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload1)
-	require.NotNil(s.T(), workItemLink1)
-	createPayload2 := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemLinkConflict(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload2)
-}
-
-// Same for /api/workitems/:id/relationships/links
-func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemRelationshipsLink() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemRelationshipsLinksCreated(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.bug1ID, createPayload)
-	require.NotNil(s.T(), workItemLink)
-}
-
-func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToInvalidLinkTypeID() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, uuid.Nil)
-	_, _ = test.CreateWorkItemLinkBadRequest(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-}
-
-// Same for /api/workitems/:id/relationships/links
-func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToInvalidLinkTypeID() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, uuid.Nil)
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.bug1ID, createPayload)
-}
-
-func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundLinkType() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, uuid.FromStringOrNil("11122233-871b-43a6-9166-0c4bd573e333"))
-	_, _ = test.CreateWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-}
-
-// Same for /api/workitems/:id/relationships/links
-func (s *workItemLinkSuite) TestCreateWorkItemRelationshipLinksBadRequestDueToNotFoundLinkType() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, uuid.FromStringOrNil("11122233-871b-43a6-9166-0c4bd573e333"))
-	_, _ = test.CreateWorkItemRelationshipsLinksNotFound(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.bug1ID, createPayload)
-}
-
-func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundSource() {
-	createPayload := newCreateWorkItemLinkPayload(uuid.NewV4(), s.bug2ID, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-}
-
-// Same for /api/workitems/:id/relationships/links
-func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToNotFoundSource() {
-	createPayload := newCreateWorkItemLinkPayload(uuid.NewV4(), s.bug2ID, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.bug2ID, createPayload)
-}
-
-func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundTarget() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, uuid.NewV4(), s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-}
-
-// Same for /api/workitems/:id/relationships/links
-func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToNotFoundTarget() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, uuid.NewV4(), s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemRelationshipsLinksNotFound(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.bug1ID, createPayload)
-}
-
-func (s *workItemLinkSuite) TestDeleteWorkItemLinkNotFound() {
-	test.DeleteWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, uuid.FromStringOrNil("1e9a8b53-73a6-40de-b028-5177add79ffa"))
-}
-
-func (s *workItemLinkSuite) TestUpdateWorkItemLinkNotFound() {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.userLinkCategoryID)
-	notExistingId := uuid.FromStringOrNil("46bbce9c-8219-4364-a450-dfd1b501654e")
-	createPayload.Data.ID = &notExistingId
-	// Wrap data portion in an update payload instead of a create payload
-	updateLinkPayload := &app.UpdateWorkItemLinkPayload{
-		Data: createPayload.Data,
-	}
-	test.UpdateWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *updateLinkPayload.Data.ID, updateLinkPayload)
-}
-
-func (s *workItemLinkSuite) TestUpdateWorkItemLinkOK() {
-	// given
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-	require.NotNil(s.T(), workItemLink)
-	// Specify new description for link type that we just created
-	// Wrap data portion in an update payload instead of a create payload
-	updateLinkPayload := newUpdateWorkItemLinkPayload(*workItemLink.Data.ID, s.bug1ID, s.bug3ID, s.bugBlockerLinkTypeID)
-	// when
-	_, l := test.UpdateWorkItemLinkOK(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *updateLinkPayload.Data.ID, updateLinkPayload)
-	// then
-	require.NotNil(s.T(), l.Data)
-	require.Equal(s.T(), workItemLink.Data.Attributes.CreatedAt.UTC(), l.Data.Attributes.CreatedAt.UTC())
-	require.NotNil(s.T(), l.Data.Attributes.CreatedAt)
-	require.NotNil(s.T(), l.Data.Relationships)
-	require.NotNil(s.T(), l.Data.Relationships.Target.Data)
-	assert.Equal(s.T(), s.bug3ID, l.Data.Relationships.Target.Data.ID)
-}
-
-func (s *workItemLinkSuite) TestUpdateWorkItemLinkVersionConflict() {
-	// given
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-	require.NotNil(s.T(), workItemLink)
-	// Specify new description for link type that we just created
-	// Wrap data portion in an update payload instead of a create payload
-	updateLinkPayload := &app.UpdateWorkItemLinkPayload{
-		Data: workItemLink.Data,
-	}
-	updateLinkPayload.Data.Relationships.Target.Data.ID = s.bug3ID
-	// force a different version of the entity
-	previousVersion := *updateLinkPayload.Data.Attributes.Version - 1
-	updateLinkPayload.Data.Attributes.Version = &previousVersion
-	// when/then
-	test.UpdateWorkItemLinkConflict(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *updateLinkPayload.Data.ID, updateLinkPayload)
-	// then
-}
-
-func (s *workItemLinkSuite) newCreateWorkItemLinkPayload() *app.WorkItemLinkSingle {
-	createPayload := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
-	require.NotNil(s.T(), workItemLink)
-	require.NotNil(s.T(), workItemLink.Data.Attributes.UpdatedAt)
-	return workItemLink
-}
-
-func assertWorkItemLink(t *testing.T, expectedWorkItemLink *app.WorkItemLinkSingle, wiLink *app.WorkItemLinkSingle) {
-	require.NotNil(t, wiLink)
-	expected, err := ConvertLinkToModel(*expectedWorkItemLink)
-	require.Nil(t, err)
-	// Convert to model space and use equal function
-	actual, err := ConvertLinkToModel(*wiLink)
-	require.Nil(t, err)
-	require.Equal(t, *expected, *actual)
-	require.NotNil(t, wiLink.Data.Links, "The link MUST include a self link")
-	require.NotEmpty(t, wiLink.Data.Links.Self, "The link MUST include a self link that's not empty")
-}
-
-// TestShowWorkItemLinkOK tests if we can fetch the "system" work item link
-func (s *workItemLinkSuite) TestShowWorkItemLinkOK() {
-	// given
-	createdWorkItemLink := s.newCreateWorkItemLinkPayload()
-	// when
-	_, retrievedWorkItemLink := test.ShowWorkItemLinkOK(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *createdWorkItemLink.Data.ID, nil, nil)
-	// then
-	assertWorkItemLink(s.T(), createdWorkItemLink, retrievedWorkItemLink)
-}
-
-// TestShowWorkItemLinkOKUsingExpiredIfModifiedSinceHeader
-func (s *workItemLinkSuite) TestShowWorkItemLinkOKUsingExpiredIfModifiedSinceHeader() {
-	// given
-	createdWorkItemLink := s.newCreateWorkItemLinkPayload()
-	// when
-	ifModifiedSince := app.ToHTTPTime(createdWorkItemLink.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
-	res, retrievedWorkItemLink := test.ShowWorkItemLinkOK(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *createdWorkItemLink.Data.ID, &ifModifiedSince, nil)
-	// then
-	assertWorkItemLink(s.T(), createdWorkItemLink, retrievedWorkItemLink)
-	assertResponseHeaders(s.T(), res)
-}
-
-// TestShowWorkItemLinkOKUsingExpiredIfModifiedSinceHeader
-func (s *workItemLinkSuite) TestShowWorkItemLinkOKUsingExpiredIfNoneMatchHeader() {
-	// given
-	createdWorkItemLink := s.newCreateWorkItemLinkPayload()
-	// when
-	ifNoneMatch := "foo"
-	res, retrievedWorkItemLink := test.ShowWorkItemLinkOK(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *createdWorkItemLink.Data.ID, nil, &ifNoneMatch)
-	// then
-	assertWorkItemLink(s.T(), createdWorkItemLink, retrievedWorkItemLink)
-	assertResponseHeaders(s.T(), res)
-}
-
-// TestShowWorkItemLinkOKUsingExpiredIfModifiedSinceHeader
-func (s *workItemLinkSuite) TestShowWorkItemLinkNotModifiedUsingIfModifiedSinceHeader() {
-	// given
-	createdWorkItemLink := s.newCreateWorkItemLinkPayload()
-	// when
-	ifModifiedSince := app.ToHTTPTime(*createdWorkItemLink.Data.Attributes.UpdatedAt)
-	res := test.ShowWorkItemLinkNotModified(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *createdWorkItemLink.Data.ID, &ifModifiedSince, nil)
-	// then
-	assertResponseHeaders(s.T(), res)
-}
-
-// TestShowWorkItemLinkOKUsingExpiredIfModifiedSinceHeader
-func (s *workItemLinkSuite) TestShowWorkItemLinkNotModifiedUsingIfNoneMatchHeader() {
-	// given
-	createdWorkItemLink := s.newCreateWorkItemLinkPayload()
-	// when
-	modelWorkItemLink, err := ConvertLinkToModel(*createdWorkItemLink)
-	require.Nil(s.T(), err)
-	ifNoneMatch := app.GenerateEntityTag(modelWorkItemLink)
-	res := test.ShowWorkItemLinkNotModified(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, *createdWorkItemLink.Data.ID, nil, &ifNoneMatch)
-	// then
-	assertResponseHeaders(s.T(), res)
-}
-
-// TestShowWorkItemLinkNotFound tests if we can fetch a non existing work item link
-func (s *workItemLinkSuite) TestShowWorkItemLinkNotFound() {
-	test.ShowWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19"), nil, nil)
-}
-
-func (s *workItemLinkSuite) createSomeLinks() (*app.WorkItemLinkSingle, *app.WorkItemLinkSingle) {
-	createPayload1 := newCreateWorkItemLinkPayload(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink1 := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload1)
-	require.NotNil(s.T(), workItemLink1)
-	_, err := ConvertLinkToModel(*workItemLink1)
-	require.Nil(s.T(), err)
-
-	createPayload2 := newCreateWorkItemLinkPayload(s.bug2ID, s.bug3ID, s.bugBlockerLinkTypeID)
-	_, workItemLink2 := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload2)
-	require.NotNil(s.T(), workItemLink2)
-	_, err = ConvertLinkToModel(*workItemLink2)
-	require.Nil(s.T(), err)
-
-	return workItemLink1, workItemLink2
-}
-
-// validateSomeLinks validates that workItemLink1 and workItemLink2 are in the
-// linkCollection and that all resources are included
-func (s *workItemLinkSuite) validateSomeLinks(linkCollection *app.WorkItemLinkList, workItemLink1, workItemLink2 *app.WorkItemLinkSingle) {
-	require.NotNil(s.T(), linkCollection)
-	require.Nil(s.T(), linkCollection.Validate())
-	// Check the number of found work item links
-	require.NotNil(s.T(), linkCollection.Data)
-	require.Condition(s.T(), func() bool {
-		return (len(linkCollection.Data) >= 2)
-	}, "At least two work item links must exist (%s and %s), but only %d exist.", *workItemLink1.Data.ID, *workItemLink2.Data.ID, len(linkCollection.Data))
-	// Search for the work item types that must exist at minimum
-	toBeFound := 2
-	for i := 0; i < len(linkCollection.Data) && toBeFound > 0; i++ {
-		actualLink := *linkCollection.Data[i]
-		var expectedLink *app.WorkItemLinkData
-
-		switch *actualLink.ID {
-		case *workItemLink1.Data.ID:
-			expectedLink = workItemLink1.Data
-		case *workItemLink2.Data.ID:
-			expectedLink = workItemLink2.Data
+			require.Empty(t, 0, expectedIDs, "these elements where missing from the included objects: %+v", expectedIDs)
 		}
 
-		if expectedLink != nil {
-			s.T().Log("Found work item link in collection: ", *expectedLink.ID)
-			toBeFound--
+		t.Run("as space owner", func(t *testing.T) {
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(4), tf.WorkItemLinkTypes(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			createOK(t, fxt, svc, ctrl)
+		})
+		t.Run("as space collaborator", func(t *testing.T) {
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(4), tf.WorkItemLinkTypes(1), tf.Identities(2, tf.SetIdentityUsernames("owner", "collaborator")))
+			svc := testsupport.ServiceAsSpaceUser("TestWorkItem-Service", *fxt.IdentityByUsername("collaborator"), &TestSpaceAuthzService{*fxt.IdentityByUsername("collaborator"), ""})
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			createOK(t, fxt, svc, ctrl)
+		})
+		t.Run("as non-owner and non-collaborator", func(t *testing.T) {
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(4), tf.WorkItemLinkTypes(1), tf.Identities(2, tf.SetIdentityUsernames("alice", "bob")))
+			svc := testsupport.ServiceAsUser("TestWorkItem-Service", *fxt.IdentityByUsername("bob"))
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			createOK(t, fxt, svc, ctrl)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusUnauthorized), func(t *testing.T) {
+		t.Run("as not logged in user", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(4), tf.WorkItemLinkTypes(1))
+			svc := goa.New("TestUnauthorizedCreateWorkItemLink-Service")
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// when/then
+			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, fxt.WorkItems[1].ID, fxt.WorkItemLinkTypes[0].ID)
+			_, _ = test.CreateWorkItemLinkUnauthorized(t, svc.Context, svc, ctrl, createPayload)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusConflict), func(t *testing.T) {
+		t.Run("regression test for issue #586", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB,
+				tf.CreateWorkItemEnvironment(),
+				tf.WorkItemLinks(2),
+				tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyNetwork)))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// then the same link cannot be created again
+			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItemLinks[0].SourceID, fxt.WorkItemLinks[0].TargetID, fxt.WorkItemLinks[0].LinkTypeID)
+			_, _ = test.CreateWorkItemLinkConflict(t, svc.Context, svc, ctrl, createPayload)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusBadRequest), func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2), tf.WorkItemLinkTypes(1))
+		svc, ctrl := s.SecuredController(*fxt.Identities[0])
+		relCtrl := NewWorkItemRelationshipsLinksController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 
-			// Check JSONAPI "type"" field (should be "workitemlinks")
-			require.Equal(s.T(), expectedLink.Type, actualLink.Type)
+		t.Run("invalid type id", func(t *testing.T) {
+			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, fxt.WorkItems[1].ID, uuid.Nil)
+			t.Run("for /api/workitemlinks", func(t *testing.T) {
+				// when then
+				_, _ = test.CreateWorkItemLinkBadRequest(t, svc.Context, svc, ctrl, createPayload)
+			})
+			t.Run("for /api/workitems/:id/relationships/links", func(t *testing.T) {
+				_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(t, svc.Context, svc, relCtrl, fxt.WorkItems[0].ID, createPayload)
+			})
+		})
+	})
 
-			// Check work item link type
-			require.Equal(s.T(), expectedLink.Relationships.LinkType.Data.ID, actualLink.Relationships.LinkType.Data.ID)
-			require.Equal(s.T(), expectedLink.Relationships.LinkType.Data.Type, actualLink.Relationships.LinkType.Data.Type)
+	s.T().Run(http.StatusText(http.StatusNotFound), func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2), tf.WorkItemLinkTypes(1))
+		svc, ctrl := s.SecuredController(*fxt.Identities[0])
+		relCtrl := NewWorkItemRelationshipsLinksController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+		t.Run("not existing link type id", func(t *testing.T) {
+			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, fxt.WorkItems[1].ID, uuid.NewV4())
+			t.Run("for /api/workitemlinks", func(t *testing.T) {
+				// when then
+				_, _ = test.CreateWorkItemLinkNotFound(t, svc.Context, svc, ctrl, createPayload)
+			})
+			t.Run("for /api/workitems/:id/relationships/links", func(t *testing.T) {
+				_, _ = test.CreateWorkItemRelationshipsLinksNotFound(t, svc.Context, svc, relCtrl, fxt.WorkItems[0].ID, createPayload)
+			})
+		})
+		t.Run("not existing source", func(t *testing.T) {
+			createPayload := newCreateWorkItemLinkPayload(uuid.NewV4(), fxt.WorkItems[1].ID, fxt.WorkItemLinkTypes[0].ID)
+			t.Run("for /api/workitemlinks", func(t *testing.T) {
+				// when then
+				_, _ = test.CreateWorkItemLinkNotFound(t, svc.Context, svc, ctrl, createPayload)
+			})
+			t.Run("for /api/workitems/:id/relationships/links", func(t *testing.T) {
+				_, _ = test.CreateWorkItemRelationshipsLinksNotFound(t, svc.Context, svc, relCtrl, createPayload.Data.Relationships.Source.Data.ID, createPayload)
+			})
+		})
+		t.Run("not existing target", func(t *testing.T) {
+			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, uuid.NewV4(), fxt.WorkItemLinkTypes[0].ID)
+			t.Run("for /api/workitemlinks", func(t *testing.T) {
+				// when then
+				_, _ = test.CreateWorkItemLinkNotFound(t, svc.Context, svc, ctrl, createPayload)
+			})
+			t.Run("for /api/workitems/:id/relationships/links", func(t *testing.T) {
+				_, _ = test.CreateWorkItemRelationshipsLinksNotFound(t, svc.Context, svc, relCtrl, fxt.WorkItems[0].ID, createPayload)
+			})
+		})
+	})
 
-			// Check source type
-			require.Equal(s.T(), expectedLink.Relationships.Source.Data.ID, actualLink.Relationships.Source.Data.ID, "Wrong source ID for the link")
-			require.Equal(s.T(), expectedLink.Relationships.Source.Data.Type, actualLink.Relationships.Source.Data.Type, "Wrong source JSONAPI type for the link")
-
-			// Check target type
-			require.Equal(s.T(), expectedLink.Relationships.Target.Data.ID, actualLink.Relationships.Target.Data.ID, "Wrong target ID for the link")
-			require.Equal(s.T(), expectedLink.Relationships.Target.Data.Type, actualLink.Relationships.Target.Data.Type, "Wrong target JSONAPI type for the link")
-		}
-	}
-	require.Exactly(s.T(), 0, toBeFound, "Not all required work item links (%s and %s) where found.", *workItemLink1.Data.ID, *workItemLink2.Data.ID)
-
-	toBeFound = 5 // 1 x link category, 1 x link type, 3 x work items
-	for i := 0; i < len(linkCollection.Included) && toBeFound > 0; i++ {
-		switch v := linkCollection.Included[i].(type) {
-		case *app.WorkItemLinkCategoryData:
-			if *v.ID == s.userLinkCategoryID {
-				s.T().Log("Found work item link category in \"included\" element: ", *v.ID)
-				toBeFound--
-			}
-		case *app.Space:
-			if *v.ID == s.userSpaceID {
-				s.T().Log("Found work item link space in \"included\" element: ", *v.ID)
-				toBeFound--
-			}
-		case *app.WorkItemLinkTypeData:
-			if *v.ID == s.bugBlockerLinkTypeID {
-				s.T().Log("Found work item link type in \"included\" element: ", *v.ID)
-				toBeFound--
-			}
-		case *app.WorkItem:
-			wid := *v.ID
-			if wid == s.bug1ID || wid == s.bug2ID || wid == s.bug3ID {
-				s.T().Log("Found work item in \"included\" element: ", *v.ID)
-				toBeFound--
-			}
-		// TODO(kwk): Check for WITs (once #559 is merged)
-		// case *app.WorkItemTypeData:
-		default:
-			s.T().Errorf("Object of unknown type included in work item link list response: %T", linkCollection.Included[i])
-		}
-	}
-	require.Exactly(s.T(), 0, toBeFound, "Not all required included elements where found.")
 }
 
-// Same as TestListWorkItemLinkOK, for /api/workitems/:id/relationships/links
-func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksOK() {
-	link1, link2 := s.createSomeLinks()
-	_, linkCollection := test.ListWorkItemRelationshipsLinksOK(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.bug2ID, nil, nil)
-	s.validateSomeLinks(linkCollection, link1, link2)
+func (s *workItemLinkSuite) TestDelete() {
+	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
+		t.Run("as space owner", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			_ = test.DeleteWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID)
+			// then verify that the link really was deleted
+			_, _ = test.ShowWorkItemLinkNotFound(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, nil)
+		})
+		t.Run("as space collaborator", func(t *testing.T) {
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1), tf.Identities(2, tf.SetIdentityUsernames("owner", "collaborator")))
+			svc := testsupport.ServiceAsSpaceUser("TestWorkItem-Service", *fxt.IdentityByUsername("collaborator"), &TestSpaceAuthzService{*fxt.IdentityByUsername("collaborator"), ""})
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// when
+			test.DeleteWorkItemLinkOK(s.T(), svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID)
+			// then verify that the link really was deleted
+			_, _ = test.ShowWorkItemLinkNotFound(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, nil)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusForbidden), func(t *testing.T) {
+		t.Run("not as space collaborator", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1), tf.Identities(2, tf.SetIdentityUsernames("owner", "collaborator")))
+			svc := testsupport.ServiceAsSpaceUser("svc", *fxt.IdentityByUsername("collaborator"), &TestSpaceAuthzService{*fxt.IdentityByUsername("owner"), ""})
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// when
+			test.DeleteWorkItemLinkForbidden(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID)
+			// then verify the link still exists
+			_, _ = test.ShowWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, nil)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusUnauthorized), func(t *testing.T) {
+		t.Run("as not logged in user", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1))
+			svc := goa.New("TestUnauthorizedDeleteWorkItemLink-Service")
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// when/then
+			_, _ = test.DeleteWorkItemLinkUnauthorized(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusNotFound), func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment())
+		svc, ctrl := s.SecuredController(*fxt.Identities[0])
+		// when/then
+		_, _ = test.DeleteWorkItemLinkNotFound(t, svc.Context, svc, ctrl, uuid.NewV4())
+	})
 }
 
-func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksNotFound() {
-	_, _ = test.ListWorkItemRelationshipsLinksNotFound(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, uuid.NewV4(), nil, nil)
+func (s *workItemLinkSuite) TestUpdate() {
+	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
+		t.Run("as space owner", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			updateLinkPayload := newUpdateWorkItemLinkPayload(fxt.WorkItemLinks[0].ID, fxt.WorkItemLinks[0].TargetID, fxt.WorkItemLinks[0].SourceID, fxt.WorkItemLinks[0].LinkTypeID)
+			_, _ = test.UpdateWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, updateLinkPayload)
+			// then verify the update exchanged the source and the target
+			_, l := test.ShowWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, nil)
+			model, err := ConvertLinkToModel(*l)
+			require.Nil(t, err)
+			require.Equal(t, fxt.WorkItemLinks[0].TargetID, model.SourceID)
+			require.Equal(t, fxt.WorkItemLinks[0].SourceID, model.TargetID)
+			require.Equal(t, fxt.WorkItemLinks[0].LinkTypeID, model.LinkTypeID)
+		})
+		t.Run("as space collaborator", func(t *testing.T) {
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1), tf.Identities(2, tf.SetIdentityUsernames("owner", "collaborator")))
+			svc := testsupport.ServiceAsSpaceUser("TestWorkItem-Service", *fxt.IdentityByUsername("collaborator"), &TestSpaceAuthzService{*fxt.IdentityByUsername("collaborator"), ""})
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// when
+			updateLinkPayload := newUpdateWorkItemLinkPayload(fxt.WorkItemLinks[0].ID, fxt.WorkItemLinks[0].TargetID, fxt.WorkItemLinks[0].SourceID, fxt.WorkItemLinks[0].LinkTypeID)
+			_, _ = test.UpdateWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, updateLinkPayload)
+			// then verify the update exchanged the source and the target
+			_, l := test.ShowWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, nil)
+			model, err := ConvertLinkToModel(*l)
+			require.Nil(t, err)
+			require.Equal(t, fxt.WorkItemLinks[0].TargetID, model.SourceID)
+			require.Equal(t, fxt.WorkItemLinks[0].SourceID, model.TargetID)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusForbidden), func(t *testing.T) {
+		t.Run("not as space collaborator", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1), tf.Identities(2, tf.SetIdentityUsernames("owner", "bob")))
+			svc := testsupport.ServiceAsSpaceUser("svc", *fxt.IdentityByUsername("bob"), &TestSpaceAuthzService{*fxt.IdentityByUsername("owner"), ""})
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// when
+			updateLinkPayload := newUpdateWorkItemLinkPayload(fxt.WorkItemLinks[0].ID, fxt.WorkItemLinks[0].TargetID, fxt.WorkItemLinks[0].SourceID, fxt.WorkItemLinks[0].LinkTypeID)
+			test.UpdateWorkItemLinkForbidden(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, updateLinkPayload)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusUnauthorized), func(t *testing.T) {
+		t.Run("as not logged in user", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1))
+			svc := goa.New("TestUnauthorizedUpdateWorkItemLink-Service")
+			ctrl := NewWorkItemLinkController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// when
+			updateLinkPayload := newUpdateWorkItemLinkPayload(fxt.WorkItemLinks[0].ID, fxt.WorkItemLinks[0].TargetID, fxt.WorkItemLinks[0].SourceID, fxt.WorkItemLinks[0].LinkTypeID)
+			test.UpdateWorkItemLinkUnauthorized(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, updateLinkPayload)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusNotFound), func(t *testing.T) {
+		t.Run("not existing link id", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			updateLinkPayload := newUpdateWorkItemLinkPayload(uuid.NewV4(), fxt.WorkItemLinks[0].TargetID, fxt.WorkItemLinks[0].SourceID, fxt.WorkItemLinks[0].LinkTypeID)
+			test.UpdateWorkItemLinkNotFound(t, svc.Context, svc, ctrl, *updateLinkPayload.Data.ID, updateLinkPayload)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusConflict), func(t *testing.T) {
+		t.Run("version conflict", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1), tf.WorkItems(3))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			updateLinkPayload := newUpdateWorkItemLinkPayload(fxt.WorkItemLinks[0].ID, fxt.WorkItems[1].ID, fxt.WorkItems[2].ID, fxt.WorkItemLinks[0].LinkTypeID)
+			// force a different version of the entity
+			previousVersion := *updateLinkPayload.Data.Attributes.Version - 1
+			updateLinkPayload.Data.Attributes.Version = &previousVersion
+			test.UpdateWorkItemLinkConflict(t, svc.Context, svc, ctrl, *updateLinkPayload.Data.ID, updateLinkPayload)
+		})
+	})
+}
+
+func (s *workItemLinkSuite) TestShow() {
+	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
+		t.Run("normal", func(t *testing.T) {
+			resetFn := s.DisableGormCallbacks()
+			defer resetFn()
+
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			res, l := test.ShowWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, nil)
+			// then
+			assertResponseHeaders(t, res)
+			actual, err := ConvertLinkToModel(*l)
+			require.Nil(t, err)
+			require.Equal(t, fxt.WorkItemLinks[0].SourceID, actual.SourceID)
+			require.Equal(t, fxt.WorkItemLinks[0].TargetID, actual.TargetID)
+			require.Equal(t, fxt.WorkItemLinks[0].LinkTypeID, actual.LinkTypeID)
+			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.golden.json"), l)
+			res.Header().Set("Etag", "0icd7ov5CqwDXN6Fx9z18g==") // overwrite Etag to always match
+			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res)
+		})
+		t.Run("using expired IfModifiedSince header", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			ifModifiedSince := app.ToHTTPTime(fxt.WorkItemLinks[0].UpdatedAt.Add(-1 * time.Hour))
+			res, l := test.ShowWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, &ifModifiedSince, nil)
+			// then
+			assertResponseHeaders(t, res)
+			actual, err := ConvertLinkToModel(*l)
+			require.Nil(t, err)
+			require.Equal(t, fxt.WorkItemLinks[0].SourceID, actual.SourceID)
+			require.Equal(t, fxt.WorkItemLinks[0].TargetID, actual.TargetID)
+			require.Equal(t, fxt.WorkItemLinks[0].LinkTypeID, actual.LinkTypeID)
+		})
+		t.Run("using expired IfNoneMatch header", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			ifNoneMatch := "foo"
+			res, l := test.ShowWorkItemLinkOK(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, &ifNoneMatch)
+			// then
+			assertResponseHeaders(t, res)
+			actual, err := ConvertLinkToModel(*l)
+			require.Nil(t, err)
+			require.Equal(t, fxt.WorkItemLinks[0].SourceID, actual.SourceID)
+			require.Equal(t, fxt.WorkItemLinks[0].TargetID, actual.TargetID)
+			require.Equal(t, fxt.WorkItemLinks[0].LinkTypeID, actual.LinkTypeID)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusNotModified), func(t *testing.T) {
+		t.Run("using IfModifiedSince header", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			ifModifiedSince := app.ToHTTPTime(fxt.WorkItemLinks[0].UpdatedAt)
+			res := test.ShowWorkItemLinkNotModified(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, &ifModifiedSince, nil)
+			// then
+			assertResponseHeaders(t, res)
+		})
+		t.Run("using IfNoneMatch header", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			ifNoneMatch := app.GenerateEntityTag(*fxt.WorkItemLinks[0])
+			res := test.ShowWorkItemLinkNotModified(t, svc.Context, svc, ctrl, fxt.WorkItemLinks[0].ID, nil, &ifNoneMatch)
+			// then
+			assertResponseHeaders(t, res)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusNotFound), func(t *testing.T) {
+		t.Run("not existing link", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment())
+			svc, ctrl := s.SecuredController(*fxt.Identities[0])
+			// when
+			_, jerrs := test.ShowWorkItemLinkNotFound(t, svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
+			ignoreMe := "IGNOREME"
+			jerrs.Errors[0].ID = &ignoreMe
+			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.errors.golden.json"), jerrs)
+		})
+	})
+}
+
+func (s *workItemLinkSuite) TestList() {
+	resetFn := s.DisableGormCallbacks()
+	defer resetFn()
+	// given
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+	svc, _ := s.SecuredController(*fxt.Identities[0])
+	relCtrl := NewWorkItemRelationshipsLinksController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+
+	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
+		t.Run("for /api/workitems/:id/relationships/links", func(t *testing.T) {
+			// when
+			_, links := test.ListWorkItemRelationshipsLinksOK(t, svc.Context, svc, relCtrl, fxt.WorkItemLinks[0].SourceID, nil, nil)
+			for i, obj := range links.Included {
+				switch t := obj.(type) {
+				case *app.WorkItem:
+					t.Attributes[workitem.SystemNumber] = i
+					t.Attributes[workitem.SystemOrder] = float64(i)
+				}
+			}
+			// then
+			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.golden.json"), links)
+		})
+	})
+	s.T().Run(http.StatusText(http.StatusNotFound), func(t *testing.T) {
+		t.Run("for /api/workitems/:id/relationships/links", func(t *testing.T) {
+			// when
+			_, _ = test.ListWorkItemRelationshipsLinksNotFound(t, svc.Context, svc, relCtrl, uuid.NewV4(), nil, nil)
+		})
+	})
 }
 
 func (s *workItemLinkSuite) getWorkItemLinkTestDataFunc() func(t *testing.T) []testSecureAPI {
@@ -887,11 +672,109 @@ func (s *workItemLinkSuite) getWorkItemRelationshipLinksTestData(spaceID, wiID u
 }
 
 func (s *workItemLinkSuite) TestUnauthorizeWorkItemRelationshipsLinksCUD() {
-	UnauthorizeCreateUpdateDeleteTest(s.T(), s.getWorkItemRelationshipLinksTestData(space.SystemSpace, s.bug1ID), func() *goa.Service {
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
+	UnauthorizeCreateUpdateDeleteTest(s.T(), s.getWorkItemRelationshipLinksTestData(fxt.WorkItems[0].SpaceID, fxt.WorkItems[0].ID), func() *goa.Service {
 		return goa.New("TestUnauthorizedCreateWorkItemRelationshipsLinks-Service")
 	}, func(service *goa.Service) error {
 		controller := NewWorkItemRelationshipsLinksController(service, gormapplication.NewGormDB(s.DB), s.Configuration)
 		app.MountWorkItemRelationshipsLinksController(service, controller)
 		return nil
 	})
+}
+
+//-----------------------------------------------------------------------------
+// helper methods
+//-----------------------------------------------------------------------------
+
+// CreateWorkItemLinkCategory creates a work item link category
+func newCreateWorkItemLinkCategoryPayload(name string) *app.CreateWorkItemLinkCategoryPayload {
+	description := "This work item link category is managed by an admin user."
+	// Use the goa generated code to create a work item link category
+	return &app.CreateWorkItemLinkCategoryPayload{
+		Data: &app.WorkItemLinkCategoryData{
+			Type: link.EndpointWorkItemLinkCategories,
+			Attributes: &app.WorkItemLinkCategoryAttributes{
+				Name:        &name,
+				Description: &description,
+			},
+		},
+	}
+}
+
+// CreateWorkItem defines a work item link
+func newCreateWorkItemPayload(spaceID uuid.UUID, workItemType uuid.UUID, title string) *app.CreateWorkitemsPayload {
+	spaceRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
+	witRelatedURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.WorkitemtypeHref(spaceID.String(), workItemType))
+	payload := app.CreateWorkitemsPayload{
+		Data: &app.WorkItem{
+			Attributes: map[string]interface{}{
+				workitem.SystemTitle: title,
+				workitem.SystemState: workitem.SystemStateClosed,
+			},
+			Relationships: &app.WorkItemRelationships{
+				BaseType: &app.RelationBaseType{
+					Data: &app.BaseTypeData{
+						ID:   workItemType,
+						Type: "workitemtypes",
+					},
+					Links: &app.GenericLinks{
+						Self:    &witRelatedURL,
+						Related: &witRelatedURL,
+					},
+				},
+				Space: app.NewSpaceRelation(spaceID, spaceRelatedURL),
+			},
+			Type: "workitems",
+		},
+	}
+	return &payload
+}
+
+// CreateWorkItemLinkType defines a work item link type
+func newCreateWorkItemLinkTypePayload(name string, categoryID, spaceID uuid.UUID) *app.CreateWorkItemLinkTypePayload {
+	description := "Specify that one bug blocks another one."
+	lt := link.WorkItemLinkType{
+		Name:           name,
+		Description:    &description,
+		Topology:       link.TopologyNetwork,
+		ForwardName:    "forward name string for " + name,
+		ReverseName:    "reverse name string for " + name,
+		LinkCategoryID: categoryID,
+		SpaceID:        spaceID,
+	}
+	reqLong := &http.Request{Host: "api.service.domain.org"}
+	payload := ConvertWorkItemLinkTypeFromModel(reqLong, lt)
+	// The create payload is required during creation. Simply copy data over.
+	return &app.CreateWorkItemLinkTypePayload{
+		Data: payload.Data,
+	}
+}
+
+// newCreateWorkItemLinkPayload returns the payload to create a work item link
+func newCreateWorkItemLinkPayload(sourceID, targetID, linkTypeID uuid.UUID) *app.CreateWorkItemLinkPayload {
+	lt := link.WorkItemLink{
+		SourceID:   sourceID,
+		TargetID:   targetID,
+		LinkTypeID: linkTypeID,
+	}
+	payload := ConvertLinkFromModel(lt)
+	// The create payload is required during creation. Simply copy data over.
+	return &app.CreateWorkItemLinkPayload{
+		Data: payload.Data,
+	}
+}
+
+// newUpdateWorkItemLinkPayload returns the payload to update a work item link
+func newUpdateWorkItemLinkPayload(linkID, sourceID, targetID, linkTypeID uuid.UUID) *app.UpdateWorkItemLinkPayload {
+	lt := link.WorkItemLink{
+		ID:         linkID,
+		SourceID:   sourceID,
+		TargetID:   targetID,
+		LinkTypeID: linkTypeID,
+	}
+	payload := ConvertLinkFromModel(lt)
+	// The create payload is required during creation. Simply copy data over.
+	return &app.UpdateWorkItemLinkPayload{
+		Data: payload.Data,
+	}
 }

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -149,9 +149,10 @@ func (s *workItemLinkSuite) TestCreate() {
 		createOK := func(t *testing.T, fxt *tf.TestFixture, svc *goa.Service, ctrl *WorkItemLinkController) {
 			// when
 			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, fxt.WorkItems[1].ID, fxt.WorkItemLinkTypes[0].ID)
-			_, workItemLink := test.CreateWorkItemLinkCreated(t, svc.Context, svc, ctrl, createPayload)
+			res, workItemLink := test.CreateWorkItemLinkCreated(t, svc.Context, svc, ctrl, createPayload)
 			// then
 			require.NotNil(t, workItemLink)
+
 			// ensure some relations are included in the response
 			expectedIDs := map[uuid.UUID]struct{}{
 				fxt.WorkItemLinkCategories[0].ID: {},
@@ -180,6 +181,10 @@ func (s *workItemLinkSuite) TestCreate() {
 				}
 			}
 			require.Empty(t, 0, expectedIDs, "these elements where missing from the included objects: %+v", expectedIDs)
+
+			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.golden.json"), workItemLink)
+			res.Header().Set("Etag", "0icd7ov5CqwDXN6Fx9z18g==") // overwrite Etag to always match
+			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.headers.golden.json"), res)
 		}
 
 		t.Run("as space owner", func(t *testing.T) {

--- a/controller/work_item_relationships_links.go
+++ b/controller/work_item_relationships_links.go
@@ -94,7 +94,7 @@ func (c *WorkItemRelationshipsLinksController) List(ctx *app.ListWorkItemRelatio
 			appLinks := app.WorkItemLinkList{}
 			appLinks.Data = make([]*app.WorkItemLinkData, len(modelLinks))
 			for index, modelLink := range modelLinks {
-				appLink := ConvertLinkFromModel(modelLink)
+				appLink := ConvertLinkFromModel(ctx.Request, modelLink)
 				appLinks.Data[index] = appLink.Data
 			}
 			// TODO: When adding pagination, this must not be len(rows) but
@@ -102,8 +102,7 @@ func (c *WorkItemRelationshipsLinksController) List(ctx *app.ListWorkItemRelatio
 			appLinks.Meta = &app.WorkItemLinkListMeta{
 				TotalCount: len(modelLinks),
 			}
-			linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, nil)
-			if err := enrichLinkList(linkCtx, &appLinks); err != nil {
+			if err := enrichLinkList(ctx.Context, appl, ctx.Request, &appLinks); err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
 			return ctx.OK(&appLinks)

--- a/design/work_item_link.go
+++ b/design/work_item_link.go
@@ -80,6 +80,7 @@ See also http://jsonapi.org/format/#document-resource-object-relationships`)
 // relationWorkItem is the JSONAPI store for the links
 var relationWorkItem = a.Type("RelationWorkItem", func() {
 	a.Attribute("data", relationWorkItemData)
+	a.Attribute("links", genericLinks)
 })
 
 // relationWorkItemData is the JSONAPI data object of the the work item relationship objects

--- a/design/work_item_link_type.go
+++ b/design/work_item_link_type.go
@@ -97,6 +97,7 @@ var relationWorkItemTypeData = a.Type("RelationWorkItemTypeData", func() {
 // relationWorkItemLinkType is the JSONAPI store for the links
 var relationWorkItemLinkType = a.Type("RelationWorkItemLinkType", func() {
 	a.Attribute("data", relationWorkItemLinkTypeData)
+	a.Attribute("links", genericLinks)
 })
 
 // relationWorkItemLinkTypeData is the JSONAPI data object of the the work item link type relationship objects

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -13,6 +13,7 @@ import (
 
 	"net/url"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/fabric8-services/fabric8-wit/criteria"
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/log"
@@ -613,6 +614,7 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 				"err": err,
 				"wit": value.Type,
 			}, "failed to load work item type")
+			spew.Dump(value)
 			return nil, 0, errors.NewInternalError(ctx, errs.Wrap(err, "failed to load work item type"))
 		}
 		wiModel, err := wiType.ConvertWorkItemStorageToModel(value)

--- a/test/testfixture/make_functions.go
+++ b/test/testfixture/make_functions.go
@@ -249,10 +249,9 @@ func makeWorkItemTypes(fxt *TestFixture) error {
 				workitem.SystemCreatedAt:    {Type: workitem.SimpleType{Kind: workitem.KindInstant}, Required: false, Label: "Created at", Description: "The date and time when the work item was created"},
 				workitem.SystemUpdatedAt:    {Type: workitem.SimpleType{Kind: workitem.KindInstant}, Required: false, Label: "Updated at", Description: "The date and time when the work item was last updated"},
 				workitem.SystemOrder:        {Type: workitem.SimpleType{Kind: workitem.KindFloat}, Required: false, Label: "Execution Order", Description: "Execution Order of the workitem."},
-				//workitem.SystemNumber:       {Type: workitem.SimpleType{Kind: workitem.KindInteger}, Required: false, Label: "Work Item Number", Description: "Humand-readable number."},
-				workitem.SystemIteration: {Type: workitem.SimpleType{Kind: workitem.KindIteration}, Required: false, Label: "Iteration", Description: "The iteration to which the work item belongs"},
-				workitem.SystemArea:      {Type: workitem.SimpleType{Kind: workitem.KindArea}, Required: false, Label: "Area", Description: "The area to which the work item belongs"},
-				workitem.SystemCodebase:  {Type: workitem.SimpleType{Kind: workitem.KindCodebase}, Required: false, Label: "Codebase", Description: "Contains codebase attributes to which this WI belongs to"},
+				workitem.SystemIteration:    {Type: workitem.SimpleType{Kind: workitem.KindIteration}, Required: false, Label: "Iteration", Description: "The iteration to which the work item belongs"},
+				workitem.SystemArea:         {Type: workitem.SimpleType{Kind: workitem.KindArea}, Required: false, Label: "Area", Description: "The area to which the work item belongs"},
+				workitem.SystemCodebase:     {Type: workitem.SimpleType{Kind: workitem.KindCodebase}, Required: false, Label: "Codebase", Description: "Contains codebase attributes to which this WI belongs to"},
 				workitem.SystemAssignees: {
 					Type: &workitem.ListType{
 						SimpleType:    workitem.SimpleType{Kind: workitem.KindList},

--- a/test/testfixture/make_functions.go
+++ b/test/testfixture/make_functions.go
@@ -28,7 +28,7 @@ func makeIdentities(fxt *TestFixture) error {
 	for i := range fxt.Identities {
 		fxt.Identities[i] = &account.Identity{
 			Username:     testsupport.CreateRandomValidTestName("John Doe "),
-			ProviderType: "test provider",
+			ProviderType: "test provider", // alternatively: account.KeycloakIDP
 		}
 		if err := fxt.runCustomizeEntityFuncs(i, kindIdentities); err != nil {
 			return errs.WithStack(err)
@@ -249,9 +249,10 @@ func makeWorkItemTypes(fxt *TestFixture) error {
 				workitem.SystemCreatedAt:    {Type: workitem.SimpleType{Kind: workitem.KindInstant}, Required: false, Label: "Created at", Description: "The date and time when the work item was created"},
 				workitem.SystemUpdatedAt:    {Type: workitem.SimpleType{Kind: workitem.KindInstant}, Required: false, Label: "Updated at", Description: "The date and time when the work item was last updated"},
 				workitem.SystemOrder:        {Type: workitem.SimpleType{Kind: workitem.KindFloat}, Required: false, Label: "Execution Order", Description: "Execution Order of the workitem."},
-				workitem.SystemIteration:    {Type: workitem.SimpleType{Kind: workitem.KindIteration}, Required: false, Label: "Iteration", Description: "The iteration to which the work item belongs"},
-				workitem.SystemArea:         {Type: workitem.SimpleType{Kind: workitem.KindArea}, Required: false, Label: "Area", Description: "The area to which the work item belongs"},
-				workitem.SystemCodebase:     {Type: workitem.SimpleType{Kind: workitem.KindCodebase}, Required: false, Label: "Codebase", Description: "Contains codebase attributes to which this WI belongs to"},
+				//workitem.SystemNumber:       {Type: workitem.SimpleType{Kind: workitem.KindInteger}, Required: false, Label: "Work Item Number", Description: "Humand-readable number."},
+				workitem.SystemIteration: {Type: workitem.SimpleType{Kind: workitem.KindIteration}, Required: false, Label: "Iteration", Description: "The iteration to which the work item belongs"},
+				workitem.SystemArea:      {Type: workitem.SimpleType{Kind: workitem.KindArea}, Required: false, Label: "Area", Description: "The area to which the work item belongs"},
+				workitem.SystemCodebase:  {Type: workitem.SimpleType{Kind: workitem.KindCodebase}, Required: false, Label: "Codebase", Description: "Contains codebase attributes to which this WI belongs to"},
 				workitem.SystemAssignees: {
 					Type: &workitem.ListType{
 						SimpleType:    workitem.SimpleType{Kind: workitem.KindList},

--- a/test/testfixture/recipe_funcs.go
+++ b/test/testfixture/recipe_funcs.go
@@ -62,7 +62,7 @@ func Identities(n int, fns ...CustomizeIdentityFunc) RecipeFunction {
 	}
 }
 
-// CustomizeSpacesFunc is directly compatible with CustomizeEntityFunc
+// CustomizeSpaceFunc is directly compatible with CustomizeEntityFunc
 // but it can only be used for the Spaces() recipe-function.
 type CustomizeSpaceFunc CustomizeEntityFunc
 


### PR DESCRIPTION
Most of the change is due to golden files being added.
Apart from that I've removed all the ugliness of test setup and have grouped tests into sub-tests under their proper parent test (e.g. `TestCreate`, `TestList`, `TestShow`, `TestUpdate`, `TestDelete`).

In responses for work item links I've removed the work item link category from the included section as well. 