### PR TITLE
repository.CheckExists now accepts a uuid.UUID instead of a string

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -142,7 +142,7 @@ func (m *GormIdentityRepository) Load(ctx context.Context, id uuid.UUID) (*Ident
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormIdentityRepository) CheckExists(ctx context.Context, id string) error {
+func (m *GormIdentityRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "identity", "exists"}, time.Now())
 	return repository.CheckExists(ctx, m.db, m.TableName(), id)
 }
@@ -341,7 +341,7 @@ func (m *GormIdentityRepository) List(ctx context.Context) ([]Identity, error) {
 
 // IsValid returns true if the identity exists
 func (m *GormIdentityRepository) IsValid(ctx context.Context, id uuid.UUID) bool {
-	return m.CheckExists(ctx, id.String()) == nil
+	return m.CheckExists(ctx, id) == nil
 }
 
 // Search searches for Identites where FullName like %q% or users.email like %q% or users.username like %q%

--- a/account/identity_blackbox_test.go
+++ b/account/identity_blackbox_test.go
@@ -67,14 +67,14 @@ func (s *identityBlackBoxTest) TestExistsIdentity() {
 		// given
 		identity := createAndLoad(s)
 		// when
-		err := s.repo.CheckExists(s.Ctx, identity.ID.String())
+		err := s.repo.CheckExists(s.Ctx, identity.ID)
 		// then
 		require.NoError(t, err, "Could not check if identity exists")
 	})
 
 	t.Run("identity doesn't exist", func(t *testing.T) {
 		//t.Parallel()
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.NewV4())
 		// then
 
 		require.IsType(t, errors.NotFoundError{}, err)

--- a/account/user.go
+++ b/account/user.go
@@ -93,7 +93,7 @@ func (m *GormUserRepository) Load(ctx context.Context, id uuid.UUID) (*User, err
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormUserRepository) CheckExists(ctx context.Context, id string) error {
+func (m *GormUserRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "user", "exists"}, time.Now())
 	return repository.CheckExists(ctx, m.db, m.TableName(), id)
 }

--- a/account/user_blackbox_test.go
+++ b/account/user_blackbox_test.go
@@ -66,7 +66,7 @@ func (s *userBlackBoxTest) TestExistsUser() {
 		//t.Parallel()
 		user := createAndLoadUser(s)
 		// when
-		err := s.repo.CheckExists(s.Ctx, user.ID.String())
+		err := s.repo.CheckExists(s.Ctx, user.ID)
 		// then
 		require.NoError(t, err)
 	})
@@ -74,7 +74,7 @@ func (s *userBlackBoxTest) TestExistsUser() {
 	t.Run("user doesn't exist", func(t *testing.T) {
 		//t.Parallel()
 		// Check not existing
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.NewV4())
 		// then
 		//
 		require.IsType(s.T(), errors.NotFoundError{}, err)

--- a/application/repository/exister.go
+++ b/application/repository/exister.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 )
 
 type Exister interface {
-	// Exists returns nil if the object with the given ID exists;
-	// otherwise an error is returned in case the given ID doesn't exists or any
-	// other unknown issue occured
-	CheckExists(ctx context.Context, id string) error
+	// Exists returns nil if the object with the given ID exists; otherwise an
+	// error is returned in case the given ID doesn't exists or any other
+	// unknown issue occured
+	CheckExists(ctx context.Context, id uuid.UUID) error
 }
 
 // Exists returns true if an item exists in the database table with a given ID
@@ -40,7 +41,7 @@ func Exists(ctx context.Context, db *gorm.DB, tableName string, id string) (bool
 
 // CheckExists does the same as Exists but only returns the error value; thereby
 // being a handy convenience function.
-func CheckExists(ctx context.Context, db *gorm.DB, tableName string, id string) error {
-	_, err := Exists(ctx, db, tableName, id)
+func CheckExists(ctx context.Context, db *gorm.DB, tableName string, id uuid.UUID) error {
+	_, err := Exists(ctx, db, tableName, id.String())
 	return err
 }

--- a/area/area.go
+++ b/area/area.go
@@ -126,7 +126,7 @@ func (m *GormAreaRepository) Load(ctx context.Context, id uuid.UUID) (*Area, err
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormAreaRepository) CheckExists(ctx context.Context, id string) error {
+func (m *GormAreaRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "area", "exists"}, time.Now())
 	return repository.CheckExists(ctx, m.db, Area{}.TableName(), id)
 }

--- a/area/area_blackbox_test.go
+++ b/area/area_blackbox_test.go
@@ -78,14 +78,14 @@ func (s *TestAreaRepository) TestExistsArea() {
 		// given
 		fxt := tf.NewTestFixture(s.T(), s.DB, tf.Areas(1))
 		// when
-		err := repo.CheckExists(context.Background(), fxt.Areas[0].ID.String())
+		err := repo.CheckExists(context.Background(), fxt.Areas[0].ID)
 		// then
 		require.NoError(t, err)
 	})
 
 	t.Run("area doesn't exist", func(t *testing.T) {
 		// when
-		err := repo.CheckExists(context.Background(), uuid.NewV4().String())
+		err := repo.CheckExists(context.Background(), uuid.NewV4())
 		// then
 		require.IsType(t, errs.NotFoundError{}, err)
 	})

--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -291,7 +291,7 @@ func (m *GormCodebaseRepository) List(ctx context.Context, spaceID uuid.UUID, st
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormCodebaseRepository) CheckExists(ctx context.Context, id string) error {
+func (m *GormCodebaseRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "codebase", "exists"}, time.Now())
 	return repository.CheckExists(ctx, m.db, Codebase{}.TableName(), id)
 }

--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -189,14 +189,14 @@ func (test *TestCodebaseRepository) TestExistsCodebase() {
 		// given
 		fxt := tf.NewTestFixture(t, test.DB, tf.Codebases(1))
 		// when
-		err := repo.CheckExists(context.Background(), fxt.Codebases[0].ID.String())
+		err := repo.CheckExists(context.Background(), fxt.Codebases[0].ID)
 		// then
 		require.NoError(t, err)
 	})
 
 	test.T().Run("codebase doesn't exist", func(t *testing.T) {
 		// when
-		err := repo.CheckExists(context.Background(), uuid.NewV4().String())
+		err := repo.CheckExists(context.Background(), uuid.NewV4())
 		// then
 		require.IsType(t, errors.NotFoundError{}, err)
 	})

--- a/comment/comment_repository.go
+++ b/comment/comment_repository.go
@@ -232,7 +232,7 @@ func (m *GormCommentRepository) Load(ctx context.Context, id uuid.UUID) (*Commen
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormCommentRepository) CheckExists(ctx context.Context, id string) error {
+func (m *GormCommentRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "comment", "exists"}, time.Now())
 	return repository.CheckExists(ctx, m.db, Comment{}.TableName(), id)
 }

--- a/comment/comment_repository_blackbox_test.go
+++ b/comment/comment_repository_blackbox_test.go
@@ -200,14 +200,14 @@ func (s *TestCommentRepository) TestExistsComment() {
 		// given
 		fxt := tf.NewTestFixture(s.T(), s.DB, tf.Comments(1))
 		// when
-		err := s.repo.CheckExists(s.Ctx, fxt.Comments[0].ID.String())
+		err := s.repo.CheckExists(s.Ctx, fxt.Comments[0].ID)
 		// then
 		require.NoError(t, err)
 	})
 
 	s.T().Run("comment doesn't exist", func(t *testing.T) {
 		// when
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.NewV4())
 		// then
 		require.IsType(t, errors.NotFoundError{}, err)
 	})

--- a/controller/space_areas.go
+++ b/controller/space_areas.go
@@ -33,7 +33,7 @@ func NewSpaceAreasController(service *goa.Service, db application.DB, config Spa
 // List runs the list action.
 func (c *SpaceAreasController) List(ctx *app.ListSpaceAreasContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-		if err := appl.Spaces().CheckExists(ctx, ctx.SpaceID.String()); err != nil {
+		if err := appl.Spaces().CheckExists(ctx, ctx.SpaceID); err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		areas, err := appl.Areas().List(ctx, ctx.SpaceID)

--- a/controller/space_codebases.go
+++ b/controller/space_codebases.go
@@ -73,7 +73,7 @@ func (c *SpaceCodebasesController) Create(ctx *app.CreateSpaceCodebasesContext) 
 func (c *SpaceCodebasesController) List(ctx *app.ListSpaceCodebasesContext) error {
 	offset, limit := computePagingLimits(ctx.PageOffset, ctx.PageLimit)
 	return application.Transactional(c.db, func(appl application.Application) error {
-		err := appl.Spaces().CheckExists(ctx, ctx.SpaceID.String())
+		err := appl.Spaces().CheckExists(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/controller/space_iterations.go
+++ b/controller/space_iterations.go
@@ -115,7 +115,7 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 // List runs the list action.
 func (c *SpaceIterationsController) List(ctx *app.ListSpaceIterationsContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-		err := appl.Spaces().CheckExists(ctx, ctx.SpaceID.String())
+		err := appl.Spaces().CheckExists(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/controller/space_template.go
+++ b/controller/space_template.go
@@ -25,7 +25,7 @@ func (c *SpaceTemplateController) Show(ctx *app.ShowSpaceTemplateContext) error 
 	// till we have space templates in place, let this controller redirect
 	// user to the typegroups endpoint that returns list of type-groups.
 	err := application.Transactional(c.db, func(appl application.Application) error {
-		return appl.Spaces().CheckExists(ctx, ctx.SpaceTemplateID.String())
+		return appl.Spaces().CheckExists(ctx, ctx.SpaceTemplateID)
 	})
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/work_item_type_groups.go
+++ b/controller/work_item_type_groups.go
@@ -27,7 +27,7 @@ func NewWorkItemTypeGroupsController(service *goa.Service, db application.DB) *W
 // List runs the list action.
 func (c *WorkItemTypeGroupsController) List(ctx *app.ListWorkItemTypeGroupsContext) error {
 	err := application.Transactional(c.db, func(appl application.Application) error {
-		return appl.Spaces().CheckExists(ctx, ctx.SpaceTemplateID.String())
+		return appl.Spaces().CheckExists(ctx, ctx.SpaceTemplateID)
 	})
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -309,7 +309,7 @@ func ConvertJSONAPIToWorkItem(ctx context.Context, method string, appl applicati
 			if err != nil {
 				return errors.NewBadParameterError("data.relationships.iteration.data.id", *d.ID)
 			}
-			if err := appl.Iterations().CheckExists(ctx, iterationUUID.String()); err != nil {
+			if err := appl.Iterations().CheckExists(ctx, iterationUUID); err != nil {
 				return errors.NewNotFoundError("data.relationships.iteration.data.id", *d.ID)
 			}
 			target.Fields[workitem.SystemIteration] = iterationUUID.String()
@@ -339,7 +339,7 @@ func ConvertJSONAPIToWorkItem(ctx context.Context, method string, appl applicati
 			if err != nil {
 				return errors.NewBadParameterError("data.relationships.area.data.id", *d.ID)
 			}
-			if err := appl.Areas().CheckExists(ctx, areaUUID.String()); err != nil {
+			if err := appl.Areas().CheckExists(ctx, areaUUID); err != nil {
 				cause := errs.Cause(err)
 				switch cause.(type) {
 				case errors.NotFoundError:

--- a/controller/workitems.go
+++ b/controller/workitems.go
@@ -114,7 +114,7 @@ func (c *WorkitemsController) Create(ctx *app.CreateWorkitemsContext) error {
 		//verify spaceID:
 		// To be removed once we have endpoint like - /api/space/{spaceID}/workitems
 		var err error
-		err = appl.Spaces().CheckExists(ctx, ctx.SpaceID.String())
+		err = appl.Spaces().CheckExists(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -219,7 +219,7 @@ func (m *GormIterationRepository) Load(ctx context.Context, id uuid.UUID) (*Iter
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (m *GormIterationRepository) CheckExists(ctx context.Context, id string) error {
+func (m *GormIterationRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "iteration", "exists"}, time.Now())
 	return repository.CheckExists(ctx, m.db, Iteration{}.TableName(), id)
 }

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -337,10 +337,10 @@ func (s *TestIterationRepository) TestExistsIteration() {
 	repo := iteration.NewIterationRepository(s.DB)
 	t.Run("iteration exists", func(t *testing.T) {
 		fxt := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1))
-		require.Nil(t, repo.CheckExists(context.Background(), fxt.Iterations[0].ID.String()))
+		require.Nil(t, repo.CheckExists(context.Background(), fxt.Iterations[0].ID))
 	})
 	t.Run("iteration doesn't exist", func(t *testing.T) {
-		err := repo.CheckExists(context.Background(), uuid.NewV4().String())
+		err := repo.CheckExists(context.Background(), uuid.NewV4())
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
 }

--- a/label/label.go
+++ b/label/label.go
@@ -156,7 +156,7 @@ func (m *GormLabelRepository) List(ctx context.Context, spaceID uuid.UUID) ([]La
 
 // IsValid returns true if the identity exists
 func (m *GormLabelRepository) IsValid(ctx context.Context, id uuid.UUID) bool {
-	return repository.CheckExists(ctx, m.db, LabelTableName, id.String()) == nil
+	return repository.CheckExists(ctx, m.db, LabelTableName, id) == nil
 }
 
 // Load label in a space

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -665,7 +665,7 @@ func createOrUpdateSpace(ctx context.Context, spaceRepo *space.GormRepository, i
 }
 
 func createSpace(ctx context.Context, spaceRepo *space.GormRepository, id uuid.UUID, description string) error {
-	err := spaceRepo.CheckExists(ctx, id.String())
+	err := spaceRepo.CheckExists(ctx, id)
 	if err != nil {
 		cause := errs.Cause(err)
 		switch cause.(type) {

--- a/remoteworkitem/tracker_repository.go
+++ b/remoteworkitem/tracker_repository.go
@@ -88,7 +88,7 @@ func (r *GormTrackerRepository) Load(ctx context.Context, ID uuid.UUID) (*Tracke
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (r *GormTrackerRepository) CheckExists(ctx context.Context, id string) error {
+func (r *GormTrackerRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	return repository.CheckExists(ctx, r.db, trackersTableName, id)
 }
 

--- a/remoteworkitem/tracker_repository_test.go
+++ b/remoteworkitem/tracker_repository_test.go
@@ -69,13 +69,13 @@ func (test *TestTrackerRepository) TestExistsTracker() {
 		assert.Equal(t, githubTrackerURL, fxt.Trackers[0].URL)
 		assert.Equal(t, remoteworkitem.ProviderGithub, fxt.Trackers[0].Type)
 
-		err := test.repo.CheckExists(context.Background(), fxt.Trackers[0].ID.String())
+		err := test.repo.CheckExists(context.Background(), fxt.Trackers[0].ID)
 		require.NoError(t, err)
 	})
 
 	t.Run("tracker doesn't exist", func(t *testing.T) {
 		t.Parallel()
-		err := test.repo.CheckExists(context.Background(), uuid.NewV4().String())
+		err := test.repo.CheckExists(context.Background(), uuid.NewV4())
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
 

--- a/remoteworkitem/trackerquery_repository.go
+++ b/remoteworkitem/trackerquery_repository.go
@@ -30,7 +30,7 @@ func NewTrackerQueryRepository(db *gorm.DB) *GormTrackerQueryRepository {
 
 // TrackerQueryRepository encapsulate storage & retrieval of tracker queries
 type TrackerQueryRepository interface {
-	repository.Exister
+	CheckExists(ctx context.Context, id string) error
 	Create(ctx context.Context, query string, schedule string, tracker uuid.UUID, spaceID uuid.UUID) (*app.TrackerQuery, error)
 	Save(ctx context.Context, tq app.TrackerQuery) (*app.TrackerQuery, error)
 	Load(ctx context.Context, ID string) (*app.TrackerQuery, error)
@@ -113,7 +113,8 @@ func (r *GormTrackerQueryRepository) Load(ctx context.Context, ID string) (*app.
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
 func (r *GormTrackerQueryRepository) CheckExists(ctx context.Context, id string) error {
-	return repository.CheckExists(ctx, r.db, trackerQueriesTableName, id)
+	_, err := repository.Exists(ctx, r.db, trackerQueriesTableName, id)
+	return err
 }
 
 // Save updates the given tracker query in storage.

--- a/space/space.go
+++ b/space/space.go
@@ -167,7 +167,7 @@ func (r *GormRepository) LoadMany(ctx context.Context, IDs []uuid.UUID) ([]Space
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (r *GormRepository) CheckExists(ctx context.Context, id string) error {
+func (r *GormRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "space", "exists"}, time.Now())
 	return repository.CheckExists(ctx, r.db, Space{}.TableName(), id)
 }

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -100,12 +100,12 @@ func (s *SpaceRepositoryTestSuite) TestCheckExists() {
 		// given a space
 		fxt := tf.NewTestFixture(t, s.DB, tf.Spaces(1))
 		// when checking for existence
-		err := s.repo.CheckExists(s.Ctx, fxt.Spaces[0].ID.String())
+		err := s.repo.CheckExists(s.Ctx, fxt.Spaces[0].ID)
 		// then
 		require.NoError(t, err)
 	})
 	s.T().Run("space doesn't exist", func(t *testing.T) {
-		err := s.repo.CheckExists(context.Background(), uuid.NewV4().String())
+		err := s.repo.CheckExists(context.Background(), uuid.NewV4())
 		require.Error(t, err)
 		require.IsType(t, errors.NotFoundError{}, err, "error was %v", err)
 	})

--- a/workitem/link/category_repository.go
+++ b/workitem/link/category_repository.go
@@ -81,7 +81,7 @@ func (r *GormWorkItemLinkCategoryRepository) Load(ctx context.Context, ID uuid.U
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (r *GormWorkItemLinkCategoryRepository) CheckExists(ctx context.Context, id string) error {
+func (r *GormWorkItemLinkCategoryRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "workitemlinkcategory", "exists"}, time.Now())
 	return repository.CheckExists(ctx, r.db, WorkItemLinkCategory{}.TableName(), id)
 }

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -193,7 +193,7 @@ func (r *GormWorkItemLinkRepository) Load(ctx context.Context, ID uuid.UUID) (*W
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (r *GormWorkItemLinkRepository) CheckExists(ctx context.Context, id string) error {
+func (r *GormWorkItemLinkRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "workitemlink", "exists"}, time.Now())
 	return repository.CheckExists(ctx, r.db, WorkItemLink{}.TableName(), id)
 }

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -192,12 +192,12 @@ func (s *linkRepoBlackBoxTest) TestCreate() {
 func (s *linkRepoBlackBoxTest) TestExistsLink() {
 	s.T().Run("link exists", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinks(1))
-		err := s.workitemLinkRepo.CheckExists(s.Ctx, fxt.WorkItemLinks[0].ID.String())
+		err := s.workitemLinkRepo.CheckExists(s.Ctx, fxt.WorkItemLinks[0].ID)
 		require.NoError(t, err)
 	})
 
 	s.T().Run("link doesn't exist", func(t *testing.T) {
-		err := s.workitemLinkRepo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.workitemLinkRepo.CheckExists(s.Ctx, uuid.NewV4())
 		require.IsType(t, errors.NotFoundError{}, err)
 	})
 }

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -102,7 +102,7 @@ func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID uuid.UUID)
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (r *GormWorkItemLinkTypeRepository) CheckExists(ctx context.Context, id string) error {
+func (r *GormWorkItemLinkTypeRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "workitemlinktype", "exists"}, time.Now())
 	return repository.CheckExists(ctx, r.db, WorkItemLinkType{}.TableName(), id)
 }

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -211,7 +211,7 @@ func (r *GormWorkItemRepository) LookupIDByNamedSpaceAndNumber(ctx context.Conte
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (r *GormWorkItemRepository) CheckExists(ctx context.Context, workitemID string) error {
+func (r *GormWorkItemRepository) CheckExists(ctx context.Context, workitemID uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "workitem", "exists"}, time.Now())
 	return repository.CheckExists(ctx, r.db, workitemTableName, workitemID)
 }

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -273,14 +273,14 @@ func (s *workItemRepoBlackBoxTest) TestCheckExists() {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItems(1))
 		// when
-		err := s.repo.CheckExists(s.Ctx, fxt.WorkItems[0].ID.String())
+		err := s.repo.CheckExists(s.Ctx, fxt.WorkItems[0].ID)
 		// then
 		require.NoError(t, err)
 	})
 
 	s.T().Run("work item doesn't exist", func(t *testing.T) {
 		// when
-		err := s.repo.CheckExists(s.Ctx, uuid.NewV4().String())
+		err := s.repo.CheckExists(s.Ctx, uuid.NewV4())
 		// then
 		require.IsType(t, errors.NotFoundError{}, err)
 	})

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -81,17 +81,13 @@ func (r *GormWorkItemTypeRepository) Load(ctx context.Context, spaceID uuid.UUID
 }
 
 // CheckExists returns nil if the given ID exists otherwise returns an error
-func (r *GormWorkItemTypeRepository) CheckExists(ctx context.Context, id string) error {
+func (r *GormWorkItemTypeRepository) CheckExists(ctx context.Context, id uuid.UUID) error {
 	defer goa.MeasureSince([]string{"goa", "db", "workitemtype", "exists"}, time.Now())
 	log.Info(ctx, map[string]interface{}{
 		"wit_id": id,
 	}, "Checking if work item type exists")
 
-	uuid, err := uuid.FromString(id)
-	if err != nil {
-		return errors.NewBadParameterError("id", id)
-	}
-	_, exists := cache.Get(uuid)
+	_, exists := cache.Get(id)
 	if exists {
 		return nil
 	}

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -33,7 +33,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestExists() {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemTypes(1))
 		// when
-		err := s.repo.CheckExists(s.Ctx, fxt.WorkItemTypes[0].ID.String())
+		err := s.repo.CheckExists(s.Ctx, fxt.WorkItemTypes[0].ID)
 		// then
 		require.NoError(s.T(), err)
 	})
@@ -42,7 +42,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestExists() {
 		// given
 		nonExistingWorkItemTypeID := uuid.NewV4()
 		// when
-		err := s.repo.CheckExists(s.Ctx, nonExistingWorkItemTypeID.String())
+		err := s.repo.CheckExists(s.Ctx, nonExistingWorkItemTypeID)
 		// then
 		require.IsType(t, errors.NotFoundError{}, err)
 	})


### PR DESCRIPTION
it accepted `string` before because the tracker query repo was using string. I've changed that to have a standalone CheckExists function: https://github.com/fabric8-services/fabric8-wit/pull/1831/files#diff-cbc645207e5431802cb2869a92ce9197L33
  