### PR TITLE
fix loadMultiple functions from area & iteration repo

### DIFF
--- a/area/area.go
+++ b/area/area.go
@@ -135,7 +135,9 @@ func (m *GormAreaRepository) CheckExists(ctx context.Context, id uuid.UUID) erro
 func (m *GormAreaRepository) LoadMultiple(ctx context.Context, ids []uuid.UUID) ([]Area, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "Area", "getmultiple"}, time.Now())
 	var objs []Area
-
+	if len(ids) == 0 {
+		return objs, nil
+	}
 	for i := 0; i < len(ids); i++ {
 		m.db = m.db.Or("id = ?", ids[i])
 	}

--- a/area/area_blackbox_test.go
+++ b/area/area_blackbox_test.go
@@ -293,3 +293,17 @@ func (s *TestAreaRepository) TestListParentTree() {
 		assert.NotNil(s.T(), searchInAreaSlice(listOfCreatedID[i], listOfCreatedAreas))
 	}
 }
+
+func (s *TestAreaRepository) TestLoadMultiple() {
+	// nothing should be returned by LoadMultiple when we pass empty slice
+	s.T().Run("input empty slice", func(t *testing.T) {
+		// keep few areas in DB on purpose
+		_ = tf.NewTestFixture(t, s.DB, tf.Areas(2))
+		emptyList := []uuid.UUID{}
+		// when
+		listLoadedAreas, err := area.NewAreaRepository(s.DB).LoadMultiple(context.Background(), emptyList)
+		// then
+		require.NoError(t, err)
+		require.Empty(t, listLoadedAreas)
+	})
+}

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -118,7 +118,9 @@ type GormIterationRepository struct {
 func (m *GormIterationRepository) LoadMultiple(ctx context.Context, ids []uuid.UUID) ([]Iteration, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "iteration", "getmultiple"}, time.Now())
 	var objs []Iteration
-
+	if len(ids) == 0 {
+		return objs, nil
+	}
 	for i := 0; i < len(ids); i++ {
 		m.db = m.db.Or("id = ?", ids[i])
 	}

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -438,3 +438,17 @@ func (s *TestIterationRepository) TestParent() {
 		require.Equal(t, iteration4ID, fxt.Iterations[5].Parent())
 	})
 }
+
+func (s *TestIterationRepository) TestLoadMultiple() {
+	// nothing should be returned by LoadMultiple when we pass empty slice
+	s.T().Run("input empty slice", func(t *testing.T) {
+		// keep few iterations in DB on purpose
+		_ = tf.NewTestFixture(t, s.DB, tf.Iterations(2))
+		emptyList := []uuid.UUID{}
+		// when
+		listLoadedIterations, err := iteration.NewIterationRepository(s.DB).LoadMultiple(context.Background(), emptyList)
+		// then
+		require.NoError(t, err)
+		require.Empty(t, listLoadedIterations)
+	})
+}


### PR DESCRIPTION
fixes https://github.com/openshiftio/openshift.io/issues/2040

If we call LoadMultiple from area/area.go or iteration/iteration.go with an empty slice of IDs then the following query is executed `SELECT * FROM "areas"  WHERE "areas"."deleted_at" IS NULL` which in turn loads the whole table unnecessarily.