### PR TITLE
Made show action for WIT group standalone

### DIFF
--- a/controller/test-files/work_item_type_group/list/ok.witg.golden.json
+++ b/controller/test-files/work_item_type_group/list/ok.witg.golden.json
@@ -11,16 +11,16 @@
       },
       "id": "00000000-0000-0000-0000-000000000001",
       "links": {
-        "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000001"
+        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000001"
       },
       "relationships": {
         "defaultType": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "workitemtypes"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes/00000000-0000-0000-0000-000000000003"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
           }
         },
         "nextGroup": {
@@ -29,19 +29,19 @@
             "type": "workitemtypegroups"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000004"
+            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
           }
         },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
+            "id": "00000000-0000-0000-0000-000000000003",
             "type": "spacetemplates"
           }
         },
         "typeList": {
           "data": [
             {
-              "id": "00000000-0000-0000-0000-000000000003",
+              "id": "00000000-0000-0000-0000-000000000002",
               "type": "workitemtypes"
             },
             {
@@ -68,7 +68,7 @@
       },
       "id": "00000000-0000-0000-0000-000000000004",
       "links": {
-        "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000004"
+        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
       },
       "relationships": {
         "defaultType": {
@@ -77,7 +77,7 @@
             "type": "workitemtypes"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes/00000000-0000-0000-0000-000000000007"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000007"
           }
         },
         "nextGroup": {
@@ -86,7 +86,7 @@
             "type": "workitemtypegroups"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000008"
+            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000008"
           }
         },
         "prevGroup": {
@@ -95,12 +95,12 @@
             "type": "workitemtypegroups"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000001"
+            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000001"
           }
         },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
+            "id": "00000000-0000-0000-0000-000000000003",
             "type": "spacetemplates"
           }
         },
@@ -130,7 +130,7 @@
       },
       "id": "00000000-0000-0000-0000-000000000008",
       "links": {
-        "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000008"
+        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000008"
       },
       "relationships": {
         "defaultType": {
@@ -139,7 +139,7 @@
             "type": "workitemtypes"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes/00000000-0000-0000-0000-000000000010"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000010"
           }
         },
         "nextGroup": {
@@ -148,7 +148,7 @@
             "type": "workitemtypegroups"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000011"
+            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000011"
           }
         },
         "prevGroup": {
@@ -157,12 +157,12 @@
             "type": "workitemtypegroups"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000004"
+            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
           }
         },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
+            "id": "00000000-0000-0000-0000-000000000003",
             "type": "spacetemplates"
           }
         },
@@ -192,7 +192,7 @@
       },
       "id": "00000000-0000-0000-0000-000000000011",
       "links": {
-        "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000011"
+        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000011"
       },
       "relationships": {
         "defaultType": {
@@ -201,7 +201,7 @@
             "type": "workitemtypes"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes/00000000-0000-0000-0000-000000000013"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000013"
           }
         },
         "prevGroup": {
@@ -210,12 +210,12 @@
             "type": "workitemtypegroups"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000008"
+            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000008"
           }
         },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
+            "id": "00000000-0000-0000-0000-000000000003",
             "type": "spacetemplates"
           }
         },
@@ -232,6 +232,6 @@
     }
   ],
   "links": {
-    "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups"
+    "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003/workitemtypegroups"
   }
 }

--- a/controller/test-files/work_item_type_group/show/ok.witg.golden.json
+++ b/controller/test-files/work_item_type_group/show/ok.witg.golden.json
@@ -10,16 +10,16 @@
     },
     "id": "00000000-0000-0000-0000-000000000001",
     "links": {
-      "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000001"
+      "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
       "defaultType": {
         "data": {
-          "id": "00000000-0000-0000-0000-000000000003",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "workitemtypes"
         },
         "links": {
-          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes/00000000-0000-0000-0000-000000000003"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
         }
       },
       "nextGroup": {
@@ -28,19 +28,19 @@
           "type": "workitemtypegroups"
         },
         "links": {
-          "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/00000000-0000-0000-0000-000000000004"
+          "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
         }
       },
       "spaceTemplate": {
         "data": {
-          "id": "00000000-0000-0000-0000-000000000002",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "spacetemplates"
         }
       },
       "typeList": {
         "data": [
           {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "workitemtypes"
           },
           {

--- a/controller/work_item_type_group_blackbox_test.go
+++ b/controller/work_item_type_group_blackbox_test.go
@@ -19,9 +19,10 @@ import (
 
 type workItemTypeGroupSuite struct {
 	gormtestsupport.DBTestSuite
-	svc           *goa.Service
-	typeGroupCtrl *WorkItemTypeGroupController
-	testDir       string
+	svc            *goa.Service
+	typeGroupCtrl  *WorkItemTypeGroupController
+	typeGroupsCtrl *WorkItemTypeGroupsController
+	testDir        string
 }
 
 func TestWorkItemTypeGroupSuite(t *testing.T) {
@@ -36,6 +37,7 @@ func (s *workItemTypeGroupSuite) SetupTest() {
 	s.DBTestSuite.SetupTest()
 	s.svc = testsupport.ServiceAsUser("WITG-Service", testsupport.TestIdentity)
 	s.typeGroupCtrl = NewWorkItemTypeGroupController(s.svc, gormapplication.NewGormDB(s.DB))
+	s.typeGroupsCtrl = NewWorkItemTypeGroupsController(s.svc, gormapplication.NewGormDB(s.DB))
 	s.testDir = filepath.Join("test-files", "work_item_type_group")
 }
 
@@ -44,7 +46,7 @@ func (s *workItemTypeGroupSuite) TestList() {
 		// given
 		sapcetemplateID := space.SystemSpace // must be valid space ID
 		// when
-		res, groups := test.ListWorkItemTypeGroupOK(t, nil, s.svc, s.typeGroupCtrl, sapcetemplateID)
+		res, groups := test.ListWorkItemTypeGroupsOK(t, nil, s.svc, s.typeGroupsCtrl, sapcetemplateID)
 		// then
 		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.witg.golden.json"), groups)
 		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.headers.golden.json"), res.Header())
@@ -53,7 +55,7 @@ func (s *workItemTypeGroupSuite) TestList() {
 		// given
 		sapcetemplateID := uuid.NewV4()
 		// when
-		res, jerrs := test.ListWorkItemTypeGroupNotFound(t, nil, s.svc, s.typeGroupCtrl, sapcetemplateID)
+		res, jerrs := test.ListWorkItemTypeGroupsNotFound(t, nil, s.svc, s.typeGroupsCtrl, sapcetemplateID)
 		// then
 		ignoreMe := "IGNOREME"
 		jerrs.Errors[0].ID = &ignoreMe
@@ -62,23 +64,21 @@ func (s *workItemTypeGroupSuite) TestList() {
 	})
 }
 
-func (s *workItemTypeGroupSuite) TestListShow() {
+func (s *workItemTypeGroupSuite) TestShow() {
 	s.T().Run("ok", func(t *testing.T) {
 		// given
-		sapcetemplateID := space.SystemSpace // must be valid space ID
 		typeGroupID := workitem.TypeGroups()[0].ID
 		// when
-		res, group := test.ShowWorkItemTypeGroupOK(t, nil, s.svc, s.typeGroupCtrl, sapcetemplateID, typeGroupID)
+		res, group := test.ShowWorkItemTypeGroupOK(t, nil, s.svc, s.typeGroupCtrl, typeGroupID)
 		// then
 		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.witg.golden.json"), group)
 		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
 	})
 	s.T().Run("not found", func(t *testing.T) {
 		// given
-		sapcetemplateID := space.SystemSpace
 		typeGroupID := uuid.NewV4()
 		// when
-		res, jerrs := test.ShowWorkItemTypeGroupNotFound(t, nil, s.svc, s.typeGroupCtrl, sapcetemplateID, typeGroupID)
+		res, jerrs := test.ShowWorkItemTypeGroupNotFound(t, nil, s.svc, s.typeGroupCtrl, typeGroupID)
 		// then
 		ignoreMe := "IGNOREME"
 		jerrs.Errors[0].ID = &ignoreMe

--- a/controller/work_item_type_groups.go
+++ b/controller/work_item_type_groups.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"github.com/fabric8-services/fabric8-wit/app"
+	"github.com/fabric8-services/fabric8-wit/application"
+	"github.com/fabric8-services/fabric8-wit/jsonapi"
+	"github.com/fabric8-services/fabric8-wit/rest"
+	"github.com/fabric8-services/fabric8-wit/space"
+	"github.com/fabric8-services/fabric8-wit/workitem"
+	"github.com/goadesign/goa"
+)
+
+// WorkItemTypeGroupsController implements the work_item_type_groups resource.
+type WorkItemTypeGroupsController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewWorkItemTypeGroupsController creates a work_item_type_groups controller.
+func NewWorkItemTypeGroupsController(service *goa.Service, db application.DB) *WorkItemTypeGroupsController {
+	return &WorkItemTypeGroupsController{
+		Controller: service.NewController("WorkItemTypeGroupsController"),
+		db:         db,
+	}
+}
+
+// List runs the list action.
+func (c *WorkItemTypeGroupsController) List(ctx *app.ListWorkItemTypeGroupsContext) error {
+	err := application.Transactional(c.db, func(appl application.Application) error {
+		return appl.Spaces().CheckExists(ctx, ctx.SpaceTemplateID.String())
+	})
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	typeGroups := workitem.TypeGroups()
+	res := &app.WorkItemTypeGroupList{
+		Data: make([]*app.WorkItemTypeGroupData, len(typeGroups)),
+		Links: &app.WorkItemTypeGroupLinks{
+			Self: rest.AbsoluteURL(ctx.Request, app.SpaceTemplateHref(space.SystemSpace)) + "/" + APIWorkItemTypeGroups,
+		},
+	}
+	for i, group := range typeGroups {
+		res.Data[i] = ConvertTypeGroup(ctx.Request, group)
+	}
+	return ctx.OK(res)
+}

--- a/design/work_item_type_group.go
+++ b/design/work_item_type_group.go
@@ -59,9 +59,23 @@ var workItemTypeGroupsRelationships = a.Type("WorkItemTypeGroupRelationships", f
 	a.Attribute("prevGroup", relationGeneric, "The type group (if any) that comes before this one in the list")
 })
 
-var _ = a.Resource("work_item_type_group", func() {
+var _ = a.Resource("work_item_type_groups", func() {
 	a.BasePath("/workitemtypegroups")
 	a.Parent("space_template")
+
+	a.Action("list", func() {
+		a.Routing(
+			a.GET(""),
+		)
+		a.Description("List of work item type groups")
+		a.Response(d.OK, workItemTypeGroupList)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+})
+
+var _ = a.Resource("work_item_type_group", func() {
+	a.BasePath("/workitemtypegroups")
 
 	a.Action("show", func() {
 		a.Routing(
@@ -72,16 +86,6 @@ var _ = a.Resource("work_item_type_group", func() {
 		})
 		a.Description("Show work item type group for given ID")
 		a.Response(d.OK, workItemTypeGroupSingle)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-	})
-
-	a.Action("list", func() {
-		a.Routing(
-			a.GET(""),
-		)
-		a.Description("List of work item type groups")
-		a.Response(d.OK, workItemTypeGroupList)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 	})


### PR DESCRIPTION
Before you could view a WIT group by hitting

```
/api/spacetemplates/<SPACE_TEMPLATE_ID>/workitemtypegroups/<WIT_GROUP_ID>
```

That level of nesting should not be needed becaus the `<WIT_GROUP_ID>` is good enough to filter on a work item type group. Now you can view a group with

```
/api/workitemtypegroups/<WIT_GROUP_ID>
```

The *list* action is still located under the space template endpoint:

```
/api/spacetemplates/<SPACE_TEMPLATE_ID>/workitemtypegroups
```