### PR TITLE
Improve TestSearchController.TestUpdateWorkItem() test

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -954,15 +954,25 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 
 	s.T().Run("assignees", func(t *testing.T) {
 		// given
-		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
-		spaceIDStr := fxt.Spaces[0].ID.String()
-		filter := fmt.Sprintf(`{"assignee":null}`)
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.CreateWorkItemEnvironment(),
+			tf.WorkItems(2,
+				tf.SetWorkItemField(workitem.SystemTitle, "assigned", "unassigned"),
+				func(fxt *tf.TestFixture, idx int) error {
+					if idx == 0 {
+						fxt.WorkItems[idx].Fields[workitem.SystemAssignees] = []string{fxt.Identities[0].ID.String()}
+					}
+					return nil
+				},
+			),
+		)
+		filter := fmt.Sprintf(`{"$AND":[{"space":"%s"},{"assignee":null}]}`, fxt.Spaces[0].ID.String())
 		t.Run("filter null", func(t *testing.T) {
 			// when
-			_, result := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+			_, result := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
 			// then
 			require.Len(t, result.Data, 1)
-			require.Equal(t, fxt.WorkItems[0].ID, *result.Data[0].ID)
+			require.Equal(t, fxt.WorkItemByTitle("unassigned").ID, *result.Data[0].ID)
 
 			t.Run("assignee should be nil if assignee field is not touched during update", func(t *testing.T) {
 				wi := result.Data[0]
@@ -973,7 +983,7 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 				_, updated := test.UpdateWorkitemOK(t, s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
 				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_update_work_item.golden.json"), updated)
 
-				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
 				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_show_after_update_work_item.golden.json"), updated)
 				assert.Nil(s.T(), result.Data[0].Attributes[workitem.SystemAssignees])
 
@@ -982,29 +992,38 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 	})
 	s.T().Run("labels", func(t *testing.T) {
 		// given
-		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
-		spaceIDStr := fxt.Spaces[0].ID.String()
-		filter := fmt.Sprintf(`{"label":{"$EQ":null}}`)
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.CreateWorkItemEnvironment(),
+			tf.Labels(1),
+			tf.WorkItems(2,
+				tf.SetWorkItemField(workitem.SystemTitle, "labelled", "unlabelled"),
+				func(fxt *tf.TestFixture, idx int) error {
+					if idx == 0 {
+						fxt.WorkItems[idx].Fields[workitem.SystemLabels] = []string{fxt.Labels[0].ID.String()}
+					}
+					return nil
+				},
+			),
+		)
+		filter := fmt.Sprintf(`{"$AND":[{"space":"%s"},{"label":{"$EQ":null}}]}`, fxt.Spaces[0].ID.String())
 		t.Run("filter null", func(t *testing.T) {
 			// when
-			_, result := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+			_, result := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
 			// then
-			require.Len(t, result.Data, 2)
-			require.Equal(t, fxt.WorkItems[0].ID, *result.Data[1].ID)
+			require.Len(t, result.Data, 1)
+			require.Equal(t, fxt.WorkItemByTitle("unlabelled").ID, *result.Data[0].ID)
 
 			t.Run("assignee should be nil if label field is not touched during update", func(t *testing.T) {
 				wi := result.Data[0]
 				workitemCtrl := NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-
 				wi.Attributes[workitem.SystemTitle] = "Updated Test WI"
 				payload2 := app.UpdateWorkitemPayload{Data: wi}
 				_, updated := test.UpdateWorkitemOK(t, s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
 				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_update_work_item.golden.json"), updated)
 
-				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
 				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_show_after_update_work_item.golden.json"), updated)
 				assert.Nil(s.T(), result.Data[0].Attributes[workitem.SystemLabels])
-
 			})
 		})
 	})

--- a/controller/test-files/search/show/filter_assignee_null_show_after_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_assignee_null_show_after_update_work_item.golden.json
@@ -2,8 +2,8 @@
   "data": {
     "attributes": {
       "system.created_at": "0001-01-01T00:00:00Z",
-      "system.number": 1,
-      "system.order": 1000,
+      "system.number": 2,
+      "system.order": 2000,
       "system.remote_item_id": null,
       "system.state": "new",
       "system.title": "Updated Test WI",

--- a/controller/test-files/search/show/filter_assignee_null_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_assignee_null_update_work_item.golden.json
@@ -2,8 +2,8 @@
   "data": {
     "attributes": {
       "system.created_at": "0001-01-01T00:00:00Z",
-      "system.number": 1,
-      "system.order": 1000,
+      "system.number": 2,
+      "system.order": 2000,
       "system.remote_item_id": null,
       "system.state": "new",
       "system.title": "Updated Test WI",

--- a/controller/test-files/search/show/filter_label_null_show_after_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_label_null_show_after_update_work_item.golden.json
@@ -2,13 +2,13 @@
   "data": {
     "attributes": {
       "system.created_at": "0001-01-01T00:00:00Z",
-      "system.number": 1,
-      "system.order": 1000,
+      "system.number": 2,
+      "system.order": 2000,
       "system.remote_item_id": null,
       "system.state": "new",
       "system.title": "Updated Test WI",
       "system.updated_at": "0001-01-01T00:00:00Z",
-      "version": 2
+      "version": 1
     },
     "id": "3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
     "links": {

--- a/controller/test-files/search/show/filter_label_null_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_label_null_update_work_item.golden.json
@@ -2,13 +2,13 @@
   "data": {
     "attributes": {
       "system.created_at": "0001-01-01T00:00:00Z",
-      "system.number": 1,
-      "system.order": 1000,
+      "system.number": 2,
+      "system.order": 2000,
       "system.remote_item_id": null,
       "system.state": "new",
       "system.title": "Updated Test WI",
       "system.updated_at": "0001-01-01T00:00:00Z",
-      "version": 2
+      "version": 1
     },
     "id": "3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
     "links": {

--- a/test/testfixture/query_functions.go
+++ b/test/testfixture/query_functions.go
@@ -52,6 +52,16 @@ func (fxt *TestFixture) WorkItemTypeByName(name string, spaceID ...uuid.UUID) *w
 	return nil
 }
 
+// WorkItemTypeByID returns the work item type that has the given ID (if any).
+func (fxt *TestFixture) WorkItemTypeByID(id uuid.UUID) *workitem.WorkItemType {
+	for _, wit := range fxt.WorkItemTypes {
+		if wit.ID == id {
+			return wit
+		}
+	}
+	return nil
+}
+
 // IdentityByUsername returns the first identity that has the given username (if
 // any).
 func (fxt *TestFixture) IdentityByUsername(username string) *account.Identity {


### PR DESCRIPTION
Before the test didn't filter by space ID. I should say, it specified a space ID in their call to `test.ShowSearchOK()` but that `spaceID` is  internally ignored if a filter expression is also given.

I've created more than one work item per test and changed the query to an `AND` filter which includes the old query and the new *by-space-query*.

Some supporting changes I've done are these:

* Added test fixture customization functions:
  * `SetWorkItemField` this lets a user set any field in a work item by giving its key as the first argument. We validated the input based on the work item's type definition and return an error if a wrong argument is passed.
* Added test fixture query functions:
  * `WorkItemTypeByID`