### PR TITLE
auto-create dir to write golden file to

### DIFF
--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -60,8 +60,7 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 	}
 	if update {
 		// Make sure the directory exists where to write the file to
-		dir := filepath.Dir(absPath)
-		err := os.MkdirAll(dir, os.FileMode(0777))
+		err := os.MkdirAll(filepath.Dir(absPath), os.FileMode(0777))
 		if err != nil {
 			return errs.Wrapf(err, "failed to create directory (and potential parents dirs) to write golden file to")
 		}

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -59,8 +59,14 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 		return errs.WithStack(err)
 	}
 	if update {
+		// Make sure the directory exists where to write the file to
+		dir := filepath.Dir(absPath)
+		err := os.MkdirAll(dir, os.FileMode(0777))
+		if err != nil {
+			return errs.Wrapf(err, "failed to create directory (and potential parents dirs) to write golden file to")
+		}
+
 		tmp := string(actual)
-		var err error
 		// Eliminate concrete UUIDs if requested. This makes adding changes to
 		// golden files much more easy in git.
 		if uuidAgnostic {

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -256,15 +256,16 @@ func TestCompareWithGolden(t *testing.T) {
 			_, isPathError := errs.Cause(err).(*os.PathError)
 			require.True(t, isPathError)
 		})
-		t.Run("unable to update golden file due to not existing folder", func(t *testing.T) {
+		t.Run("update golden file in a folder that does not yet exist", func(t *testing.T) {
 			// given
 			f := "not/existing/folder/file.golden.json"
 			// when
 			err := testableCompareWithGolden(true, f, dummy, uuidAgnostic)
 			// then
-			require.Error(t, err)
-			_, isPathError := errs.Cause(err).(*os.PathError)
-			require.True(t, isPathError)
+			// then double check that file exists and no error occurred
+			require.NoError(t, err)
+			_, err = os.Stat(f)
+			require.NoError(t, err)
 		})
 		t.Run("mismatch between expected and actual output", func(t *testing.T) {
 			// given


### PR DESCRIPTION
When using the `-update` switch to `go test` this will auto-create the directory and potential parent directories in order for you to write golden test to. Just use 
```go
compareWithGoldenUUIDAgnostic(t, filepath.Join("foo", "bar", "foobar.golden.json"), payload)
```
and `/foo/bar` will be created with `0777` permissions.