### PR TITLE
Enabling updates to accept empty fields

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -211,7 +211,7 @@ func (m *GormIdentityRepository) Save(ctx context.Context, model *Identity) erro
 		}, "unable to update the identity")
 		return errs.WithStack(err)
 	}
-	err = m.db.Model(obj).Updates(model).Error
+	err = m.db.Model(obj).Save(model).Error
 
 	log.Debug(ctx, map[string]interface{}{
 		"identity_id": model.ID,

--- a/account/user.go
+++ b/account/user.go
@@ -130,7 +130,7 @@ func (m *GormUserRepository) Save(ctx context.Context, model *User) error {
 		}, "unable to update user")
 		return errs.WithStack(err)
 	}
-	err = m.db.Model(obj).Updates(model).Error
+	err = m.db.Model(obj).Save(model).Error
 	if err != nil {
 		return errs.WithStack(err)
 	}


### PR DESCRIPTION
Made changes such that gorm can update fields with blank values as well
It was treating them as not-changed before

Fixes(#1771)