### PR TITLE
Added "id" package with "Slice" and "Map" of UUIDs

### DIFF
--- a/id/doc.go
+++ b/id/doc.go
@@ -1,0 +1,2 @@
+// Package id contains functions for dealing with various UUID containers.
+package id

--- a/id/map.go
+++ b/id/map.go
@@ -1,0 +1,28 @@
+package id
+
+import uuid "github.com/satori/go.uuid"
+
+// Map describes a map of UUID keys with empty structs as their values
+type Map map[uuid.UUID]struct{}
+
+// MapFromSlice constructs a map of empty struct values with keys taken from the
+// given slice. As a consequence all potential IDs from the given slice are
+// removed.
+func MapFromSlice(s Slice) Map {
+	m := Map{}
+	for _, ID := range s {
+		m[ID] = struct{}{}
+	}
+	return m
+}
+
+// ToSlice takes all keys from the given map and returns them as an array.
+func (m Map) ToSlice() Slice {
+	s := make(Slice, len(m))
+	i := 0
+	for k := range m {
+		s[i] = k
+		i++
+	}
+	return s
+}

--- a/id/map.go
+++ b/id/map.go
@@ -1,6 +1,10 @@
 package id
 
-import uuid "github.com/satori/go.uuid"
+import (
+	"strings"
+
+	uuid "github.com/satori/go.uuid"
+)
 
 // Map describes a map of UUID keys with empty structs as their values
 type Map map[uuid.UUID]struct{}
@@ -24,4 +28,35 @@ func (m Map) ToSlice() Slice {
 		i++
 	}
 	return s
+}
+
+// Copy returns a standalone copy of this map.
+func (m Map) Copy() Map {
+	res := Map{}
+	for k, v := range m {
+		res[k] = v
+	}
+	return res
+}
+
+// ToString returns all IDs as a string separated by the given separation
+// string. If a callback is specified that callback will be called for every ID
+// to generate a custom output string for that element.
+func (m Map) ToString(sep string, fn ...func(ID uuid.UUID) string) string {
+	res := make([]string, len(m))
+	i := 0
+	for ID := range m {
+		if len(fn) != 0 {
+			res[i] = fn[0](ID)
+		} else {
+			res[i] = ID.String()
+		}
+		i++
+	}
+	return strings.Join(res, sep)
+}
+
+// String returns all map keys separated by ", ".
+func (m Map) String() string {
+	return m.ToString(", ")
 }

--- a/id/map.go
+++ b/id/map.go
@@ -6,8 +6,7 @@ import uuid "github.com/satori/go.uuid"
 type Map map[uuid.UUID]struct{}
 
 // MapFromSlice constructs a map of empty struct values with keys taken from the
-// given slice. As a consequence all potential IDs from the given slice are
-// removed.
+// given slice.
 func MapFromSlice(s Slice) Map {
 	m := Map{}
 	for _, ID := range s {

--- a/id/map_blackbox_test.go
+++ b/id/map_blackbox_test.go
@@ -1,10 +1,13 @@
 package id_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/id"
 	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,4 +39,34 @@ func TestMapToSlice(t *testing.T) {
 		}
 		require.Empty(t, toBeFound)
 	})
+}
+
+func TestMapToString(t *testing.T) {
+	// given
+	a := uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94")
+	b := uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8")
+	c := uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809")
+	m := id.Map{a: {}, b: {}, c: {}}
+	// when
+	res := m.ToString("; ", func(ID uuid.UUID) string { return fmt.Sprintf("(%s)", ID) })
+	// then
+	assert.Equal(t, 1, strings.Count(res, fmt.Sprintf("(%s)", a)))
+	assert.Equal(t, 1, strings.Count(res, fmt.Sprintf("(%s)", b)))
+	assert.Equal(t, 1, strings.Count(res, fmt.Sprintf("(%s)", c)))
+	assert.Equal(t, 2, strings.Count(res, "; "))
+}
+
+func TestMapString(t *testing.T) {
+	// given
+	a := uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94")
+	b := uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8")
+	c := uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809")
+	m := id.Map{a: {}, b: {}, c: {}, c: {}}
+	// when
+	res := m.String()
+	// then
+	assert.Equal(t, 1, strings.Count(res, a.String()))
+	assert.Equal(t, 1, strings.Count(res, b.String()))
+	assert.Equal(t, 1, strings.Count(res, c.String()))
+	assert.Equal(t, 2, strings.Count(res, ", "))
 }

--- a/id/map_blackbox_test.go
+++ b/id/map_blackbox_test.go
@@ -1,0 +1,39 @@
+package id_test
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-wit/id"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapFromSlice(t *testing.T) {
+	t.Run("empty slice", func(t *testing.T) {
+		require.Equal(t, id.Map{}, id.MapFromSlice(id.Slice{}))
+	})
+	a := uuid.FromStringOrNil("4c6ed1b1-8de6-4ebc-8238-95e2e28ac0a6")
+	b := uuid.FromStringOrNil("a5bb3827-432c-4ab1-9ce2-4de8c7261a2b")
+	t.Run("w/o duplicates", func(t *testing.T) {
+		require.Equal(t, id.Map{a: {}, b: {}}, id.MapFromSlice(id.Slice{a, b}))
+	})
+	t.Run("with duplicates", func(t *testing.T) {
+		require.Equal(t, id.Map{a: {}, b: {}}, id.MapFromSlice(id.Slice{a, b, a, b}))
+	})
+}
+
+func TestMapToSlice(t *testing.T) {
+	t.Run("empty map", func(t *testing.T) {
+		require.Equal(t, id.Slice{}, id.Map{}.ToSlice())
+	})
+	a := uuid.FromStringOrNil("4c6ed1b1-8de6-4ebc-8238-95e2e28ac0a6")
+	b := uuid.FromStringOrNil("a5bb3827-432c-4ab1-9ce2-4de8c7261a2b")
+	t.Run("with values", func(t *testing.T) {
+		s := id.Map{a: {}, b: {}}.ToSlice()
+		toBeFound := id.Map{a: {}, b: {}}
+		for _, ID := range s {
+			delete(toBeFound, ID)
+		}
+		require.Empty(t, toBeFound)
+	})
+}

--- a/id/slice.go
+++ b/id/slice.go
@@ -1,6 +1,10 @@
 package id
 
-import uuid "github.com/satori/go.uuid"
+import (
+	"strings"
+
+	uuid "github.com/satori/go.uuid"
+)
 
 // Slice describes a slice of UUID objects
 type Slice []uuid.UUID
@@ -41,4 +45,26 @@ func (s Slice) Sub(b Slice) Slice {
 // Unique returns a slice in which all duplicate elements have been removed.
 func (s Slice) Unique(b Slice) Slice {
 	return MapFromSlice(s).ToSlice()
+}
+
+// ToString returns all IDs as a string separated by the given separation
+// string. If a callback is specified that callback will be called for every ID
+// to generate a custom output string for that element.
+func (s Slice) ToString(sep string, fn ...func(ID uuid.UUID) string) string {
+	res := make([]string, len(s))
+	i := 0
+	for _, ID := range s {
+		if len(fn) != 0 {
+			res[i] = fn[0](ID)
+		} else {
+			res[i] = ID.String()
+		}
+		i++
+	}
+	return strings.Join(res, sep)
+}
+
+// String returns all IDs separated by ", ".
+func (s Slice) String() string {
+	return s.ToString(", ")
 }

--- a/id/slice.go
+++ b/id/slice.go
@@ -1,0 +1,44 @@
+package id
+
+import uuid "github.com/satori/go.uuid"
+
+// Slice describes a slice of UUID objects
+type Slice []uuid.UUID
+
+// Diff returns the difference between this and the given slice.
+func (s Slice) Diff(b Slice) Slice {
+	slice := append(s, b...)
+	encountered := map[uuid.UUID]int{}
+	for _, v := range slice {
+		encountered[v] = encountered[v] + 1
+	}
+
+	diff := []uuid.UUID{}
+	for _, v := range slice {
+		if encountered[v] == 1 {
+			diff = append(diff, v)
+		}
+	}
+	return diff
+}
+
+// Sub returns the result of removing elements in b from the given slice.
+func (s Slice) Sub(b Slice) Slice {
+	lut := map[uuid.UUID]struct{}{}
+	for _, id := range b {
+		lut[id] = struct{}{}
+	}
+
+	sub := []uuid.UUID{}
+	for _, id := range s {
+		if _, foundInB := lut[id]; !foundInB {
+			sub = append(sub, id)
+		}
+	}
+	return sub
+}
+
+// Unique returns a slice in which all duplicate elements have been removed.
+func (s Slice) Unique(b Slice) Slice {
+	return MapFromSlice(s).ToSlice()
+}

--- a/id/slice_blackbox_test.go
+++ b/id/slice_blackbox_test.go
@@ -1,0 +1,117 @@
+package id_test
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-wit/id"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSliceDiff(t *testing.T) {
+	a := id.Slice{
+		// shared with b
+		uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94"),
+		uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8"),
+		// unique
+		uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809"),
+		uuid.FromStringOrNil("0b5159b5-c21b-40c2-af90-f020d71a8e94"),
+	}
+	b := id.Slice{
+		// shared with a
+		uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94"),
+		uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8"),
+		// unique to b
+		uuid.FromStringOrNil("03a9a225-e7b0-4229-b698-716308f2136a"),
+		uuid.FromStringOrNil("1db1c165-2360-4efc-89b4-e4d3d4988091"),
+		uuid.FromStringOrNil("2fc09162-bf2f-4a1c-b622-323d8495ac58"),
+	}
+	t.Run("equality", func(t *testing.T) {
+		require.Equal(t, id.Slice{}, a.Diff(a))
+	})
+	diffs := []id.Slice{a.Diff(b),
+		b.Diff(a),
+	}
+	for _, d := range diffs {
+		t.Run("difference", func(t *testing.T) {
+			toBeFound := map[uuid.UUID]struct{}{
+				// unique to a
+				uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809"): {},
+				uuid.FromStringOrNil("0b5159b5-c21b-40c2-af90-f020d71a8e94"): {},
+				// unique to b
+				uuid.FromStringOrNil("03a9a225-e7b0-4229-b698-716308f2136a"): {},
+				uuid.FromStringOrNil("1db1c165-2360-4efc-89b4-e4d3d4988091"): {},
+				uuid.FromStringOrNil("2fc09162-bf2f-4a1c-b622-323d8495ac58"): {},
+			}
+			// then
+			for _, i := range d {
+				_, ok := toBeFound[i]
+				require.True(t, ok, "failed to find %s in expected difference: %s", i, toBeFound)
+				delete(toBeFound, i)
+			}
+			require.Empty(t, toBeFound, "found not all IDs in difference: %+v", toBeFound)
+		})
+	}
+}
+
+func TestSliceSub(t *testing.T) {
+	a := id.Slice{
+		// shared with b
+		uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94"),
+		uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8"),
+		// unique
+		uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809"),
+		uuid.FromStringOrNil("0b5159b5-c21b-40c2-af90-f020d71a8e94"),
+	}
+	b := id.Slice{
+		// shared with a
+		uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94"),
+		uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8"),
+		// unique to b
+		uuid.FromStringOrNil("03a9a225-e7b0-4229-b698-716308f2136a"),
+		uuid.FromStringOrNil("1db1c165-2360-4efc-89b4-e4d3d4988091"),
+		uuid.FromStringOrNil("2fc09162-bf2f-4a1c-b622-323d8495ac58"),
+	}
+	t.Run("equality", func(t *testing.T) {
+		require.Empty(t, a.Sub(a))
+	})
+	t.Run("unchanged when subtracting nothing", func(t *testing.T) {
+		require.Equal(t, a, a.Sub(id.Slice{}))
+	})
+	t.Run("unchanged when subtracting non existent ID", func(t *testing.T) {
+		require.Equal(t, a, a.Sub(id.Slice{uuid.FromStringOrNil("29976200-df70-49d9-9fb1-789de14c5cec")}))
+	})
+	t.Run("a-b", func(t *testing.T) {
+		toBeFound := map[uuid.UUID]struct{}{
+			// unique to a
+			uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809"): {},
+			uuid.FromStringOrNil("0b5159b5-c21b-40c2-af90-f020d71a8e94"): {},
+		}
+		// when
+		res := a.Sub(b)
+		// then
+		for _, i := range res {
+			_, ok := toBeFound[i]
+			require.True(t, ok, "failed to find %s in expected subtraction result: %s", i, toBeFound)
+			delete(toBeFound, i)
+		}
+		require.Empty(t, toBeFound, "found not all IDs in subtraction result: %+v", toBeFound)
+	})
+	t.Run("b-a", func(t *testing.T) {
+		toBeFound := map[uuid.UUID]struct{}{
+			// unique to b
+			uuid.FromStringOrNil("03a9a225-e7b0-4229-b698-716308f2136a"): {},
+			uuid.FromStringOrNil("1db1c165-2360-4efc-89b4-e4d3d4988091"): {},
+			uuid.FromStringOrNil("2fc09162-bf2f-4a1c-b622-323d8495ac58"): {},
+		}
+		// when
+		res := b.Sub(a)
+		// then
+		for _, i := range res {
+			_, ok := toBeFound[i]
+			require.True(t, ok, "failed to find %s in expected subtraction result: %s", i, toBeFound)
+			delete(toBeFound, i)
+		}
+		require.Empty(t, toBeFound, "found not all IDs in subtraction result: %+v", toBeFound)
+	})
+}

--- a/id/slice_blackbox_test.go
+++ b/id/slice_blackbox_test.go
@@ -1,6 +1,7 @@
 package id_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/id"
@@ -114,4 +115,28 @@ func TestSliceSub(t *testing.T) {
 		}
 		require.Empty(t, toBeFound, "found not all IDs in subtraction result: %+v", toBeFound)
 	})
+}
+
+func TestSliceToString(t *testing.T) {
+	// given
+	a := uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94")
+	b := uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8")
+	c := uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809")
+	s := id.Slice{a, b, c}
+	// when
+	res := s.ToString("; ", func(ID uuid.UUID) string { return fmt.Sprintf("(%s)", ID) })
+	// then
+	require.Equal(t, fmt.Sprintf("(%s); (%s); (%s)", a, b, c), res)
+}
+
+func TestSliceString(t *testing.T) {
+	// given
+	a := uuid.FromStringOrNil("9afc7d5c-9f4e-4a04-8359-71d72e5eed94")
+	b := uuid.FromStringOrNil("4ce8076c-4997-4565-8272-9a3cb4d7a1a8")
+	c := uuid.FromStringOrNil("0403d2cb-02d9-466f-88cd-65dc9247f809")
+	s := id.Slice{a, b, c}
+	// when
+	res := s.String()
+	// then
+	require.Equal(t, fmt.Sprintf("%s, %s, %s", a, b, c), res)
 }


### PR DESCRIPTION
The `id` package defines these handy containers for UUIDs:

```go
type Slice []uuid.UUID
type Map map[uuid.UUID]struct{}
```

In recent tests that I discovered that I wrote a lot of duplicate code for dealing with UUIDs. That's where `Slice` and `Map` come in.

`Map` comes with these functions:

```go
func MapFromSlice(s Slice) Map
func (m Map) ToSlice() Slice
func (m Map) Copy() Map
func (m Map) ToString(sep string, fn ...func(ID uuid.UUID) string) string
func (m Map) String() string
```

Slice comes with these functions:

```go
func (s Slice) Diff(b Slice) Slice
func (s Slice) Sub(b Slice) Slice
func (s Slice) Unique(b Slice) Slice
func (s Slice) ToString(sep string, fn ...func(ID uuid.UUID) string) string
func (s Slice) String() string
```