### PR TITLE
ensure pod status is returned even when no pods are running

### DIFF
--- a/kubernetes/apps_kubeclient.go
+++ b/kubernetes/apps_kubeclient.go
@@ -656,19 +656,7 @@ func (kc *kubeClient) getCurrentDeployment(space string, appName string, namespa
 	for idx := range rcs {
 		rc := &rcs[idx]
 		if newest == nil || newest.CreationTimestamp.Before(rc.CreationTimestamp) {
-			visible := false
-			// Check if this RC has replicas running
-			if rc.Status.Replicas > 0 {
-				visible = true
-			} else { // Check if RC is in progress
-				phase := rc.Annotations[deploymentPhaseAnnotation]
-				if phase == "New" || phase == "Pending" || phase == "Running" {
-					visible = true
-				}
-			}
-			if visible {
-				newest = rc
-			}
+			newest = rc
 		}
 	}
 	if newest != nil {


### PR DESCRIPTION
This small fix ensures that pod counts will be returned even if there are no running pods.  This allows the UI to display a '0' pod count, which the user can then scale to 1 or higher.

Before:
$ curl -H "Authorization: Bearer $PROD" http://localhost:8080/api/apps/spaces/9c21a121-3c9e-49e3-9ce4-afa8593d34da
{"data":{"applications":[{"name":"stooke-test1","pipeline":[]}]}}

After:
$ curl -H "Authorization: Bearer $PROD" http://localhost:8080/api/apps/spaces/9c21a121-3c9e-49e3-9ce4-afa8593d34da
{"data":{"applications":[{"name":"stooke-test1","pipeline":[{"name":"run","pods":{"running":0,"starting":0,"stopping":0,"total":0},"version":"1.0.2"},{"name":"stage","pods":{"running":0,"starting":0,"stopping":0,"total":0},"version":"1.0.2"}]}]}}
