### PR TITLE
Use transaction when creating a link

### DIFF
--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -233,8 +233,10 @@ func (c *WorkItemLinkController) Create(ctx *app.CreateWorkItemLinkContext) erro
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, c.db, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
-	return createWorkItemLink(linkCtx, ctx, ctx.Payload)
+	return application.Transactional(c.db, func(appl application.Application) error {
+		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
+		return createWorkItemLink(linkCtx, ctx, ctx.Payload)
+	})
 }
 
 func (c *WorkItemLinkController) checkIfUserIsSpaceCollaboratorOrWorkItemCreator(ctx context.Context, linkID uuid.UUID, currentIdentityID uuid.UUID) (bool, error) {


### PR DESCRIPTION
We didn't use a transaction to wrap the link creation before. This is required.