### PR TITLE
UUID agnostic golden file comparison replaces real UUIDs during update

### DIFF
--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -59,7 +59,17 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 		return errs.WithStack(err)
 	}
 	if update {
-		err = ioutil.WriteFile(absPath, actual, os.ModePerm)
+		tmp := string(actual)
+		var err error
+		// Eliminate concrete UUIDs if requested. This makes adding changes to
+		// golden files much more easy in git.
+		if uuidAgnostic {
+			tmp, err = replaceUUIDs(tmp)
+			if err != nil {
+				return errs.Wrapf(err, "failed to replace UUIDs with more generic ones")
+			}
+		}
+		err = ioutil.WriteFile(absPath, []byte(tmp), os.ModePerm)
 		if err != nil {
 			return errs.Wrapf(err, "failed to update golden file: %s", absPath)
 		}

--- a/controller/test-files/codebase/show/ok_with_stackId.golden.json
+++ b/controller/test-files/codebase/show/ok_with_stackId.golden.json
@@ -7,21 +7,21 @@
       "type": "git",
       "url": "git@github.com:fabric8-services/fabric8-wit.git"
     },
-    "id": "cf4c1254-e624-40b4-ba2f-2a461659a4e2",
+    "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "edit": "http:///api/codebases/cf4c1254-e624-40b4-ba2f-2a461659a4e2/edit",
-      "related": "http:///api/codebases/cf4c1254-e624-40b4-ba2f-2a461659a4e2",
-      "self": "http:///api/codebases/cf4c1254-e624-40b4-ba2f-2a461659a4e2"
+      "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000001/edit",
+      "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001",
+      "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
       "space": {
         "data": {
-          "id": "657fb163-777c-4a31-b9e9-c215947cea0c",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/657fb163-777c-4a31-b9e9-c215947cea0c",
-          "self": "http:///api/spaces/657fb163-777c-4a31-b9e9-c215947cea0c"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/codebase/show/ok_without_stackId.golden.json
+++ b/controller/test-files/codebase/show/ok_without_stackId.golden.json
@@ -7,21 +7,21 @@
       "type": "git",
       "url": "git@github.com:fabric8-services/fabric8-wit.git"
     },
-    "id": "7ffb4b6d-7db6-4dd9-981f-991c14cf61c9",
+    "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "edit": "http:///api/codebases/7ffb4b6d-7db6-4dd9-981f-991c14cf61c9/edit",
-      "related": "http:///api/codebases/7ffb4b6d-7db6-4dd9-981f-991c14cf61c9",
-      "self": "http:///api/codebases/7ffb4b6d-7db6-4dd9-981f-991c14cf61c9"
+      "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000001/edit",
+      "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001",
+      "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
       "space": {
         "data": {
-          "id": "703a5a0d-3885-42aa-948d-e03303d6ab2c",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/703a5a0d-3885-42aa-948d-e03303d6ab2c",
-          "self": "http:///api/spaces/703a5a0d-3885-42aa-948d-e03303d6ab2c"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/iteration/create/bad_request_unknown_parent.golden.json
+++ b/controller/test-files/iteration/create/bad_request_unknown_parent.golden.json
@@ -2,7 +2,7 @@
   "errors": [
     {
       "code": "not_found",
-      "detail": "Iteration with id '4b567d6a-2835-4d23-9730-21152a28242b' not found",
+      "detail": "Iteration with id '00000000-0000-0000-0000-000000000001' not found",
       "id": "IGNORE_ME",
       "status": "404",
       "title": "Not Found"

--- a/controller/test-files/iteration/create/conflict_for_same_name.golden.json
+++ b/controller/test-files/iteration/create/conflict_for_same_name.golden.json
@@ -2,7 +2,7 @@
   "errors": [
     {
       "code": "data_conflict_error",
-      "detail": "iteration already exists with name = iteration 82cce03c-7c51-4b6c-8565-f468a8f081f9 , space_id = ddfb6ae7-e006-42e4-a181-49b334afd18c , path = /d2665ed8-3f66-4149-886a-aca90e7f7d06 ",
+      "detail": "iteration already exists with name = iteration 00000000-0000-0000-0000-000000000001 , space_id = 00000000-0000-0000-0000-000000000002 , path = /00000000-0000-0000-0000-000000000003 ",
       "status": "409",
       "title": "Data conflict error"
     }

--- a/controller/test-files/iteration/create/ok_create_child.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child.golden.json
@@ -6,42 +6,42 @@
       "description": "Some description",
       "endAt": "2016-11-25T15:08:41Z",
       "name": "Sprint #21",
-      "parent_path": "/58c5f839-8127-4f48-92d2-29cde9e3833b/db101168-6452-46a0-a951-a622945d8648",
+      "parent_path": "/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/root iteration/child iteration",
       "startAt": "2016-11-04T15:08:41Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false
     },
-    "id": "90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab",
+    "id": "00000000-0000-0000-0000-000000000003",
     "links": {
-      "related": "http:///api/iterations/90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab",
-      "self": "http:///api/iterations/90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab"
+      "related": "http:///api/iterations/00000000-0000-0000-0000-000000000003",
+      "self": "http:///api/iterations/00000000-0000-0000-0000-000000000003"
     },
     "relationships": {
       "parent": {
         "data": {
-          "id": "db101168-6452-46a0-a951-a622945d8648",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "iterations"
         },
         "links": {
-          "related": "http:///api/iterations/db101168-6452-46a0-a951-a622945d8648",
-          "self": "http:///api/iterations/db101168-6452-46a0-a951-a622945d8648"
+          "related": "http:///api/iterations/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/iterations/00000000-0000-0000-0000-000000000002"
         }
       },
       "space": {
         "data": {
-          "id": "85124ecc-1080-439a-92df-01d68a75f1d7",
+          "id": "00000000-0000-0000-0000-000000000004",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/85124ecc-1080-439a-92df-01d68a75f1d7",
-          "self": "http:///api/spaces/85124ecc-1080-439a-92df-01d68a75f1d7"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
       },
       "workitems": {
         "links": {
-          "related": "http:///api/workitems/?filter[iteration]=90ba10d2-6d90-4bb2-9d80-b0feba9ae2ab"
+          "related": "http:///api/workitems/?filter[iteration]=00000000-0000-0000-0000-000000000003"
         },
         "meta": {
           "closed": 0,

--- a/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_ID_paylod.golden.json
@@ -6,42 +6,42 @@
       "description": "Some description",
       "endAt": "2016-11-25T15:08:41Z",
       "name": "Sprint #21",
-      "parent_path": "/8319dda7-0e91-4445-9d7e-4964b024c917/67d326b8-d182-4fcb-b9e0-868bb08b155c",
+      "parent_path": "/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/root iteration/child iteration",
       "startAt": "2016-11-04T15:08:41Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false
     },
-    "id": "ee678073-2645-4ff3-afc7-a94b79e46546",
+    "id": "00000000-0000-0000-0000-000000000003",
     "links": {
-      "related": "http:///api/iterations/ee678073-2645-4ff3-afc7-a94b79e46546",
-      "self": "http:///api/iterations/ee678073-2645-4ff3-afc7-a94b79e46546"
+      "related": "http:///api/iterations/00000000-0000-0000-0000-000000000003",
+      "self": "http:///api/iterations/00000000-0000-0000-0000-000000000003"
     },
     "relationships": {
       "parent": {
         "data": {
-          "id": "67d326b8-d182-4fcb-b9e0-868bb08b155c",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "iterations"
         },
         "links": {
-          "related": "http:///api/iterations/67d326b8-d182-4fcb-b9e0-868bb08b155c",
-          "self": "http:///api/iterations/67d326b8-d182-4fcb-b9e0-868bb08b155c"
+          "related": "http:///api/iterations/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/iterations/00000000-0000-0000-0000-000000000002"
         }
       },
       "space": {
         "data": {
-          "id": "f18bc172-6865-464d-9a06-390d3e6284d0",
+          "id": "00000000-0000-0000-0000-000000000004",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/f18bc172-6865-464d-9a06-390d3e6284d0",
-          "self": "http:///api/spaces/f18bc172-6865-464d-9a06-390d3e6284d0"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
       },
       "workitems": {
         "links": {
-          "related": "http:///api/workitems/?filter[iteration]=ee678073-2645-4ff3-afc7-a94b79e46546"
+          "related": "http:///api/workitems/?filter[iteration]=00000000-0000-0000-0000-000000000003"
         },
         "meta": {
           "closed": 0,

--- a/controller/test-files/search/search_codebase_per_url_multi_match.json
+++ b/controller/test-files/search/search_codebase_per_url_multi_match.json
@@ -8,21 +8,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "6003af1d-05dd-4089-a85b-2b7f1898a5a4",
+      "id": "00000000-0000-0000-0000-000000000001",
       "links": {
-        "edit": "http:///api/codebases/6003af1d-05dd-4089-a85b-2b7f1898a5a4/edit",
-        "related": "http:///api/codebases/6003af1d-05dd-4089-a85b-2b7f1898a5a4",
-        "self": "http:///api/codebases/6003af1d-05dd-4089-a85b-2b7f1898a5a4"
+        "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000001/edit",
+        "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001",
+        "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "95c18030-9087-4db8-a456-583cac5576e4",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4",
-            "self": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
           }
         }
       },
@@ -36,21 +36,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "932dcc48-23ef-496e-b5a2-e112cef716f0",
+      "id": "00000000-0000-0000-0000-000000000003",
       "links": {
-        "edit": "http:///api/codebases/932dcc48-23ef-496e-b5a2-e112cef716f0/edit",
-        "related": "http:///api/codebases/932dcc48-23ef-496e-b5a2-e112cef716f0",
-        "self": "http:///api/codebases/932dcc48-23ef-496e-b5a2-e112cef716f0"
+        "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000003/edit",
+        "related": "http:///api/codebases/00000000-0000-0000-0000-000000000003",
+        "self": "http:///api/codebases/00000000-0000-0000-0000-000000000003"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "a8c3bd45-c124-44dc-95a5-9613567cbfb7",
+            "id": "00000000-0000-0000-0000-000000000004",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7",
-            "self": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
           }
         }
       },
@@ -64,21 +64,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "3aa39498-cf74-4ee4-bf78-5d792e7fd2b9",
+      "id": "00000000-0000-0000-0000-000000000005",
       "links": {
-        "edit": "http:///api/codebases/3aa39498-cf74-4ee4-bf78-5d792e7fd2b9/edit",
-        "related": "http:///api/codebases/3aa39498-cf74-4ee4-bf78-5d792e7fd2b9",
-        "self": "http:///api/codebases/3aa39498-cf74-4ee4-bf78-5d792e7fd2b9"
+        "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000005/edit",
+        "related": "http:///api/codebases/00000000-0000-0000-0000-000000000005",
+        "self": "http:///api/codebases/00000000-0000-0000-0000-000000000005"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "a91074a8-406b-4e78-8765-eb2fdf28e720",
+            "id": "00000000-0000-0000-0000-000000000006",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720",
-            "self": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000006"
           }
         }
       },
@@ -92,21 +92,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "b92d0db4-1154-4a3b-9013-7926c9af1925",
+      "id": "00000000-0000-0000-0000-000000000007",
       "links": {
-        "edit": "http:///api/codebases/b92d0db4-1154-4a3b-9013-7926c9af1925/edit",
-        "related": "http:///api/codebases/b92d0db4-1154-4a3b-9013-7926c9af1925",
-        "self": "http:///api/codebases/b92d0db4-1154-4a3b-9013-7926c9af1925"
+        "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000007/edit",
+        "related": "http:///api/codebases/00000000-0000-0000-0000-000000000007",
+        "self": "http:///api/codebases/00000000-0000-0000-0000-000000000007"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "d78c9c5a-060a-490a-85ef-3403f2719ea2",
+            "id": "00000000-0000-0000-0000-000000000008",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2",
-            "self": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
           }
         }
       },
@@ -120,21 +120,21 @@
         "type": "git",
         "url": "http://foo.com/multi/0"
       },
-      "id": "43d72950-0733-4289-8a8b-0ec15c32aeca",
+      "id": "00000000-0000-0000-0000-000000000009",
       "links": {
-        "edit": "http:///api/codebases/43d72950-0733-4289-8a8b-0ec15c32aeca/edit",
-        "related": "http:///api/codebases/43d72950-0733-4289-8a8b-0ec15c32aeca",
-        "self": "http:///api/codebases/43d72950-0733-4289-8a8b-0ec15c32aeca"
+        "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000009/edit",
+        "related": "http:///api/codebases/00000000-0000-0000-0000-000000000009",
+        "self": "http:///api/codebases/00000000-0000-0000-0000-000000000009"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "e8026936-16cc-4f7c-9cf6-97b30916d6ba",
+            "id": "00000000-0000-0000-0000-000000000010",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba",
-            "self": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000010"
           }
         }
       },
@@ -146,41 +146,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 1c8cfb75-bd4c-4025-9a81-8ce8302e37a6",
+        "name": "space 00000000-0000-0000-0000-000000000011",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "95c18030-9087-4db8-a456-583cac5576e4",
+      "id": "00000000-0000-0000-0000-000000000002",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/backlog"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4",
-        "self": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4",
-        "workitemlinktypes": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/95c18030-9087-4db8-a456-583cac5576e4/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemtypes"
+        "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+        "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+        "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/areas"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/backlog"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/codebases"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/collaborators"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/collaborators"
           }
         },
         "filters": {
@@ -190,41 +190,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/iterations"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/labels"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
+            "id": "00000000-0000-0000-0000-000000000012",
             "type": "identities"
           },
           "links": {
-            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000012"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemlinktypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitems"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/95c18030-9087-4db8-a456-583cac5576e4/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/95c18030-9087-4db8-a456-583cac5576e4/workitemtypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
           }
         }
       },
@@ -234,41 +234,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space abad46b1-f4ff-4876-9293-d6874efb6c07",
+        "name": "space 00000000-0000-0000-0000-000000000013",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "a8c3bd45-c124-44dc-95a5-9613567cbfb7",
+      "id": "00000000-0000-0000-0000-000000000004",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/backlog"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7",
-        "self": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7",
-        "workitemlinktypes": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypes"
+        "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+        "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+        "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/areas"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/backlog"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/codebases"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/collaborators"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/collaborators"
           }
         },
         "filters": {
@@ -278,41 +278,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/iterations"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/labels"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
+            "id": "00000000-0000-0000-0000-000000000012",
             "type": "identities"
           },
           "links": {
-            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000012"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemlinktypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitems"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/a8c3bd45-c124-44dc-95a5-9613567cbfb7/workitemtypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemtypes"
           }
         }
       },
@@ -322,41 +322,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space e9138690-e996-405e-8396-fbc1ea0da3de",
+        "name": "space 00000000-0000-0000-0000-000000000014",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "a91074a8-406b-4e78-8765-eb2fdf28e720",
+      "id": "00000000-0000-0000-0000-000000000006",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/backlog"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000006/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720",
-        "self": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720",
-        "workitemlinktypes": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypes"
+        "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006",
+        "self": "http:///api/spaces/00000000-0000-0000-0000-000000000006",
+        "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000006/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000006/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000006/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/areas"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/backlog"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/codebases"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/collaborators"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/collaborators"
           }
         },
         "filters": {
@@ -366,41 +366,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/iterations"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/labels"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
+            "id": "00000000-0000-0000-0000-000000000012",
             "type": "identities"
           },
           "links": {
-            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000012"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemlinktypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitems"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000006/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/a91074a8-406b-4e78-8765-eb2fdf28e720/workitemtypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006/workitemtypes"
           }
         }
       },
@@ -410,41 +410,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 39c7f11b-8356-47ff-b149-97e661712d9d",
+        "name": "space 00000000-0000-0000-0000-000000000015",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "d78c9c5a-060a-490a-85ef-3403f2719ea2",
+      "id": "00000000-0000-0000-0000-000000000008",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/backlog"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2",
-        "self": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2",
-        "workitemlinktypes": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypes"
+        "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+        "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
+        "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000008/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/areas"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/backlog"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/codebases"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/collaborators"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/collaborators"
           }
         },
         "filters": {
@@ -454,41 +454,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/iterations"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/labels"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
+            "id": "00000000-0000-0000-0000-000000000012",
             "type": "identities"
           },
           "links": {
-            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000012"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemlinktypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitems"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000008/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/d78c9c5a-060a-490a-85ef-3403f2719ea2/workitemtypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes"
           }
         }
       },
@@ -498,41 +498,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 4875c49d-9d98-4c47-94fb-f7ec7f4a61b7",
+        "name": "space 00000000-0000-0000-0000-000000000016",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "e8026936-16cc-4f7c-9cf6-97b30916d6ba",
+      "id": "00000000-0000-0000-0000-000000000010",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/backlog"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000010/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba",
-        "self": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba",
-        "workitemlinktypes": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypes"
+        "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010",
+        "self": "http:///api/spaces/00000000-0000-0000-0000-000000000010",
+        "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000010/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000010/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/areas"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/backlog"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/codebases"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/collaborators"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/collaborators"
           }
         },
         "filters": {
@@ -542,41 +542,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/iterations"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/labels"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "db16a704-dcc5-4f1c-8e93-5baddd96c263",
+            "id": "00000000-0000-0000-0000-000000000012",
             "type": "identities"
           },
           "links": {
-            "related": "http:///api/users/db16a704-dcc5-4f1c-8e93-5baddd96c263"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000012"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemlinktypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitems"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/e8026936-16cc-4f7c-9cf6-97b30916d6ba/workitemtypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010/workitemtypes"
           }
         }
       },

--- a/controller/test-files/search/search_codebase_per_url_single_match.json
+++ b/controller/test-files/search/search_codebase_per_url_single_match.json
@@ -8,21 +8,21 @@
         "type": "git",
         "url": "http://foo.com/single/0"
       },
-      "id": "ae5712e0-b4ad-43bb-9774-5c92fae85eb1",
+      "id": "00000000-0000-0000-0000-000000000001",
       "links": {
-        "edit": "http:///api/codebases/ae5712e0-b4ad-43bb-9774-5c92fae85eb1/edit",
-        "related": "http:///api/codebases/ae5712e0-b4ad-43bb-9774-5c92fae85eb1",
-        "self": "http:///api/codebases/ae5712e0-b4ad-43bb-9774-5c92fae85eb1"
+        "edit": "http:///api/codebases/00000000-0000-0000-0000-000000000001/edit",
+        "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001",
+        "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001"
       },
       "relationships": {
         "space": {
           "data": {
-            "id": "8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
-            "self": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
           }
         }
       },
@@ -34,41 +34,41 @@
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
         "description": "Some description",
-        "name": "space 276fe7ea-2f36-4153-befa-19e455ed08d6",
+        "name": "space 00000000-0000-0000-0000-000000000003",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
+      "id": "00000000-0000-0000-0000-000000000002",
       "links": {
         "backlog": {
-          "self": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/backlog"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002/backlog"
         },
         "filters": "http:///api/filters",
-        "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
-        "self": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605",
-        "workitemlinktypes": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypegroups/",
-        "workitemtypes": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypes"
+        "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+        "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+        "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes",
+        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/",
+        "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
       },
       "relationships": {
         "areas": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/areas"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/areas"
           }
         },
         "backlog": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/backlog"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/backlog"
           }
         },
         "codebases": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/codebases"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/codebases"
           }
         },
         "collaborators": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/collaborators"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/collaborators"
           }
         },
         "filters": {
@@ -78,41 +78,41 @@
         },
         "iterations": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/iterations"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/iterations"
           }
         },
         "labels": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/labels"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/labels"
           }
         },
         "owned-by": {
           "data": {
-            "id": "f0f62def-b76a-4fd0-87d5-b1ce8b885196",
+            "id": "00000000-0000-0000-0000-000000000004",
             "type": "identities"
           },
           "links": {
-            "related": "http:///api/users/f0f62def-b76a-4fd0-87d5-b1ce8b885196"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000004"
           }
         },
         "workitemlinktypes": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemlinktypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes"
           }
         },
         "workitems": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitems"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitems"
           }
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/"
           }
         },
         "workitemtypes": {
           "links": {
-            "related": "http:///api/spaces/8e33e6cd-5c13-4ca3-9e25-e64813e2d605/workitemtypes"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
           }
         }
       },

--- a/controller/test-files/search/show/filter_assignee_null_show_after_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_assignee_null_show_after_update_work_item.golden.json
@@ -10,18 +10,18 @@
       "system.updated_at": "0001-01-01T00:00:00Z",
       "version": 1
     },
-    "id": "3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
+    "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
-      "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+      "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001",
+      "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
       "area": {
         "data": {
-          "id": "e189ad80-5d49-437c-ae4d-3905ff868bee",
+          "id": "00000000-0000-0000-0000-000000000002",
           "links": {
-            "related": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee",
-            "self": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee"
+            "related": "http:///api/areas/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/areas/00000000-0000-0000-0000-000000000002"
           },
           "type": "areas"
         }
@@ -29,16 +29,16 @@
       "assignees": {},
       "baseType": {
         "data": {
-          "id": "f13a0fbf-1c9b-4561-801e-cb2210067d18",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "workitemtypes"
         },
         "links": {
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba/workitemtypes/f13a0fbf-1c9b-4561-801e-cb2210067d18"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemtypes/00000000-0000-0000-0000-000000000003"
         }
       },
       "children": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/children"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/children"
         },
         "meta": {
           "hasChildren": false
@@ -46,49 +46,49 @@
       },
       "comments": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/comments",
-          "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/relationships/comments"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/comments",
+          "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001/relationships/comments"
         }
       },
       "creator": {
         "data": {
-          "id": "71a1e4e2-0de9-4b47-9365-e600fdce4947",
+          "id": "00000000-0000-0000-0000-000000000005",
           "links": {
-            "related": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947",
-            "self": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000005",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000005"
           },
           "type": "users"
         }
       },
       "iteration": {
         "data": {
-          "id": "ccfe5d06-69e4-45b9-b101-5a3d422694d6",
+          "id": "00000000-0000-0000-0000-000000000006",
           "links": {
-            "related": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6",
-            "self": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6"
+            "related": "http:///api/iterations/00000000-0000-0000-0000-000000000006",
+            "self": "http:///api/iterations/00000000-0000-0000-0000-000000000006"
           },
           "type": "iterations"
         }
       },
       "labels": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/labels"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/labels"
         }
       },
       "space": {
         "data": {
-          "id": "8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
+          "id": "00000000-0000-0000-0000-000000000004",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
       }
     },
     "type": "workitems"
   },
   "links": {
-    "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+    "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
   }
 }

--- a/controller/test-files/search/show/filter_assignee_null_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_assignee_null_update_work_item.golden.json
@@ -10,18 +10,18 @@
       "system.updated_at": "0001-01-01T00:00:00Z",
       "version": 1
     },
-    "id": "3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
+    "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
-      "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+      "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001",
+      "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
       "area": {
         "data": {
-          "id": "e189ad80-5d49-437c-ae4d-3905ff868bee",
+          "id": "00000000-0000-0000-0000-000000000002",
           "links": {
-            "related": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee",
-            "self": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee"
+            "related": "http:///api/areas/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/areas/00000000-0000-0000-0000-000000000002"
           },
           "type": "areas"
         }
@@ -29,16 +29,16 @@
       "assignees": {},
       "baseType": {
         "data": {
-          "id": "f13a0fbf-1c9b-4561-801e-cb2210067d18",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "workitemtypes"
         },
         "links": {
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba/workitemtypes/f13a0fbf-1c9b-4561-801e-cb2210067d18"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemtypes/00000000-0000-0000-0000-000000000003"
         }
       },
       "children": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/children"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/children"
         },
         "meta": {
           "hasChildren": false
@@ -46,49 +46,49 @@
       },
       "comments": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/comments",
-          "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/relationships/comments"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/comments",
+          "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001/relationships/comments"
         }
       },
       "creator": {
         "data": {
-          "id": "71a1e4e2-0de9-4b47-9365-e600fdce4947",
+          "id": "00000000-0000-0000-0000-000000000005",
           "links": {
-            "related": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947",
-            "self": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000005",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000005"
           },
           "type": "users"
         }
       },
       "iteration": {
         "data": {
-          "id": "ccfe5d06-69e4-45b9-b101-5a3d422694d6",
+          "id": "00000000-0000-0000-0000-000000000006",
           "links": {
-            "related": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6",
-            "self": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6"
+            "related": "http:///api/iterations/00000000-0000-0000-0000-000000000006",
+            "self": "http:///api/iterations/00000000-0000-0000-0000-000000000006"
           },
           "type": "iterations"
         }
       },
       "labels": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/labels"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/labels"
         }
       },
       "space": {
         "data": {
-          "id": "8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
+          "id": "00000000-0000-0000-0000-000000000004",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
       }
     },
     "type": "workitems"
   },
   "links": {
-    "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+    "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
   }
 }

--- a/controller/test-files/search/show/filter_label_null_show_after_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_label_null_show_after_update_work_item.golden.json
@@ -10,18 +10,18 @@
       "system.updated_at": "0001-01-01T00:00:00Z",
       "version": 1
     },
-    "id": "3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
+    "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
-      "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+      "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001",
+      "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
       "area": {
         "data": {
-          "id": "e189ad80-5d49-437c-ae4d-3905ff868bee",
+          "id": "00000000-0000-0000-0000-000000000002",
           "links": {
-            "related": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee",
-            "self": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee"
+            "related": "http:///api/areas/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/areas/00000000-0000-0000-0000-000000000002"
           },
           "type": "areas"
         }
@@ -29,16 +29,16 @@
       "assignees": {},
       "baseType": {
         "data": {
-          "id": "f13a0fbf-1c9b-4561-801e-cb2210067d18",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "workitemtypes"
         },
         "links": {
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba/workitemtypes/f13a0fbf-1c9b-4561-801e-cb2210067d18"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemtypes/00000000-0000-0000-0000-000000000003"
         }
       },
       "children": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/children"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/children"
         },
         "meta": {
           "hasChildren": false
@@ -46,49 +46,49 @@
       },
       "comments": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/comments",
-          "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/relationships/comments"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/comments",
+          "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001/relationships/comments"
         }
       },
       "creator": {
         "data": {
-          "id": "71a1e4e2-0de9-4b47-9365-e600fdce4947",
+          "id": "00000000-0000-0000-0000-000000000005",
           "links": {
-            "related": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947",
-            "self": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000005",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000005"
           },
           "type": "users"
         }
       },
       "iteration": {
         "data": {
-          "id": "ccfe5d06-69e4-45b9-b101-5a3d422694d6",
+          "id": "00000000-0000-0000-0000-000000000006",
           "links": {
-            "related": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6",
-            "self": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6"
+            "related": "http:///api/iterations/00000000-0000-0000-0000-000000000006",
+            "self": "http:///api/iterations/00000000-0000-0000-0000-000000000006"
           },
           "type": "iterations"
         }
       },
       "labels": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/labels"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/labels"
         }
       },
       "space": {
         "data": {
-          "id": "8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
+          "id": "00000000-0000-0000-0000-000000000004",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
       }
     },
     "type": "workitems"
   },
   "links": {
-    "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+    "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
   }
 }

--- a/controller/test-files/search/show/filter_label_null_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_label_null_update_work_item.golden.json
@@ -10,18 +10,18 @@
       "system.updated_at": "0001-01-01T00:00:00Z",
       "version": 1
     },
-    "id": "3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
+    "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498",
-      "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+      "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001",
+      "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
       "area": {
         "data": {
-          "id": "e189ad80-5d49-437c-ae4d-3905ff868bee",
+          "id": "00000000-0000-0000-0000-000000000002",
           "links": {
-            "related": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee",
-            "self": "http:///api/areas/e189ad80-5d49-437c-ae4d-3905ff868bee"
+            "related": "http:///api/areas/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/areas/00000000-0000-0000-0000-000000000002"
           },
           "type": "areas"
         }
@@ -29,16 +29,16 @@
       "assignees": {},
       "baseType": {
         "data": {
-          "id": "f13a0fbf-1c9b-4561-801e-cb2210067d18",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "workitemtypes"
         },
         "links": {
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba/workitemtypes/f13a0fbf-1c9b-4561-801e-cb2210067d18"
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemtypes/00000000-0000-0000-0000-000000000003"
         }
       },
       "children": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/children"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/children"
         },
         "meta": {
           "hasChildren": false
@@ -46,49 +46,49 @@
       },
       "comments": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/comments",
-          "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/relationships/comments"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/comments",
+          "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001/relationships/comments"
         }
       },
       "creator": {
         "data": {
-          "id": "71a1e4e2-0de9-4b47-9365-e600fdce4947",
+          "id": "00000000-0000-0000-0000-000000000005",
           "links": {
-            "related": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947",
-            "self": "http:///api/users/71a1e4e2-0de9-4b47-9365-e600fdce4947"
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000005",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000005"
           },
           "type": "users"
         }
       },
       "iteration": {
         "data": {
-          "id": "ccfe5d06-69e4-45b9-b101-5a3d422694d6",
+          "id": "00000000-0000-0000-0000-000000000006",
           "links": {
-            "related": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6",
-            "self": "http:///api/iterations/ccfe5d06-69e4-45b9-b101-5a3d422694d6"
+            "related": "http:///api/iterations/00000000-0000-0000-0000-000000000006",
+            "self": "http:///api/iterations/00000000-0000-0000-0000-000000000006"
           },
           "type": "iterations"
         }
       },
       "labels": {
         "links": {
-          "related": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498/labels"
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/labels"
         }
       },
       "space": {
         "data": {
-          "id": "8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
+          "id": "00000000-0000-0000-0000-000000000004",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba",
-          "self": "http:///api/spaces/8aa4cb28-05a0-4f7e-b3e4-d4be40c60cba"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
       }
     },
     "type": "workitems"
   },
   "links": {
-    "self": "http:///api/workitems/3c0b14df-9205-4cbd-ade0-5feaa1a6f498"
+    "self": "http:///api/workitems/00000000-0000-0000-0000-000000000001"
   }
 }

--- a/controller/test-files/space/show_space_ok.golden.json
+++ b/controller/test-files/space/show_space_ok.golden.json
@@ -3,34 +3,34 @@
     "attributes": {
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Space for TestShowSpaceOK",
-      "name": "TestShowSpaceOK-f0e5f5ba-aae4-46eb-9ab3-6354ac535aef",
+      "name": "TestShowSpaceOK-00000000-0000-0000-0000-000000000001",
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "52b39f33-62c4-4f9a-be4c-58d8cab4b346",
+    "id": "00000000-0000-0000-0000-000000000002",
     "links": {
       "backlog": {
         "meta": {
           "totalCount": 0
         },
-        "self": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/backlog"
+        "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002/backlog"
       },
       "filters": "http:///api/filters",
-      "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346",
-      "self": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346",
-      "workitemlinktypes": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemlinktypes",
-      "workitemtypegroups": "http:///api/spacetemplates/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypegroups/",
-      "workitemtypes": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypes"
+      "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+      "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+      "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes",
+      "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/",
+      "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
     },
     "relationships": {
       "areas": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/areas"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/areas"
         }
       },
       "backlog": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/backlog"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/backlog"
         },
         "meta": {
           "totalCount": 0
@@ -38,12 +38,12 @@
       },
       "codebases": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/codebases"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/codebases"
         }
       },
       "collaborators": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/collaborators"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/collaborators"
         }
       },
       "filters": {
@@ -53,41 +53,41 @@
       },
       "iterations": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/iterations"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/iterations"
         }
       },
       "labels": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/labels"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/labels"
         }
       },
       "owned-by": {
         "data": {
-          "id": "1025eeda-cb95-4546-be43-c6c27ba59d28",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "identities"
         },
         "links": {
-          "related": "http:///api/users/1025eeda-cb95-4546-be43-c6c27ba59d28"
+          "related": "http:///api/users/00000000-0000-0000-0000-000000000003"
         }
       },
       "workitemlinktypes": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemlinktypes"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes"
         }
       },
       "workitems": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitems"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitems"
         }
       },
       "workitemtypegroups": {
         "links": {
-          "related": "http:///api/spacetemplates/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypegroups/"
+          "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/"
         }
       },
       "workitemtypes": {
         "links": {
-          "related": "http:///api/spaces/52b39f33-62c4-4f9a-be4c-58d8cab4b346/workitemtypes"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
         }
       }
     },


### PR DESCRIPTION
When you update a golden file using `go test -update` it will contain a set of new random UUIDs.

Those new UUIDs appear as changes inside a commit if you just do `git add myGoldenFile.json`. This clutters the commit and hides the real change that might have appeared in your commit.

I want you to be able to focus on the real changes to the API and not on some random UUIDs.

That is why a golden file that is generated with `controller.compareWithGoldenUUIDAgnostic()` will now have all UUIDs replaced with  "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", ..., "00000000-0000-0000-0000-00000000000N" and so on.

The next time you update your golden files will be much easier.