### PR TITLE
Link updates

### DIFF
--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -169,14 +169,6 @@ func (s *workItemChildSuite) linkWorkItems(source, target *app.WorkItemSingle) a
 	return *workitemLink
 }
 
-func (s *workItemChildSuite) updateWorkItemLink(workitemLinkID uuid.UUID, source, target *app.WorkItemSingle) app.WorkItemLinkSingle {
-	updatePayload := newUpdateWorkItemLinkPayload(workitemLinkID, *source.Data.ID, *target.Data.ID, s.bugBlockerLinkTypeID)
-	log.Info(nil, nil, fmt.Sprintf("Updating work item link from %v to %v", *source.Data.ID, *target.Data.ID))
-	_, workitemLink := test.UpdateWorkItemLinkOK(s.T(), s.svc.Context, s.svc, s.workitemLinkCtrl, workitemLinkID, updatePayload)
-	require.NotNil(s.T(), workitemLink)
-	return *workitemLink
-}
-
 //-----------------------------------------------------------------------------
 // helper method
 //-----------------------------------------------------------------------------

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -338,55 +338,6 @@ func (c *WorkItemLinkController) Show(ctx *app.ShowWorkItemLinkContext) error {
 	})
 }
 
-type updateWorkItemLinkFuncs interface {
-	OK(r *app.WorkItemLinkSingle) error
-	NotFound(r *app.JSONAPIErrors) error
-	BadRequest(r *app.JSONAPIErrors) error
-	InternalServerError(r *app.JSONAPIErrors) error
-	Unauthorized(r *app.JSONAPIErrors) error
-}
-
-func updateWorkItemLink(ctx *workItemLinkContext, httpFuncs updateWorkItemLinkFuncs, payload *app.UpdateWorkItemLinkPayload) error {
-	toSave := app.WorkItemLinkSingle{
-		Data: payload.Data,
-	}
-	modelLink, err := ConvertLinkToModel(toSave)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(httpFuncs, err)
-	}
-	savedModelLink, err := ctx.Application.WorkItemLinks().Save(ctx.Context, *modelLink, *ctx.CurrentUserIdentityID)
-	if err != nil {
-		jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(ctx.Context, err)
-		return ctx.Service.Send(ctx.Context, httpStatusCode, jerrors)
-	}
-	// Convert the created link type entry into a rest representation
-	savedAppLink := ConvertLinkFromModel(ctx.Request, *savedModelLink)
-
-	if err := enrichLinkSingle(ctx.Context, ctx.Application, ctx.Request, &savedAppLink); err != nil {
-		return jsonapi.JSONErrorResponse(httpFuncs, err)
-	}
-	return httpFuncs.OK(&savedAppLink)
-}
-
-// Update runs the update action.
-func (c *WorkItemLinkController) Update(ctx *app.UpdateWorkItemLinkContext) error {
-	currentUserIdentityID, err := login.ContextIdentity(ctx)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
-	}
-	authorized, err := c.checkIfUserIsSpaceCollaboratorOrWorkItemCreator(ctx, ctx.LinkID, *currentUserIdentityID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, err)
-	}
-	if !authorized {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError("user is not authorized to delete the link"))
-	}
-	return application.Transactional(c.db, func(appl application.Application) error {
-		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
-		return updateWorkItemLink(linkCtx, ctx, ctx.Payload)
-	})
-}
-
 // ConvertLinkFromModel converts a work item from model to REST representation
 func ConvertLinkFromModel(request *http.Request, t link.WorkItemLink) app.WorkItemLinkSingle {
 	linkSelfURL := rest.AbsoluteURL(request, app.WorkItemLinkHref(t.ID.String()))

--- a/controller/work_item_relationships_links.go
+++ b/controller/work_item_relationships_links.go
@@ -1,17 +1,10 @@
 package controller
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
-	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
-	"github.com/fabric8-services/fabric8-wit/login"
-	"github.com/fabric8-services/fabric8-wit/workitem/link"
 	"github.com/goadesign/goa"
-	uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemRelationshipsLinksController implements the work-item-relationships-links resource.
@@ -33,54 +26,6 @@ func NewWorkItemRelationshipsLinksController(service *goa.Service, db applicatio
 		db:         db,
 		config:     config,
 	}
-}
-
-func parseWorkItemIDToUint64(wiIDStr string) (uint64, error) {
-	wiID, err := strconv.ParseUint(wiIDStr, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("Invalid work item ID \"%s\": %s", wiIDStr, err.Error())
-	}
-	return wiID, nil
-}
-
-// Create runs the create action.
-func (c *WorkItemRelationshipsLinksController) Create(ctx *app.CreateWorkItemRelationshipsLinksContext) error {
-	currentUserIdentityID, err := login.ContextIdentity(ctx)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
-	}
-	return application.Transactional(c.db, func(appl application.Application) error {
-		// Check that current work item does indeed exist
-		wi, err := appl.WorkItems().LoadByID(ctx, ctx.WiID)
-		if err != nil {
-			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(ctx, err)
-			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
-		}
-		// Check that the source ID of the link is the same as the current work
-		// item ID.
-		src, _ := getSrcTgt(ctx.Payload.Data)
-		if src != nil && *src != wi.ID {
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(ctx, goa.ErrBadRequest(fmt.Sprintf("data.relationships.source.data.id is \"%s\" but must be \"%s\"", ctx.Payload.Data.Relationships.Source.Data.ID.String(), wi.ID.String())))
-			return ctx.BadRequest(jerrors)
-		}
-		// If no source is specified we pre-fill the source field of the payload
-		// with the current work item ID from the URL. This is for convenience.
-		if src == nil {
-			if ctx.Payload.Data.Relationships == nil {
-				ctx.Payload.Data.Relationships = &app.WorkItemLinkRelationships{}
-			}
-			if ctx.Payload.Data.Relationships.Source == nil {
-				ctx.Payload.Data.Relationships.Source = &app.RelationWorkItem{}
-			}
-			if ctx.Payload.Data.Relationships.Source.Data == nil {
-				ctx.Payload.Data.Relationships.Source.Data = &app.RelationWorkItemData{}
-			}
-			ctx.Payload.Data.Relationships.Source.Data.ID = wi.ID
-			ctx.Payload.Data.Relationships.Source.Data.Type = link.EndpointWorkItems
-		}
-		linkCtx := newWorkItemLinkContext(ctx.Context, ctx.Service, appl, c.db, ctx.Request, ctx.ResponseWriter, app.WorkItemLinkHref, currentUserIdentityID)
-		return createWorkItemLink(linkCtx, ctx, ctx.Payload)
-	})
 }
 
 // List runs the list action.
@@ -108,17 +53,4 @@ func (c *WorkItemRelationshipsLinksController) List(ctx *app.ListWorkItemRelatio
 			return ctx.OK(&appLinks)
 		})
 	})
-}
-
-func getSrcTgt(wilData *app.WorkItemLinkData) (*uuid.UUID, *uuid.UUID) {
-	var src, tgt *uuid.UUID
-	if wilData != nil && wilData.Relationships != nil {
-		if wilData.Relationships.Source != nil && wilData.Relationships.Source.Data != nil {
-			src = &wilData.Relationships.Source.Data.ID
-		}
-		if wilData.Relationships.Target != nil && wilData.Relationships.Target.Data != nil {
-			tgt = &wilData.Relationships.Target.Data.ID
-		}
-	}
-	return src, tgt
 }

--- a/design/work_item_link.go
+++ b/design/work_item_link.go
@@ -125,107 +125,72 @@ var workItemLinkList = JSONList(
 
 var _ = a.Resource("work_item_link", func() {
 	a.BasePath("/workitemlinks")
-	a.Action("show", showWorkItemLink)
-	a.Action("create", createWorkItemLink)
-	a.Action("delete", deleteWorkItemLink)
-	a.Action("update", updateWorkItemLink)
+	a.Action("show", func() {
+		a.Description("Retrieve work item link (as JSONAPI) for the given link ID.")
+		a.Routing(
+			a.GET("/:linkId"),
+		)
+		a.Params(func() {
+			a.Param("linkId", d.UUID, "ID of the work item link to show")
+		})
+		a.UseTrait("conditional")
+		a.Response(d.OK, workItemLink)
+		a.Response(d.NotModified)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+	a.Action("create", func() {
+		a.Description("Create a work item link")
+		a.Security("jwt")
+		a.Routing(
+			a.POST(""),
+		)
+		a.Payload(createWorkItemLinkPayload)
+		a.Response(d.Created, "/workitemlinks/.*", func() {
+			a.Media(workItemLink)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
+	})
+	a.Action("delete", func() {
+		a.Description("Delete work item link with given id.")
+		a.Security("jwt")
+		a.Routing(
+			a.DELETE("/:linkId"),
+		)
+		a.Params(func() {
+			a.Param("linkId", d.UUID, "ID of the work item link to be deleted")
+		})
+		a.Response(d.OK)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
+	})
 })
 
 var _ = a.Resource("work_item_relationships_links", func() {
 	a.BasePath("/relationships/links")
 	a.Parent("workitem")
 	a.Action("list", func() {
-		listWorkItemLinks()
+		a.Description("Retrieve work item link (as JSONAPI) for the given link ID.")
+		a.Routing(
+			a.GET(""),
+		)
+		a.UseTrait("conditional")
+		a.Response(d.OK, workItemLinkList)
+		a.Response(d.NotModified)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Description("List work item links associated with the given work item (either as source or as target work item).")
 		a.Response(d.NotFound, JSONAPIErrors, func() {
 			a.Description("This error arises when the given work item does not exist.")
 		})
 	})
-	a.Action("create", createWorkItemLink)
 })
-
-// listWorkItemLinks defines the list action for endpoints that return an array
-// of work item links.
-func listWorkItemLinks() {
-	a.Description("Retrieve work item link (as JSONAPI) for the given link ID.")
-	a.Routing(
-		a.GET(""),
-	)
-	a.UseTrait("conditional")
-	a.Response(d.OK, workItemLinkList)
-	a.Response(d.NotModified)
-	a.Response(d.BadRequest, JSONAPIErrors)
-	a.Response(d.InternalServerError, JSONAPIErrors)
-}
-
-func showWorkItemLink() {
-	a.Description("Retrieve work item link (as JSONAPI) for the given link ID.")
-	a.Routing(
-		a.GET("/:linkId"),
-	)
-	a.Params(func() {
-		a.Param("linkId", d.UUID, "ID of the work item link to show")
-	})
-	a.UseTrait("conditional")
-	a.Response(d.OK, workItemLink)
-	a.Response(d.NotModified)
-	a.Response(d.BadRequest, JSONAPIErrors)
-	a.Response(d.InternalServerError, JSONAPIErrors)
-	a.Response(d.NotFound, JSONAPIErrors)
-}
-
-func createWorkItemLink() {
-	a.Description("Create a work item link")
-	a.Security("jwt")
-	a.Routing(
-		a.POST(""),
-	)
-	a.Payload(createWorkItemLinkPayload)
-	a.Response(d.Created, "/workitemlinks/.*", func() {
-		a.Media(workItemLink)
-	})
-	a.Response(d.BadRequest, JSONAPIErrors)
-	a.Response(d.InternalServerError, JSONAPIErrors)
-	a.Response(d.Unauthorized, JSONAPIErrors)
-	a.Response(d.NotFound, JSONAPIErrors)
-	a.Response(d.Conflict, JSONAPIErrors)
-	a.Response(d.Forbidden, JSONAPIErrors)
-}
-
-func deleteWorkItemLink() {
-	a.Description("Delete work item link with given id.")
-	a.Security("jwt")
-	a.Routing(
-		a.DELETE("/:linkId"),
-	)
-	a.Params(func() {
-		a.Param("linkId", d.UUID, "ID of the work item link to be deleted")
-	})
-	a.Response(d.OK)
-	a.Response(d.BadRequest, JSONAPIErrors)
-	a.Response(d.InternalServerError, JSONAPIErrors)
-	a.Response(d.NotFound, JSONAPIErrors)
-	a.Response(d.Unauthorized, JSONAPIErrors)
-	a.Response(d.Forbidden, JSONAPIErrors)
-}
-
-func updateWorkItemLink() {
-	a.Description("Update the given work item link with given id.")
-	a.Security("jwt")
-	a.Routing(
-		a.PATCH("/:linkId"),
-	)
-	a.Params(func() {
-		a.Param("linkId", d.UUID, "ID of the work item link to be updated")
-	})
-	a.Payload(updateWorkItemLinkPayload)
-	a.Response(d.OK, func() {
-		a.Media(workItemLink)
-	})
-	a.Response(d.BadRequest, JSONAPIErrors)
-	a.Response(d.Conflict, JSONAPIErrors)
-	a.Response(d.InternalServerError, JSONAPIErrors)
-	a.Response(d.NotFound, JSONAPIErrors)
-	a.Response(d.Unauthorized, JSONAPIErrors)
-	a.Response(d.Forbidden, JSONAPIErrors)
-}

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -189,14 +189,6 @@ func (s *linkRepoBlackBoxTest) TestCreate() {
 	})
 }
 
-func (s *linkRepoBlackBoxTest) TestSave() {
-	s.T().Run("ok", func(t *testing.T) {
-		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1))
-		_, err := s.workitemLinkRepo.Save(s.Ctx, *fxt.WorkItemLinks[0], fxt.Identities[0].ID)
-		require.NoError(t, err)
-	})
-}
-
 func (s *linkRepoBlackBoxTest) TestExistsLink() {
 	s.T().Run("link exists", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1))

--- a/workitem/link/link_revision.go
+++ b/workitem/link/link_revision.go
@@ -17,7 +17,9 @@ const (
 	RevisionTypeDelete // 2
 	_                  // ignore 3rd value
 	// RevisionTypeUpdate a work item link update
+	// TODO(kwk): can we remove this "update" revsion type? We no longer support updating a link.
 	RevisionTypeUpdate // 4
+
 )
 
 // Revision represents a version of a work item link

--- a/workitem/link/link_revision_repository_blackbox_test.go
+++ b/workitem/link/link_revision_repository_blackbox_test.go
@@ -25,48 +25,6 @@ type revisionRepositoryBlackBoxTest struct {
 func (s *revisionRepositoryBlackBoxTest) TestList() {
 	revRepo := link.NewRevisionRepository(s.DB)
 
-	s.T().Run("ok - store work item link revisions", func(t *testing.T) {
-		// given a work item link
-		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1), tf.WorkItemLinkTypes(2), tf.Identities(3))
-		linkRepository := link.NewWorkItemLinkRepository(s.DB)
-		// modify the work item link (change the link type)
-		fxt.WorkItemLinks[0].LinkTypeID = fxt.WorkItemLinkTypes[1].ID
-		_, err := linkRepository.Save(s.Ctx, *fxt.WorkItemLinks[0], fxt.Identities[1].ID)
-		require.NoError(t, err)
-		// delete the work item link
-		err = linkRepository.Delete(s.Ctx, fxt.WorkItemLinks[0].ID, fxt.Identities[2].ID)
-		require.NoError(t, err)
-		// when
-		workitemLinkRevisions, err := revRepo.List(s.Ctx, fxt.WorkItemLinks[0].ID)
-		// then
-		require.NoError(t, err)
-		require.Len(t, workitemLinkRevisions, 3)
-		// revision 1
-		revision1 := workitemLinkRevisions[0]
-		assert.Equal(t, fxt.WorkItemLinks[0].ID, revision1.WorkItemLinkID)
-		assert.Equal(t, link.RevisionTypeCreate, revision1.Type)
-		assert.Equal(t, fxt.Identities[0].ID, revision1.ModifierIdentity)
-		assert.Equal(t, fxt.WorkItemLinks[0].SourceID, revision1.WorkItemLinkSourceID)
-		assert.Equal(t, fxt.WorkItemLinks[0].TargetID, revision1.WorkItemLinkTargetID)
-		assert.Equal(t, fxt.WorkItemLinkTypes[0].ID, revision1.WorkItemLinkTypeID)
-		// revision 2
-		revision2 := workitemLinkRevisions[1]
-		assert.Equal(t, fxt.WorkItemLinks[0].ID, revision2.WorkItemLinkID)
-		assert.Equal(t, link.RevisionTypeUpdate, revision2.Type)
-		assert.Equal(t, fxt.Identities[1].ID, revision2.ModifierIdentity)
-		assert.Equal(t, fxt.WorkItemLinks[0].SourceID, revision2.WorkItemLinkSourceID)
-		assert.Equal(t, fxt.WorkItemLinks[0].TargetID, revision2.WorkItemLinkTargetID)
-		assert.Equal(t, fxt.WorkItemLinkTypes[1].ID, revision2.WorkItemLinkTypeID)
-		// revision 3
-		revision3 := workitemLinkRevisions[2]
-		assert.Equal(t, fxt.WorkItemLinks[0].ID, revision3.WorkItemLinkID)
-		assert.Equal(t, link.RevisionTypeDelete, revision3.Type)
-		assert.Equal(t, fxt.Identities[2].ID, revision3.ModifierIdentity)
-		assert.Equal(t, fxt.WorkItemLinks[0].SourceID, revision3.WorkItemLinkSourceID)
-		assert.Equal(t, fxt.WorkItemLinks[0].TargetID, revision3.WorkItemLinkTargetID)
-		assert.Equal(t, fxt.WorkItemLinkTypes[1].ID, revision3.WorkItemLinkTypeID)
-	})
-
 	s.T().Run("ok - when deleting work item link", func(t *testing.T) {
 		// given a work item link
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1), tf.Identities(3))


### PR DESCRIPTION
Removes **Update**/**Save** method of work item link repository and all controllers.

The only permitted actions to a link once created are:
 * **delete**
 * **show**
 * **list**

In order to mimic the **update** behavior you have to **delete and recreate** a link with different settings (e.g. with a different link type). This is needed in order for us to maintain a valid *topology*.

Also the `Create` method has been removed from the `/api/workitems/<ID>/relationships/links` endpoint. Only the `List` method remains for this endpoint.