### PR TITLE
Added simplification for creating link chains in test

### DIFF
--- a/test/testfixture/testfixture_test.go
+++ b/test/testfixture/testfixture_test.go
@@ -351,7 +351,7 @@ func (s *testFixtureSuite) TestWorkItemLinks() {
 			require.Nil(t, fxt)
 		})
 		t.Run("multiple link chains", func(t *testing.T) {
-			// Here's a much easier was to create link trees without the hassle
+			// Here's a much easier way to create link trees without the hassle
 			// of big switch statements. I've used two link chains in order to
 			// demonstrate that you can create disjoint links as well.
 			chain1 := tf.LinkChain("A", "B", "C")

--- a/test/testfixture/testfixture_test.go
+++ b/test/testfixture/testfixture_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/workitem/link"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -348,6 +349,38 @@ func (s *testFixtureSuite) TestWorkItemLinks() {
 			// WorkItemLinks and WorkItemLinksCustom
 			require.Error(t, err)
 			require.Nil(t, fxt)
+		})
+		t.Run("multiple link chains", func(t *testing.T) {
+			// Here's a much easier was to create link trees without the hassle
+			// of big switch statements. I've used two link chains in order to
+			// demonstrate that you can create disjoint links as well.
+			chain1 := tf.LinkChain("A", "B", "C")
+			chain2 := tf.LinkChain("D", "E", "F", "G")
+
+			fxt := tf.NewTestFixture(t, s.DB,
+				tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyDependency)),
+				tf.WorkItems(7, tf.SetWorkItemTitles("A", "B", "C", "D", "E", "F", "G")),
+				tf.WorkItemLinksCustom(5, tf.BuildLinks(append(chain1, chain2...)...)),
+			)
+
+			expectedLinks := map[uuid.UUID]uuid.UUID{
+				fxt.WorkItemByTitle("A").ID: fxt.WorkItemByTitle("B").ID,
+				fxt.WorkItemByTitle("B").ID: fxt.WorkItemByTitle("C").ID,
+				fxt.WorkItemByTitle("D").ID: fxt.WorkItemByTitle("E").ID,
+				fxt.WorkItemByTitle("E").ID: fxt.WorkItemByTitle("F").ID,
+				fxt.WorkItemByTitle("F").ID: fxt.WorkItemByTitle("G").ID,
+			}
+			actualLinks := []link.WorkItemLink{}
+			db := s.DB.Table(link.WorkItemLink{}.TableName()).Where("link_type_id = ?", fxt.WorkItemLinkTypes[0].ID).Find(&actualLinks)
+			require.NoError(t, db.Error)
+			require.Len(t, actualLinks, 5)
+			for _, l := range actualLinks {
+				_, ok := expectedLinks[l.SourceID]
+				if ok {
+					delete(expectedLinks, l.SourceID)
+				}
+			}
+			require.Empty(t, expectedLinks, "failed to find all expected links: %+v", expectedLinks)
 		})
 	})
 }


### PR DESCRIPTION
Here's a much easier way to create link trees without the hassle of big switch statements. I've used two link chains in order to demonstrate that you can create disjoint links as well.

```go
chain1 := tf.LinkChain("A", "B", "C")
chain2 := tf.LinkChain("D", "E", "F", "G")

fxt := tf.NewTestFixture(t, s.DB,
	tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyDependency)),
	tf.WorkItems(7, tf.SetWorkItemTitles("A", "B", "C", "D", "E", "F", "G")),
	tf.WorkItemLinksCustom(5, tf.BuildLinks(append(chain1, chain2...)...)),
)
```

Before you would have to write this (which is still supported):

```go
fxt = tf.NewTestFixture(t, s.DB,
	tf.WorkItemLinkTypes(1, tf.SetTopologies(link.TopologyDependency)),
	tf.WorkItems(7, tf.SetWorkItemTitles("A", "B", "C", "D", "E", "F", "G")),
	tf.WorkItemLinksCustom(5, func(fxt *tf.TestFixture, idx int) error {
		l := fxt.WorkItemLinks[idx]
		switch idx {
		case 0:
			l.SourceID = fxt.WorkItemByTitle("A").ID
			l.TargetID = fxt.WorkItemByTitle("B").ID
		case 1:
			l.SourceID = fxt.WorkItemByTitle("B").ID
			l.TargetID = fxt.WorkItemByTitle("C").ID
		case 2:
			l.SourceID = fxt.WorkItemByTitle("D").ID
			l.TargetID = fxt.WorkItemByTitle("E").ID
		case 3:
			l.SourceID = fxt.WorkItemByTitle("E").ID
			l.TargetID = fxt.WorkItemByTitle("F").ID
		case 4:
			l.SourceID = fxt.WorkItemByTitle("F").ID
			l.TargetID = fxt.WorkItemByTitle("G").ID
		}
		return nil
	}),
)
```