### PR TITLE
WIP: Type hierarchy level n as a query parameter

### DIFF
--- a/search/query_language_whitebox_test.go
+++ b/search/query_language_whitebox_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime/debug"
+	"strconv"
+	"strings"
 	"testing"
 
 	c "github.com/fabric8-services/fabric8-wit/criteria"
@@ -524,7 +526,11 @@ func TestHierarchy(t *testing.T) {
 		typegroup.Requirements0,
 	}
 	for _, typeGroup := range typeGroups {
-		t.Run(typeGroup.Name, func(t *testing.T) {
+		levelArr := make([]string, len(typeGroup.Level))
+		for idx, level := range typeGroup.Level {
+			levelArr[idx] = strconv.FormatInt(int64(level), 10)
+		}
+		t.Run(typeGroup.Name+" (level: "+strings.Join(levelArr, ".")+")", func(t *testing.T) {
 			// given
 			spaceName := "openshiftio"
 			q := Query{

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -385,7 +385,7 @@ func (q Query) generateExpression() (criteria.Expression, error) {
 	//
 	// "hierarchy = y"
 	//
-	// eypression into an
+	// expression into an
 	//
 	// "Type in (y1, y2, y3, ... ,yn)"
 	//

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -434,6 +434,7 @@ func (q Query) generateExpression() (criteria.Expression, error) {
 					e = eq
 				}
 			}
+			spew.Dump(e)
 			myexpr = append(myexpr, e)
 			// switch *child.Value {
 			// case typegroup.Requirements0.Name:

--- a/workitem/typegroup/typegroup.go
+++ b/workitem/typegroup/typegroup.go
@@ -1,6 +1,9 @@
 package typegroup
 
 import (
+	"strconv"
+	"strings"
+
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/fabric8-services/fabric8-wit/workitem"
@@ -20,6 +23,16 @@ type WorkItemTypeGroup struct {
 	Name                   string // the name to be displayed to user
 	WorkItemTypeCollection []uuid.UUID
 	Icon                   string
+}
+
+// BuildName returns the name of the work item type group together with a string
+// representation of the level array.
+func (g WorkItemTypeGroup) BuildName() string {
+	levelArr := make([]string, len(g.Level))
+	for idx, level := range g.Level {
+		levelArr[idx] = strconv.FormatInt(int64(level), 10)
+	}
+	return g.Name + "-" + strings.Join(levelArr, ".")
 }
 
 // Use following group constants while defining static groups


### PR DESCRIPTION
I've started working on the support of the type hierarchy inside the query language and got pretty far I think. 

## Solution

I've introduced a `"hierarchy"` query parameter which internally gets translated from simple

```
hierarchy = y
hierarchy != y
```
expressions into an

```
Type IN (y1, y2, y3, ... ,yn)
Type NOT IN (y1, y2, y3, ... ,yn)
```

expressions where `yi` represents the `i`-th work item type associated with the hierarchy `y`.

Currently the hierarchy can be searched for on top-level of the query as well as in a deeply nested place in the query.

## Questions

### Type group naming

While implementing this I notices that the `Execution0` work item type group was actually called `Iterations` and I'm not sure this is intended ( @pranavgore09 ? ).

Another thing I found out is that type groups can carry the same name at the moment. In order to have a distinguishable name for each type group to search by, I've created a function `BuildName()` that returns a combination of the type group's `Name` field as well as the levels separated by dots (e.g. `"Requirements-1.0"`, `"Portfolio-0.1"`, `"Portfolio-1.0"`). I did this because I wanted the level to be part of the name by which we query.

This relates to [Guided Type Hierarchy as a Search Query Condition [7]](https://openshift.io/openshiftio/openshiftio/plan/detail/1717)