### PR TITLE
Remove "almighty" appearances from code.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,9 +6,9 @@ project by reporting issues, sending pull requests, writing
 documentation etc.
 
 If you have any questions, you can ask in the
-[public mailing list](https://www.redhat.com/mailman/listinfo/almighty-public)
+[public mailing list](https://groups.google.com/forum/#!forum/fabric8)
 or
-[IRC channel](http://webchat.freenode.net/?randomnick=1&channels=almighty).
+[IRC channel](http://webchat.freenode.net/?randomnick=1&channels=fabric8).
 
 ## Reporting Issues
 

--- a/docs/development/README.adoc
+++ b/docs/development/README.adoc
@@ -8,8 +8,7 @@ This section of the documentation contains a guide for users who want to contrib
 
 Code or documentation isn’t the only way to contribute. You can also link:https://github.com/fabric8-services/fabric8-wit/issues/new[report an issue].
 
-You can even propose your own type of contribution. Right now we don’t have a lot written about this yet, so just email almighty-public@redhat.com
-if this type of contributing interests you.
+You can even propose your own type of contribution. Right now we don’t have a lot written about this yet, so just discuss here https://groups.google.com/forum/#!forum/fabric8.
 
 === How to use this guide?
 

--- a/remoteworkitem/github_test.go
+++ b/remoteworkitem/github_test.go
@@ -77,7 +77,7 @@ func TestGithubFetchWithRecording(t *testing.T) {
 	}
 	f := githubIssueFetcher{}
 	f.client = github.NewClient(h)
-	g := &GithubTracker{URL: "", Query: "is:open is:issue user:almighty-test"}
+	g := &GithubTracker{URL: "", Query: "is:open is:issue user:fabric8-test"}
 	// when
 	fetch := g.fetch(&f)
 	// then

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -72,8 +72,8 @@ KnownURLs is set of KnownURLs will be used while searching on a URL
 URLs in this slice will be considered while searching to match search string and decouple it into multiple searchable parts
 e.g> Following example defines work-item-detail-page URL on client side, with its compiled version
 knownURLs["work-item-details"] = KnownURL{
-URLRegex:      `^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`,
-compiledRegex: regexp.MustCompile(`^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`),
+URLRegex:      `^(?P<protocol>http[s]?)://(?P<domain>demo.fabric8.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`,
+compiledRegex: regexp.MustCompile(`^(?P<protocol>http[s]?)://(?P<domain>demo.fabric8.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`),
 groupNamesInRegex: []string{"protocol", "domain", "path", "id"}
 }
 above url will be decoupled into two parts "ID:* | domain+path+id:*" while performing search query


### PR DESCRIPTION
As a followup we have to rename this repo

from https://github.com/almighty-test/almighty-test-unit
to https://github.com/fabric8-test/fabric8-test-unit

or something alike and adapt the places in tests accordingly.