### PR TITLE
Fix link to WIT groups in space

### DIFF
--- a/controller/space.go
+++ b/controller/space.go
@@ -405,7 +405,7 @@ func ConvertSpaceFromModel(request *http.Request, sp space.Space, options ...Spa
 	relatedCollaborators := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/collaborators", spaceIDStr))
 	relatedFilters := rest.AbsoluteURL(request, "/api/filters")
 	relatedLabels := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/labels", spaceIDStr))
-	relatedWorkitemTypeGroups := rest.AbsoluteURL(request, app.SpaceTemplateHref(spaceIDStr)+"/workitemtypegroups/")
+	relatedWorkitemTypeGroups := rest.AbsoluteURL(request, app.SpaceTemplateHref(spaceIDStr)+"/workitemtypegroups")
 
 	s := &app.Space{
 		ID:   &sp.ID,
@@ -423,10 +423,9 @@ func ConvertSpaceFromModel(request *http.Request, sp space.Space, options ...Spa
 			Backlog: &app.BacklogGenericLink{ //TODO (xcoulon): remove this link
 				Self: &relatedBacklog,
 			},
-			Workitemtypes:      &relatedWorkItemTypes,      //TODO (xcoulon): remove this link
-			Workitemlinktypes:  &relatedWorkItemLinkTypes,  //TODO (xcoulon): remove this link
-			Filters:            &relatedFilters,            //TODO (xcoulon): remove this link
-			Workitemtypegroups: &relatedWorkitemTypeGroups, //TODO (xcoulon): remove this link
+			Workitemtypes:     &relatedWorkItemTypes,     //TODO (xcoulon): remove this link
+			Workitemlinktypes: &relatedWorkItemLinkTypes, //TODO (xcoulon): remove this link
+			Filters:           &relatedFilters,           //TODO (xcoulon): remove this link
 		},
 		Relationships: &app.SpaceRelationships{
 			Areas: &app.RelationGeneric{

--- a/controller/test-files/search/search_codebase_per_url_multi_match.json
+++ b/controller/test-files/search/search_codebase_per_url_multi_match.json
@@ -159,7 +159,6 @@
         "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
         "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
         "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/",
         "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
       },
       "relationships": {
@@ -219,7 +218,7 @@
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups"
           }
         },
         "workitemtypes": {
@@ -247,7 +246,6 @@
         "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
         "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
         "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004/workitemtypegroups/",
         "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000004/workitemtypes"
       },
       "relationships": {
@@ -307,7 +305,7 @@
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004/workitemtypegroups"
           }
         },
         "workitemtypes": {
@@ -335,7 +333,6 @@
         "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006",
         "self": "http:///api/spaces/00000000-0000-0000-0000-000000000006",
         "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000006/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000006/workitemtypegroups/",
         "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000006/workitemtypes"
       },
       "relationships": {
@@ -395,7 +392,7 @@
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000006/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000006/workitemtypegroups"
           }
         },
         "workitemtypes": {
@@ -423,7 +420,6 @@
         "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
         "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
         "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000008/workitemtypegroups/",
         "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000008/workitemtypes"
       },
       "relationships": {
@@ -483,7 +479,7 @@
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000008/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000008/workitemtypegroups"
           }
         },
         "workitemtypes": {
@@ -511,7 +507,6 @@
         "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010",
         "self": "http:///api/spaces/00000000-0000-0000-0000-000000000010",
         "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000010/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010/workitemtypegroups/",
         "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000010/workitemtypes"
       },
       "relationships": {
@@ -571,7 +566,7 @@
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010/workitemtypegroups"
           }
         },
         "workitemtypes": {

--- a/controller/test-files/search/search_codebase_per_url_single_match.json
+++ b/controller/test-files/search/search_codebase_per_url_single_match.json
@@ -47,7 +47,6 @@
         "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
         "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
         "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes",
-        "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/",
         "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
       },
       "relationships": {
@@ -107,7 +106,7 @@
         },
         "workitemtypegroups": {
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups"
           }
         },
         "workitemtypes": {

--- a/controller/test-files/space/show_space_ok.golden.json
+++ b/controller/test-files/space/show_space_ok.golden.json
@@ -19,7 +19,6 @@
       "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
       "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
       "workitemlinktypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemlinktypes",
-      "workitemtypegroups": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/",
       "workitemtypes": "http:///api/spaces/00000000-0000-0000-0000-000000000002/workitemtypes"
     },
     "relationships": {
@@ -82,7 +81,7 @@
       },
       "workitemtypegroups": {
         "links": {
-          "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/"
+          "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups"
         }
       },
       "workitemtypes": {


### PR DESCRIPTION
And remove an obsolete and unused links entry for WIT groups.

Previously the link to list all work item type groups used to be

```
http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups/
```

Now it is

```
http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups
```

NOTICE: the missing trailing `/`. 