### PR TITLE
introduce "ptr" package for on-the-fly pointer values

### DIFF
--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/login"
+	"github.com/fabric8-services/fabric8-wit/ptr"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/space"
 
@@ -357,15 +358,10 @@ func ConvertCodebases(request *http.Request, codebases []codebase.Codebase, opti
 
 // ConvertCodebase converts between internal and external REST representation
 func ConvertCodebase(request *http.Request, codebase codebase.Codebase, options ...CodebaseConvertFunc) *app.Codebase {
-	codebaseType := APIStringTypeCodebase
-	spaceType := APIStringTypeSpace
-	spaceID := codebase.SpaceID.String()
 	relatedURL := rest.AbsoluteURL(request, app.CodebaseHref(codebase.ID))
-	editURL := rest.AbsoluteURL(request, app.CodebaseHref(codebase.ID)+"/edit")
-	spaceRelatedURL := rest.AbsoluteURL(request, app.SpaceHref(spaceID))
-
+	spaceRelatedURL := rest.AbsoluteURL(request, app.SpaceHref(codebase.SpaceID))
 	result := &app.Codebase{
-		Type: codebaseType,
+		Type: APIStringTypeCodebase,
 		ID:   &codebase.ID,
 		Attributes: &app.CodebaseAttributes{
 			CreatedAt:         &codebase.CreatedAt,
@@ -377,8 +373,8 @@ func ConvertCodebase(request *http.Request, codebase codebase.Codebase, options 
 		Relationships: &app.CodebaseRelations{
 			Space: &app.RelationGeneric{
 				Data: &app.GenericData{
-					Type: &spaceType,
-					ID:   &spaceID,
+					Type: ptr.String(APIStringTypeSpace),
+					ID:   ptr.String(codebase.SpaceID.String()),
 				},
 				Links: &app.GenericLinks{
 					Self:    &spaceRelatedURL,
@@ -389,7 +385,7 @@ func ConvertCodebase(request *http.Request, codebase codebase.Codebase, options 
 		Links: &app.CodebaseLinks{
 			Self:    &relatedURL,
 			Related: &relatedURL,
-			Edit:    &editURL,
+			Edit:    ptr.String(rest.AbsoluteURL(request, app.CodebaseHref(codebase.ID)+"/edit")),
 		},
 	}
 	for _, option := range options {

--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	"github.com/fabric8-services/fabric8-wit/codebase/che"
 	"github.com/fabric8-services/fabric8-wit/configuration"
+	"github.com/fabric8-services/fabric8-wit/ptr"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	. "github.com/fabric8-services/fabric8-wit/controller"
@@ -92,15 +93,13 @@ func NewMockCheClient(r http.RoundTripper, config *configuration.Registry) Codeb
 func MockShowTenant() func(context.Context) (*tenant.TenantSingle, error) {
 	return func(context.Context) (*tenant.TenantSingle, error) {
 		// return a predefined response for the Tenant
-		tenantType := "che"
-		tenantNamespace := "foo"
 		return &tenant.TenantSingle{
 				Data: &tenant.Tenant{
 					Attributes: &tenant.TenantAttributes{
 						Namespaces: []*tenant.NamespaceAttributes{
 							{
-								Type: &tenantType,
-								Name: &tenantNamespace,
+								Type: ptr.String("che"),
+								Name: ptr.String("foo"),
 							},
 						},
 					},
@@ -128,8 +127,7 @@ func (s *CodebaseControllerTestSuite) TestShowCodebase() {
 	s.T().Run("success with stackId", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.Codebases(1, func(fxt *tf.TestFixture, idx int) error {
-			stackID := "golang-default"
-			fxt.Codebases[idx].StackID = &stackID
+			fxt.Codebases[idx].StackID = ptr.String("golang-default")
 			return nil
 		}))
 		svc, ctrl := s.UnsecuredController()

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
+	"github.com/fabric8-services/fabric8-wit/ptr"
 	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
@@ -566,14 +567,12 @@ func CreateSecuredSpace(t *testing.T, db application.DB, config SpaceConfigurati
 	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", owner, &TestSpaceAuthzService{owner: owner, userIDs: userIDs})
 	spaceCtrl := NewSpaceController(svc, db, config, &DummyResourceManager{})
 	require.NotNil(t, spaceCtrl)
-	name := "TestCollaborators-space-" + uuid.NewV4().String()
-	description := "description"
 	spacePayload := &app.CreateSpacePayload{
 		Data: &app.Space{
 			Type: "spaces",
 			Attributes: &app.SpaceAttributes{
-				Name:        &name,
-				Description: &description,
+				Name:        ptr.String("TestCollaborators-space-" + uuid.NewV4().String()),
+				Description: ptr.String("description"),
 			},
 		},
 	}

--- a/controller/space_areas_blackbox_test.go
+++ b/controller/space_areas_blackbox_test.go
@@ -90,8 +90,7 @@ func (rest *TestSpaceAreaREST) setupAreas() (area.Area, []uuid.UUID, []area.Area
 	createdAreas = append(createdAreas, parentArea)
 	createdAreaUuids = append(createdAreaUuids, parentArea.ID)
 	parentID := parentArea.ID
-	name := "TestListAreas  A"
-	ci := newCreateChildAreaPayload(&name)
+	ci := newCreateChildAreaPayload("TestListAreas  A")
 	owner, err := rest.db.Identities().Load(context.Background(), sp.OwnerID)
 	require.NoError(rest.T(), err)
 	svc, ctrl := rest.SecuredAreasControllerWithIdentity(owner)
@@ -102,8 +101,7 @@ func (rest *TestSpaceAreaREST) setupAreas() (area.Area, []uuid.UUID, []area.Area
 	createdAreas = append(createdAreas, convertAreaToModel(*created))
 
 	// Create a child of the child created above.
-	name = "TestListAreas B"
-	ci = newCreateChildAreaPayload(&name)
+	ci = newCreateChildAreaPayload("TestListAreas B")
 	newParentID := *created.Data.Relationships.Parent.Data.ID
 	_, created = test.CreateChildAreaCreated(rest.T(), svc.Context, svc, ctrl, newParentID, ci)
 	assert.Equal(rest.T(), *ci.Data.Attributes.Name, *created.Data.Attributes.Name)

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/fabric8-services/fabric8-wit/ptr"
+
 	"context"
 
 	"github.com/fabric8-services/fabric8-wit/app"
@@ -406,12 +408,11 @@ func ConvertJSONAPIToWorkItem(ctx context.Context, method string, appl applicati
 // for future use
 func setupCodebase(appl application.Application, cb *codebase.Content, spaceID uuid.UUID) error {
 	if cb.CodebaseID == "" {
-		defaultStackID := "java-centos"
 		newCodeBase := codebase.Codebase{
 			SpaceID: spaceID,
 			Type:    "git",
 			URL:     cb.Repository,
-			StackID: &defaultStackID,
+			StackID: ptr.String("java-centos"),
 			//TODO: Think of making stackID dynamic value (from analyzer)
 		}
 		existingCB, err := appl.Codebases().LoadByRepo(context.Background(), spaceID, cb.Repository)
@@ -458,8 +459,6 @@ func ConvertWorkItems(request *http.Request, wis []workitem.WorkItem, additional
 func ConvertWorkItem(request *http.Request, wi workitem.WorkItem, additional ...WorkItemConvertFunc) *app.WorkItem {
 	// construct default values from input WI
 	relatedURL := rest.AbsoluteURL(request, app.WorkitemHref(wi.ID))
-	spaceRelatedURL := rest.AbsoluteURL(request, app.SpaceHref(wi.SpaceID.String()))
-	witRelatedURL := rest.AbsoluteURL(request, app.WorkitemtypeHref(wi.SpaceID.String(), wi.Type))
 	labelsRelated := relatedURL + "/labels"
 	workItemLinksRelated := relatedURL + "/links"
 
@@ -477,10 +476,10 @@ func ConvertWorkItem(request *http.Request, wi workitem.WorkItem, additional ...
 					Type: APIStringTypeWorkItemType,
 				},
 				Links: &app.GenericLinks{
-					Self: &witRelatedURL,
+					Self: ptr.String(rest.AbsoluteURL(request, app.WorkitemtypeHref(wi.SpaceID.String(), wi.Type))),
 				},
 			},
-			Space: app.NewSpaceRelation(wi.SpaceID, spaceRelatedURL),
+			Space: app.NewSpaceRelation(wi.SpaceID, rest.AbsoluteURL(request, app.SpaceHref(wi.SpaceID.String()))),
 			WorkItemLinks: &app.RelationGeneric{
 				Links: &app.GenericLinks{
 					Related: &workItemLinksRelated,

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -10,13 +10,13 @@ import (
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/login"
+	"github.com/fabric8-services/fabric8-wit/ptr"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/space"
 	"github.com/fabric8-services/fabric8-wit/workitem"
-	"github.com/satori/go.uuid"
-
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -157,15 +157,12 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 // ConvertWorkItemTypeFromModel converts from models to app representation
 func ConvertWorkItemTypeFromModel(request *http.Request, t *workitem.WorkItemType) app.WorkItemTypeData {
 	spaceSelfURL := rest.AbsoluteURL(request, app.SpaceHref(t.SpaceID.String()))
-	id := t.ID
-	createdAt := t.CreatedAt.UTC()
-	updatedAt := t.UpdatedAt.UTC()
 	var converted = app.WorkItemTypeData{
 		Type: "workitemtypes",
-		ID:   &id,
+		ID:   ptr.UUID(t.ID),
 		Attributes: &app.WorkItemTypeAttributes{
-			CreatedAt:   &createdAt,
-			UpdatedAt:   &updatedAt,
+			CreatedAt:   ptr.Time(t.CreatedAt.UTC()),
+			UpdatedAt:   ptr.Time(t.UpdatedAt.UTC()),
 			Version:     &t.Version,
 			Description: t.Description,
 			Icon:        t.Icon,
@@ -186,15 +183,14 @@ func ConvertWorkItemTypeFromModel(request *http.Request, t *workitem.WorkItemTyp
 		}
 	}
 	// TODO(kwk): Replaces this temporary static hack with a more dynamic solution
-	strPtr := func(s string) *string { return &s }
 	getGuidedChildTypes := func(witIDs ...uuid.UUID) *app.RelationGenericList {
 		res := &app.RelationGenericList{
 			Data: make([]*app.GenericData, len(witIDs)),
 		}
 		for i, id := range witIDs {
 			res.Data[i] = &app.GenericData{
-				ID:   strPtr(id.String()),
-				Type: strPtr(APIWorkItemTypes),
+				ID:   ptr.String(id.String()),
+				Type: ptr.String(APIWorkItemTypes),
 				// Links: &app.GenericLinks{
 				// 	Related: strPtr(rest.AbsoluteURL(request, app.WorkitemtypeHref(t.SpaceID, id.String()))),
 				// },
@@ -221,11 +217,9 @@ func convertFieldTypeFromModel(t workitem.FieldType) app.FieldType {
 	result.Kind = string(t.GetKind())
 	switch t2 := t.(type) {
 	case workitem.ListType:
-		kind := string(t2.ComponentType.GetKind())
-		result.ComponentType = &kind
+		result.ComponentType = ptr.String(string(t2.ComponentType.GetKind()))
 	case workitem.EnumType:
-		kind := string(t2.BaseType.GetKind())
-		result.BaseType = &kind
+		result.BaseType = ptr.String(string(t2.BaseType.GetKind()))
 		result.Values = t2.Values
 	}
 

--- a/ptr/doc.go
+++ b/ptr/doc.go
@@ -1,0 +1,7 @@
+// Package ptr provides functions to create on the fly pointer values for some
+// built-in types. This might seem stupid but in our codebase we have a lot of
+// places in which we just need to create variable just to get the pointer to
+// it. That clutters the code a lot and causes distraction. Most of the time
+// those strings are just throw-away constants and the pointer "is not really
+// important later".
+package ptr

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -1,0 +1,61 @@
+package ptr
+
+import (
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+// Interface returns the pointer to the given interface.
+func Interface(o interface{}) *interface{} { return &o }
+
+// String returns the pointer to the given string.
+func String(o string) *string { return &o }
+
+// Time returns the pointer to the given time.Time.
+func Time(o time.Time) *time.Time { return &o }
+
+// UUID returns the pointer to the given uuid.UUID.
+func UUID(o uuid.UUID) *uuid.UUID { return &o }
+
+// ints ...
+
+// Int returns the pointer to the given int.
+func Int(o int) *int { return &o }
+
+// Int8 returns the pointer to the given int8.
+func Int8(o int8) *int8 { return &o }
+
+// Int16 returns the pointer to the given int16.
+func Int16(o int16) *int16 { return &o }
+
+// Int32 returns the pointer to the given int32.
+func Int32(o int32) *int32 { return &o }
+
+// Int64 returns the pointer to the given int64.
+func Int64(o int64) *int64 { return &o }
+
+// uints ...
+
+// Uint returns the pointer to the given uint.
+func Uint(o uint) *uint { return &o }
+
+// Uint8 returns the pointer to the given uint8.
+func Uint8(o uint8) *uint8 { return &o }
+
+// Uint16 returns the pointer to the given uint16.
+func Uint16(o uint16) *uint16 { return &o }
+
+// Uint32 returns the pointer to the given uint32.
+func Uint32(o uint32) *uint32 { return &o }
+
+// Uint64 returns the pointer to the given uint64.
+func Uint64(o uint64) *uint64 { return &o }
+
+// floats ...
+
+// Float32 returns the pointer to the given float32.
+func Float32(o float32) *float32 { return &o }
+
+// Float64 returns the pointer to the given float32.
+func Float64(o float64) *float64 { return &o }


### PR DESCRIPTION
Package `ptr` provides functions to create on the fly pointer values for some built-in types. This might seem stupid at first but in our codebase we have a lot of places in which we just need to create variable just to get the pointer. That clutters the code a lot and causes distraction. Most of the time those strings are just throw-away constants and the pointer "is not really important later".

I've also changed the function `newCreateChildAreaPayload` to accept a `string` rather than a `*string` because in 99% of the time the string is not nil. 
  