### PR TITLE
Fix sorting of WorkItemInterfaceSlice

### DIFF
--- a/controller/search.go
+++ b/controller/search.go
@@ -82,15 +82,30 @@ func (a WorkItemInterfaceSlice) Len() int {
 	return len(a)
 }
 
-// Less reports whether the element with
-// index i should sort before the element with index j.
+// Less reports whether the element with index i should sort before the element
+// with index j.
+//
+// NOTE: For now we assume that included elements in the search response are
+// only work items. We can handle work items as pointers or objects. Both
+// options are possible.
 func (a WorkItemInterfaceSlice) Less(i, j int) bool {
-	x, ok := a[i].(*app.WorkItem)
-	if !ok {
-		return false
+	var x, y *app.WorkItem
+
+	switch v := a[i].(type) {
+	case app.WorkItem:
+		x = &v
+	case *app.WorkItem:
+		x = v
 	}
-	y, ok := a[j].(*app.WorkItem)
-	if !ok {
+
+	switch v := a[j].(type) {
+	case app.WorkItem:
+		y = &v
+	case *app.WorkItem:
+		y = v
+	}
+
+	if x == nil || y == nil {
 		return false
 	}
 

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -1367,10 +1367,10 @@ func TestWorkItemPtrSliceSort(t *testing.T) {
 
 func TestWorkItemInterfaceSliceSort(t *testing.T) {
 	t.Run("by work item title", func(t *testing.T) {
-		// given
-		var a interface{} = &app.WorkItem{Attributes: map[string]interface{}{workitem.SystemTitle: "A"}}
+		// given objects and pointers
+		var a interface{} = app.WorkItem{Attributes: map[string]interface{}{workitem.SystemTitle: "A"}}
 		var b interface{} = &app.WorkItem{Attributes: map[string]interface{}{workitem.SystemTitle: "B"}}
-		var c interface{} = &app.WorkItem{Attributes: map[string]interface{}{workitem.SystemTitle: "C"}}
+		var c interface{} = app.WorkItem{Attributes: map[string]interface{}{workitem.SystemTitle: "C"}}
 		s := WorkItemInterfaceSlice{c, a, b}
 		// when
 		sort.Sort(s)
@@ -1378,10 +1378,10 @@ func TestWorkItemInterfaceSliceSort(t *testing.T) {
 		require.Equal(t, WorkItemInterfaceSlice{a, b, c}, s)
 	})
 	t.Run("by work item ID", func(t *testing.T) {
-		// given
-		var a interface{} = &app.WorkItem{ID: ptr.UUID(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001"))}
+		// given objects and pointers
+		var a interface{} = app.WorkItem{ID: ptr.UUID(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001"))}
 		var b interface{} = &app.WorkItem{ID: ptr.UUID(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000002"))}
-		var c interface{} = &app.WorkItem{ID: ptr.UUID(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000003"))}
+		var c interface{} = app.WorkItem{ID: ptr.UUID(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000003"))}
 		s := WorkItemInterfaceSlice{c, a, b}
 		// when
 		sort.Sort(s)

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/C_with_tree-view=true.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/C_with_tree-view=true.res.golden.json
@@ -87,6 +87,80 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 1,
+        "system.order": 1000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "A",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/children"
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/labels"
+          }
+        },
+        "parent": {},
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/links"
+          }
+        }
+      },
+      "type": "workitems"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
         "system.number": 2,
         "system.order": 2000,
         "system.remote_item_id": null,
@@ -158,80 +232,6 @@
         "workItemLinks": {
           "links": {
             "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/links"
-          }
-        }
-      },
-      "type": "workitems"
-    },
-    {
-      "attributes": {
-        "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 1,
-        "system.order": 1000,
-        "system.remote_item_id": null,
-        "system.state": "new",
-        "system.title": "A",
-        "system.updated_at": "0001-01-01T00:00:00Z",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000006",
-      "links": {
-        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006",
-        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006"
-      },
-      "relationships": {
-        "area": {},
-        "assignees": {},
-        "baseType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
-          }
-        },
-        "children": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/children"
-          }
-        },
-        "comments": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/comments",
-            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006/relationships/comments"
-          }
-        },
-        "creator": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
-            "links": {
-              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
-              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
-            },
-            "type": "users"
-          }
-        },
-        "iteration": {},
-        "labels": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/labels"
-          }
-        },
-        "parent": {},
-        "space": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
-            "type": "spaces"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
-          }
-        },
-        "workItemLinks": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/links"
           }
         }
       },


### PR DESCRIPTION
Before I treated the `interface{}` object in the `"included"` response of the search `show` action as `*app.WorkItem` __pointers__. But it turned out that they are indeed just `app.WorkItem` __objects__. That is why my `WorkItemInterfaceSlice.Less` implementation was wrong. It can now handle pointers as well as values the same.