### PR TITLE
WIP Fix errors reported by gometalinter

### DIFF
--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -217,7 +217,7 @@ func convertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		if !componentType.IsSimpleType() {
 			return nil, fmt.Errorf("Component type is not list type: %T", componentType)
 		}
-		return workitem.ListType{workitem.SimpleType{*kind}, workitem.SimpleType{*componentType}}, nil
+		return workitem.ListType{SimpleType: workitem.SimpleType{Kind: *kind}, ComponentType: workitem.SimpleType{Kind: *componentType}}, nil
 	case workitem.KindEnum:
 		bt, err := workitem.ConvertAnyToKind(*t.BaseType)
 		if err != nil {
@@ -226,7 +226,7 @@ func convertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		if !bt.IsSimpleType() {
 			return nil, fmt.Errorf("baseType type is not list type: %T", bt)
 		}
-		baseType := workitem.SimpleType{*bt}
+		baseType := workitem.SimpleType{Kind: *bt}
 
 		values := t.Values
 		converted, err := workitem.ConvertList(func(ft workitem.FieldType, element interface{}) (interface{}, error) {
@@ -235,12 +235,13 @@ func convertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		if err != nil {
 			return nil, errs.WithStack(err)
 		}
-		return workitem.EnumType{workitem.SimpleType{*kind}, baseType, converted}, nil
+		return workitem.EnumType{SimpleType: workitem.SimpleType{Kind: *kind}, BaseType: baseType, Values: converted}, nil
 	default:
-		return workitem.SimpleType{*kind}, nil
+		return workitem.SimpleType{Kind: *kind}, nil
 	}
 }
 
+// ConvertFieldDefinitionsToModel TODO: document me
 func ConvertFieldDefinitionsToModel(fields map[string]app.FieldDefinition) (map[string]workitem.FieldDefinition, error) {
 	modelFields := map[string]workitem.FieldDefinition{}
 	// now process new fields, checking whether they are ok to add.

--- a/controller/workitemtype_whitebox_test.go
+++ b/controller/workitemtype_whitebox_test.go
@@ -121,8 +121,8 @@ func TestConvertFieldTypes(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	types := []workitem.FieldType{
 		workitem.SimpleType{Kind: workitem.KindInteger},
-		workitem.ListType{workitem.SimpleType{Kind: workitem.KindList}, workitem.SimpleType{Kind: workitem.KindString}},
-		workitem.EnumType{workitem.SimpleType{Kind: workitem.KindEnum}, workitem.SimpleType{Kind: workitem.KindString}, []interface{}{"foo", "bar"}},
+		workitem.ListType{SimpleType: workitem.SimpleType{Kind: workitem.KindList}, ComponentType: workitem.SimpleType{Kind: workitem.KindString}},
+		workitem.EnumType{SimpleType: workitem.SimpleType{Kind: workitem.KindEnum}, BaseType: workitem.SimpleType{Kind: workitem.KindString}, Values: []interface{}{"foo", "bar"}},
 	}
 
 	for _, theType := range types {


### PR DESCRIPTION
These errors have been fixed:

```
$ gometalinter ./... --skip=client --skip=app --skip=tool --errors

controller/workitemtype.go:220::error: github.com/fabric8-services/fabric8-wit/workitem.ListType composite literal uses unkeyed fields (vet)
controller/workitemtype.go:220::error: github.com/fabric8-services/fabric8-wit/workitem.SimpleType composite literal uses unkeyed fields (vet)
controller/workitemtype.go:220::error: github.com/fabric8-services/fabric8-wit/workitem.SimpleType composite literal uses unkeyed fields (vet)
controller/workitemtype.go:229::error: github.com/fabric8-services/fabric8-wit/workitem.SimpleType composite literal uses unkeyed fields (vet)
controller/workitemtype.go:238::error: github.com/fabric8-services/fabric8-wit/workitem.EnumType composite literal uses unkeyed fields (vet)
controller/workitemtype.go:238::error: github.com/fabric8-services/fabric8-wit/workitem.SimpleType composite literal uses unkeyed fields (vet)
controller/workitemtype.go:240::error: github.com/fabric8-services/fabric8-wit/workitem.SimpleType composite literal uses unkeyed fields (vet)
controller/workitemtype_whitebox_test.go:124::error: github.com/fabric8-services/fabric8-wit/workitem.ListType composite literal uses unkeyed fields (vet)
controller/workitemtype_whitebox_test.go:125::error: github.com/fabric8-services/fabric8-wit/workitem.EnumType composite literal uses unkeyed fields (vet)
```