### PR TITLE
Add "workItemLinks" relationship on work item response

### DIFF
--- a/controller/test-files/search/show/filter_assignee_null_show_after_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_assignee_null_show_after_update_work_item.golden.json
@@ -84,6 +84,11 @@
           "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
           "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
+      },
+      "workItemLinks": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/links"
+        }
       }
     },
     "type": "workitems"

--- a/controller/test-files/search/show/filter_assignee_null_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_assignee_null_update_work_item.golden.json
@@ -84,6 +84,11 @@
           "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
           "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
+      },
+      "workItemLinks": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/links"
+        }
       }
     },
     "type": "workitems"

--- a/controller/test-files/search/show/filter_label_null_show_after_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_label_null_show_after_update_work_item.golden.json
@@ -84,6 +84,11 @@
           "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
           "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
+      },
+      "workItemLinks": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/links"
+        }
       }
     },
     "type": "workitems"

--- a/controller/test-files/search/show/filter_label_null_update_work_item.golden.json
+++ b/controller/test-files/search/show/filter_label_null_update_work_item.golden.json
@@ -84,6 +84,11 @@
           "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
           "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
         }
+      },
+      "workItemLinks": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/links"
+        }
       }
     },
     "type": "workitems"

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -461,6 +461,7 @@ func ConvertWorkItem(request *http.Request, wi workitem.WorkItem, additional ...
 	spaceRelatedURL := rest.AbsoluteURL(request, app.SpaceHref(wi.SpaceID.String()))
 	witRelatedURL := rest.AbsoluteURL(request, app.WorkitemtypeHref(wi.SpaceID.String(), wi.Type))
 	labelsRelated := relatedURL + "/labels"
+	workItemLinksRelated := relatedURL + "/links"
 
 	op := &app.WorkItem{
 		ID:   &wi.ID,
@@ -480,6 +481,11 @@ func ConvertWorkItem(request *http.Request, wi workitem.WorkItem, additional ...
 				},
 			},
 			Space: app.NewSpaceRelation(wi.SpaceID, spaceRelatedURL),
+			WorkItemLinks: &app.RelationGeneric{
+				Links: &app.GenericLinks{
+					Related: &workItemLinksRelated,
+				},
+			},
 		},
 		Links: &app.GenericLinksForWorkItem{
 			Self:    &relatedURL,

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -43,6 +43,7 @@ var workItemRelationships = a.Type("WorkItemRelationships", func() {
 	a.Attribute("children", relationGeneric, "This defines the children of this work item")
 	a.Attribute("space", relationSpaces, "This defines the owning space of this work item.")
 	a.Attribute("parent", relationKindUUID, "This defines the parent of this work item.")
+	a.Attribute("workItemLinks", relationGeneric, "List of links in which this work item is involved")
 })
 
 // relationBaseType is top level block for WorkItemType relationship


### PR DESCRIPTION
I've created a long missing `related` link to a new `workItemLinks` relationship in the work item response.

With this change, the UI no longer needs to construct the URL to fetch links for a work item manually.