### PR TITLE
Ensure /apps API old and new formats can run in same WIT

### DIFF
--- a/controller/apps.go
+++ b/controller/apps.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/auth/authservice"
+	"github.com/fabric8-services/fabric8-wit/kubernetesV1"
 
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/auth"
 	"github.com/fabric8-services/fabric8-wit/configuration"
 	witerrors "github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/kubernetes"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
@@ -44,7 +44,7 @@ func tostring(item interface{}) string {
 	return string(bytes)
 }
 
-func getAndCheckOSIOClient(ctx context.Context) *OSIOClient {
+func getAndCheckOSIOClient(ctx context.Context) *OSIOClientV1 {
 
 	// defaults
 	host := "localhost"
@@ -67,7 +67,7 @@ func getAndCheckOSIOClient(ctx context.Context) *OSIOClient {
 		scheme = witurl.Scheme
 	}
 
-	oc := NewOSIOClient(ctx, scheme, host)
+	oc := NewOSIOClientV1(ctx, scheme, host)
 
 	return oc
 }
@@ -148,7 +148,7 @@ func getTokenData(authClient authservice.Client, ctx context.Context, forService
 
 // getKubeClient createa kube client for the appropriate cluster assigned to the current user.
 // many different errors are possible, so controllers should call getAndCheckKubeClient() instead
-func (c *AppsController) getKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
+func (c *AppsController) getKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
 
 	// create Auth API client
 	authClient, err := auth.CreateClient(ctx, c.Config)
@@ -184,12 +184,12 @@ func (c *AppsController) getKubeClient(ctx context.Context) (kubernetes.KubeClie
 	}
 
 	// create the cluster API client
-	kubeConfig := &kubernetes.KubeClientConfig{
+	kubeConfig := &kubernetesV1.KubeClientConfig{
 		ClusterURL:    kubeURL,
 		BearerToken:   kubeToken,
 		UserNamespace: *kubeNamespaceName,
 	}
-	kc, err := kubernetes.NewKubeClient(kubeConfig)
+	kc, err := kubernetesV1.NewKubeClient(kubeConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/apps_osioclient.go
+++ b/controller/apps_osioclient.go
@@ -16,14 +16,14 @@ import (
 )
 
 // OSIOClient contains configuration and methods for interacting with OSIO API
-type OSIOClient struct {
+type OSIOClientV1 struct {
 	wc *witclient.Client
 }
 
 // NewOSIOClient creates an openshift IO client given an http request context
-func NewOSIOClient(ctx context.Context, scheme string, host string) *OSIOClient {
+func NewOSIOClientV1(ctx context.Context, scheme string, host string) *OSIOClientV1 {
 
-	client := new(OSIOClient)
+	client := new(OSIOClientV1)
 	httpClient := newHTTPClient()
 	client.wc = witclient.New(goaclient.HTTPClientDoer(httpClient))
 	client.wc.Host = host
@@ -40,7 +40,7 @@ func newHTTPClient() *http.Client {
 
 // GetNamespaceByType finds a namespace by type (user, che, stage, etc)
 // if userService is nil, will fetch the user services under the hood
-func (osioclient *OSIOClient) GetNamespaceByType(ctx context.Context, userService *app.UserService, namespaceType string) (*app.NamespaceAttributes, error) {
+func (osioclient *OSIOClientV1) GetNamespaceByType(ctx context.Context, userService *app.UserService, namespaceType string) (*app.NamespaceAttributes, error) {
 	if userService == nil {
 		us, err := osioclient.GetUserServices(ctx)
 		if err != nil {
@@ -59,7 +59,7 @@ func (osioclient *OSIOClient) GetNamespaceByType(ctx context.Context, userServic
 
 // GetUserServices - fetch array of user services
 // In the future, consider calling the tenant service (as /api/user/services implementation does)
-func (osioclient *OSIOClient) GetUserServices(ctx context.Context) (*app.UserService, error) {
+func (osioclient *OSIOClientV1) GetUserServices(ctx context.Context) (*app.UserService, error) {
 	resp, err := osioclient.wc.ShowUserService(ctx, witclient.ShowUserServicePath())
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (osioclient *OSIOClient) GetUserServices(ctx context.Context) (*app.UserSer
 }
 
 // GetSpaceByID - fetch space given UUID
-func (osioclient *OSIOClient) GetSpaceByID(ctx context.Context, spaceID uuid.UUID) (*app.Space, error) {
+func (osioclient *OSIOClientV1) GetSpaceByID(ctx context.Context, spaceID uuid.UUID) (*app.Space, error) {
 	// there are two different uuid packages at play here:
 	//   github.com/satori/go.uuid and goadesign/goa/uuid.
 	// because of that, we fenerate our own URL to avoid issues for now.

--- a/design/apps.go
+++ b/design/apps.go
@@ -6,60 +6,60 @@ import (
 )
 
 // SimpleSpace describe a space
-var simpleSpace = a.Type("SimpleSpace", func() {
+var simpleSpaceV1 = a.Type("SimpleSpaceV1", func() {
 	a.Description(`a space consisting of multiple applications`)
 	a.Attribute("id", d.UUID)
 	a.Attribute("name", d.String)
-	a.Attribute("applications", a.ArrayOf(simpleApp))
+	a.Attribute("applications", a.ArrayOf(simpleAppV1))
 	a.Required("applications")
 })
 
 // SimpleApp describe an application within a space
-var simpleApp = a.Type("SimpleApp", func() {
+var simpleAppV1 = a.Type("SimpleAppV1", func() {
 	a.Description(`a description of an application`)
 	a.Attribute("id", d.UUID)
 	a.Attribute("name", d.String)
-	a.Attribute("pipeline", a.ArrayOf(simpleDeployment))
+	a.Attribute("pipeline", a.ArrayOf(simpleDeploymentV1))
 	a.Required("pipeline")
 })
 
 // simpleDeployment describe an element of an application pipeline
-var simpleDeployment = a.Type("SimpleDeployment", func() {
+var simpleDeploymentV1 = a.Type("SimpleDeploymentV1", func() {
 	a.Description(`a deployment (a step in a pipeline, e.g. 'build')`)
 	a.Attribute("id", d.UUID)
 	a.Attribute("name", d.String)
 	a.Attribute("version", d.String)
-	a.Attribute("pods", podStats)
+	a.Attribute("pods", podStatsV1)
 })
 
 // simpleDeployment describe an element of an application pipeline
-var simpleEnvironment = a.Type("SimpleEnvironment", func() {
+var simpleEnvironmentV1 = a.Type("SimpleEnvironmentV1", func() {
 	a.Description(`a shared environment`)
 	a.Attribute("id", d.UUID)
 	a.Attribute("name", d.String)
-	a.Attribute("quota", envStats)
+	a.Attribute("quota", envStatsV1)
 })
 
-var envStats = a.Type("EnvStats", func() {
+var envStatsV1 = a.Type("EnvStatsV1", func() {
 	a.Description("resource usage and quotas for an environment")
-	a.Attribute("cpucores", envStatCores)
-	a.Attribute("memory", envStatMemory)
+	a.Attribute("cpucores", envStatCoresV1)
+	a.Attribute("memory", envStatMemoryV1)
 })
 
-var envStatCores = a.Type("EnvStatCores", func() {
+var envStatCoresV1 = a.Type("EnvStatCoresV1", func() {
 	a.Description(`CPU core stats`)
 	a.Attribute("used", d.Number)
 	a.Attribute("quota", d.Number)
 })
 
-var envStatMemory = a.Type("EnvStatMemory", func() {
+var envStatMemoryV1 = a.Type("EnvStatMemoryV1", func() {
 	a.Description(`memory stats`)
 	a.Attribute("used", d.Number)
 	a.Attribute("quota", d.Number)
 	a.Attribute("units", d.String)
 })
 
-var podStats = a.Type("PodStats", func() {
+var podStatsV1 = a.Type("PodStatsV1", func() {
 	a.Description(`pod stats`)
 	a.Attribute("starting", d.Integer)
 	a.Attribute("running", d.Integer)
@@ -67,80 +67,80 @@ var podStats = a.Type("PodStats", func() {
 	a.Attribute("total", d.Integer)
 })
 
-var timedNumberTuple = a.Type("TimedNumberTuple", func() {
+var timedNumberTupleV1 = a.Type("TimedNumberTupleV1", func() {
 	a.Description("a set of time and number values")
 	a.Attribute("time", d.Number)
 	a.Attribute("value", d.Number)
 })
 
-var simpleDeploymentStats = a.Type("SimpleDeploymentStats", func() {
+var simpleDeploymentStatsV1 = a.Type("SimpleDeploymentStatsV1", func() {
 	a.Description("current deployment stats")
-	a.Attribute("cores", timedNumberTuple)
-	a.Attribute("memory", timedNumberTuple)
-	a.Attribute("net_tx", timedNumberTuple)
-	a.Attribute("net_rx", timedNumberTuple)
+	a.Attribute("cores", timedNumberTupleV1)
+	a.Attribute("memory", timedNumberTupleV1)
+	a.Attribute("net_tx", timedNumberTupleV1)
+	a.Attribute("net_rx", timedNumberTupleV1)
 })
 
-var simpleDeploymentStatSeries = a.Type("SimpleDeploymentStatSeries", func() {
+var simpleDeploymentStatSeriesV1 = a.Type("SimpleDeploymentStatSeriesV1", func() {
 	a.Description("pod stat series")
 	a.Attribute("start", d.Number)
 	a.Attribute("end", d.Number)
-	a.Attribute("memory", a.ArrayOf(timedNumberTuple))
-	a.Attribute("cores", a.ArrayOf(timedNumberTuple))
-	a.Attribute("net_tx", a.ArrayOf(timedNumberTuple))
-	a.Attribute("net_rx", a.ArrayOf(timedNumberTuple))
+	a.Attribute("memory", a.ArrayOf(timedNumberTupleV1))
+	a.Attribute("cores", a.ArrayOf(timedNumberTupleV1))
+	a.Attribute("net_tx", a.ArrayOf(timedNumberTupleV1))
+	a.Attribute("net_rx", a.ArrayOf(timedNumberTupleV1))
 })
 
-var simpleSpaceSingle = JSONSingle(
+var simpleSpaceSingleV1 = JSONSingle(
 	"SimpleSpace", "Holds a single response to a space request",
-	simpleSpace,
+	simpleSpaceV1,
 	nil)
 
-var simpleAppSingle = JSONSingle(
+var simpleAppSingleV1 = JSONSingle(
 	"SimpleApplication", "Holds a single response to a space/application request",
-	simpleApp,
+	simpleAppV1,
 	nil)
 
-var simpleEnvironmentSingle = JSONSingle(
+var simpleEnvironmentSingleV1 = JSONSingle(
 	"SimpleEnvironment", "Holds a single response to a space/environment request",
-	simpleEnvironment,
+	simpleEnvironmentV1,
 	nil)
 
-var simpleEnvironmentMultiple = JSONList(
+var simpleEnvironmentMultipleV1 = JSONList(
 	"SimpleEnvironment", "Holds a response to a space/environment request",
-	simpleEnvironment,
+	simpleEnvironmentV1,
 	nil,
 	nil)
 
-var simplePod = a.Type("SimplePod", func() {
+var simplePodV1 = a.Type("SimplePodV1", func() {
 	a.Description("wrapper for a kubernetes Pod")
 	a.Attribute("pod", d.Any)
 })
 
-var simplePodMultiple = JSONList(
+var simplePodMultipleV1 = JSONList(
 	"SimplePod", "Holds a list of pods",
-	simplePod,
+	simplePodV1,
 	nil,
 	nil)
 
-var simpleDeploymentSingle = JSONSingle(
+var simpleDeploymentSingleV1 = JSONSingle(
 	"SimpleDeployment", "Holds a single response to a space/application/deployment request",
-	simpleDeployment,
+	simpleDeploymentV1,
 	nil)
 
-var simpleDeploymentStatsSingle = JSONSingle(
+var simpleDeploymentStatsSingleV1 = JSONSingle(
 	"SimpleDeploymentStats", "Holds a single response to a space/application/deployment/stats request",
-	simpleDeploymentStats,
+	simpleDeploymentStatsV1,
 	nil)
 
-var simpleDeploymentStatSeriesSingle = JSONSingle(
+var simpleDeploymentStatSeriesSingleV1 = JSONSingle(
 	"SimpleDeploymentStatSeries", "HOlds a response to a stat series query",
-	simpleDeploymentStatSeries,
+	simpleDeploymentStatSeriesV1,
 	nil)
 
-var simpleEnvironmentStatSingle = JSONSingle(
+var simpleEnvironmentStatSingleV1 = JSONSingle(
 	"EnvStats", "Holds a single response to a pipeline/stats request",
-	envStats,
+	envStatsV1,
 	nil)
 
 var _ = a.Resource("apps", func() {
@@ -157,7 +157,7 @@ var _ = a.Resource("apps", func() {
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 		})
-		a.Response(d.OK, simpleSpaceSingle)
+		a.Response(d.OK, simpleSpaceSingleV1)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -172,7 +172,7 @@ var _ = a.Resource("apps", func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 			a.Param("appName", d.String, "Name of the application")
 		})
-		a.Response(d.OK, simpleAppSingle)
+		a.Response(d.OK, simpleAppSingleV1)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -188,7 +188,7 @@ var _ = a.Resource("apps", func() {
 			a.Param("appName", d.String, "Name of the application")
 			a.Param("deployName", d.String, "Name of the pipe deployment")
 		})
-		a.Response(d.OK, simpleDeploymentSingle)
+		a.Response(d.OK, simpleDeploymentSingleV1)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -205,7 +205,7 @@ var _ = a.Resource("apps", func() {
 			a.Param("deployName", d.String, "Name of the deployment")
 			a.Param("start", d.Number, "start time in millis")
 		})
-		a.Response(d.OK, simpleDeploymentStatsSingle)
+		a.Response(d.OK, simpleDeploymentStatsSingleV1)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -224,7 +224,7 @@ var _ = a.Resource("apps", func() {
 			a.Param("end", d.Number, "end time in millis")
 			a.Param("limit", d.Integer, "maximum number of data points to return")
 		})
-		a.Response(d.OK, simpleDeploymentStatSeriesSingle)
+		a.Response(d.OK, simpleDeploymentStatSeriesSingleV1)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -255,7 +255,7 @@ var _ = a.Resource("apps", func() {
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 		})
-		a.Response(d.OK, simpleEnvironmentMultiple)
+		a.Response(d.OK, simpleEnvironmentMultipleV1)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -269,7 +269,7 @@ var _ = a.Resource("apps", func() {
 		a.Params(func() {
 			a.Param("envName", d.String, "Name of the environment")
 		})
-		a.Response(d.OK, simpleEnvironmentSingle)
+		a.Response(d.OK, simpleEnvironmentSingleV1)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)

--- a/kubernetesV1/apps_kubeclient.go
+++ b/kubernetesV1/apps_kubeclient.go
@@ -1,4 +1,4 @@
-package kubernetes
+package kubernetesV1
 
 import (
 	"bytes"
@@ -57,16 +57,16 @@ type BuildConfigInterface interface {
 
 // KubeClientInterface contains configuration and methods for interacting with a Kubernetes cluster
 type KubeClientInterface interface {
-	GetSpace(spaceName string) (*app.SimpleSpace, error)
-	GetApplication(spaceName string, appName string) (*app.SimpleApp, error)
-	GetDeployment(spaceName string, appName string, envName string) (*app.SimpleDeployment, error)
+	GetSpace(spaceName string) (*app.SimpleSpaceV1, error)
+	GetApplication(spaceName string, appName string) (*app.SimpleAppV1, error)
+	GetDeployment(spaceName string, appName string, envName string) (*app.SimpleDeploymentV1, error)
 	ScaleDeployment(spaceName string, appName string, envName string, deployNumber int) (*int, error)
 	GetDeploymentStats(spaceName string, appName string, envName string,
-		startTime time.Time) (*app.SimpleDeploymentStats, error)
+		startTime time.Time) (*app.SimpleDeploymentStatsV1, error)
 	GetDeploymentStatSeries(spaceName string, appName string, envName string, startTime time.Time,
-		endTime time.Time, limit int) (*app.SimpleDeploymentStatSeries, error)
-	GetEnvironments() ([]*app.SimpleEnvironment, error)
-	GetEnvironment(envName string) (*app.SimpleEnvironment, error)
+		endTime time.Time, limit int) (*app.SimpleDeploymentStatSeriesV1, error)
+	GetEnvironments() ([]*app.SimpleEnvironmentV1, error)
+	GetEnvironment(envName string) (*app.SimpleEnvironmentV1, error)
 	GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error)
 }
 
@@ -156,7 +156,7 @@ func (*defaultGetter) GetMetrics(config *MetricsClientConfig) (MetricsInterface,
 }
 
 // GetSpace returns a space matching the provided name, containing all applications that belong to it
-func (kc *kubeClient) GetSpace(spaceName string) (*app.SimpleSpace, error) {
+func (kc *kubeClient) GetSpace(spaceName string) (*app.SimpleSpaceV1, error) {
 	// Get BuildConfigs within the user namespace that have a matching 'space' label
 	// This is similar to how pipelines are displayed in fabric8-ui
 	// https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/space/create/pipelines/pipelines.component.ts
@@ -166,7 +166,7 @@ func (kc *kubeClient) GetSpace(spaceName string) (*app.SimpleSpace, error) {
 	}
 
 	// Get all applications in this space using BuildConfig names
-	apps := make([]*app.SimpleApp, 0)
+	apps := make([]*app.SimpleAppV1, 0)
 	for _, bc := range buildconfigs {
 		appn, err := kc.GetApplication(spaceName, bc)
 		if err != nil {
@@ -175,7 +175,7 @@ func (kc *kubeClient) GetSpace(spaceName string) (*app.SimpleSpace, error) {
 		apps = append(apps, appn)
 	}
 
-	result := &app.SimpleSpace{
+	result := &app.SimpleSpaceV1{
 		Applications: apps,
 	}
 
@@ -184,9 +184,9 @@ func (kc *kubeClient) GetSpace(spaceName string) (*app.SimpleSpace, error) {
 
 // GetApplication retrieves an application with the given space and application names, with the status
 // of that application's deployment in each environment
-func (kc *kubeClient) GetApplication(spaceName string, appName string) (*app.SimpleApp, error) {
+func (kc *kubeClient) GetApplication(spaceName string, appName string) (*app.SimpleAppV1, error) {
 	// Get all deployments of this app for each environment in this space
-	deployments := make([]*app.SimpleDeployment, 0)
+	deployments := make([]*app.SimpleDeploymentV1, 0)
 	for envName := range kc.envMap {
 		deployment, err := kc.GetDeployment(spaceName, appName, envName)
 		if err != nil {
@@ -196,7 +196,7 @@ func (kc *kubeClient) GetApplication(spaceName string, appName string) (*app.Sim
 		}
 	}
 
-	result := &app.SimpleApp{
+	result := &app.SimpleAppV1{
 		Name:     &appName,
 		Pipeline: deployments,
 	}
@@ -249,7 +249,7 @@ func (kc *kubeClient) ScaleDeployment(spaceName string, appName string, envName 
 
 // GetDeployment returns information about the current deployment of an application within a
 // particular environment. The application must exist within the provided space.
-func (kc *kubeClient) GetDeployment(spaceName string, appName string, envName string) (*app.SimpleDeployment, error) {
+func (kc *kubeClient) GetDeployment(spaceName string, appName string, envName string) (*app.SimpleDeploymentV1, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
 		return nil, err
@@ -274,7 +274,7 @@ func (kc *kubeClient) GetDeployment(spaceName string, appName string, envName st
 	}
 
 	verString := string(deploy.appVersion)
-	result := &app.SimpleDeployment{
+	result := &app.SimpleDeploymentV1{
 		Name:    &envName,
 		Version: &verString,
 		Pods:    podStats,
@@ -285,7 +285,7 @@ func (kc *kubeClient) GetDeployment(spaceName string, appName string, envName st
 // GetDeploymentStats returns performance metrics of an application for a period of 1 minute
 // beyond the specified start time, which are then aggregated into a single data point.
 func (kc *kubeClient) GetDeploymentStats(spaceName string, appName string, envName string,
-	startTime time.Time) (*app.SimpleDeploymentStats, error) {
+	startTime time.Time) (*app.SimpleDeploymentStatsV1, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
 		return nil, err
@@ -322,7 +322,7 @@ func (kc *kubeClient) GetDeploymentStats(spaceName string, appName string, envNa
 		return nil, err
 	}
 
-	result := &app.SimpleDeploymentStats{
+	result := &app.SimpleDeploymentStatsV1{
 		Cores:  cpuUsage,
 		Memory: memoryUsage,
 		NetTx:  netTxUsage,
@@ -336,7 +336,7 @@ func (kc *kubeClient) GetDeploymentStats(spaceName string, appName string, envNa
 // the provided time range in startTime and endTime. If there are more data points than the
 // limit argument, only the newest datapoints within that limit are returned.
 func (kc *kubeClient) GetDeploymentStatSeries(spaceName string, appName string, envName string,
-	startTime time.Time, endTime time.Time, limit int) (*app.SimpleDeploymentStatSeries, error) {
+	startTime time.Time, endTime time.Time, limit int) (*app.SimpleDeploymentStatSeriesV1, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
 		return nil, err
@@ -376,7 +376,7 @@ func (kc *kubeClient) GetDeploymentStatSeries(spaceName string, appName string, 
 
 	// Get the earliest and latest timestamps
 	minTime, maxTime := getTimestampEndpoints(cpuMetrics, memoryMetrics)
-	result := &app.SimpleDeploymentStatSeries{
+	result := &app.SimpleDeploymentStatSeriesV1{
 		Cores:  cpuMetrics,
 		Memory: memoryMetrics,
 		NetTx:  netTxMetrics,
@@ -390,8 +390,8 @@ func (kc *kubeClient) GetDeploymentStatSeries(spaceName string, appName string, 
 
 // GetEnvironments retrieves information on all environments in the cluster
 // for the current user
-func (kc *kubeClient) GetEnvironments() ([]*app.SimpleEnvironment, error) {
-	envs := make([]*app.SimpleEnvironment, 0)
+func (kc *kubeClient) GetEnvironments() ([]*app.SimpleEnvironmentV1, error) {
+	envs := make([]*app.SimpleEnvironmentV1, 0)
 	for envName := range kc.envMap {
 		env, err := kc.GetEnvironment(envName)
 		if err != nil {
@@ -403,7 +403,7 @@ func (kc *kubeClient) GetEnvironments() ([]*app.SimpleEnvironment, error) {
 }
 
 // GetEnvironment returns information on an environment with the provided name
-func (kc *kubeClient) GetEnvironment(envName string) (*app.SimpleEnvironment, error) {
+func (kc *kubeClient) GetEnvironment(envName string) (*app.SimpleEnvironmentV1, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
 		return nil, err
@@ -414,7 +414,7 @@ func (kc *kubeClient) GetEnvironment(envName string) (*app.SimpleEnvironment, er
 		return nil, err
 	}
 
-	env := &app.SimpleEnvironment{
+	env := &app.SimpleEnvironmentV1{
 		Name:  &envName,
 		Quota: envStats,
 	}
@@ -442,7 +442,7 @@ func getMetricsURLFromAPIURL(apiURLStr string) (string, error) {
 	return metricsURL.String(), nil
 }
 
-func getTimestampEndpoints(metricsSeries ...[]*app.TimedNumberTuple) (minTime, maxTime *float64) {
+func getTimestampEndpoints(metricsSeries ...[]*app.TimedNumberTupleV1) (minTime, maxTime *float64) {
 	// Metrics arrays are ordered by timestamp, so just check beginning and end
 	for _, series := range metricsSeries {
 		if len(series) > 0 {
@@ -702,7 +702,7 @@ func (kc *kubeClient) getReplicationControllers(namespace string, dcUID types.UI
 	return rcsForDc, nil
 }
 
-func (kc *kubeClient) getResourceQuota(namespace string) (*app.EnvStats, error) {
+func (kc *kubeClient) getResourceQuota(namespace string) (*app.EnvStatsV1, error) {
 	const computeResources string = "compute-resources"
 	quota, err := kc.ResourceQuotas(namespace).Get(computeResources, metaV1.GetOptions{})
 	if err != nil {
@@ -722,7 +722,7 @@ func (kc *kubeClient) getResourceQuota(namespace string) (*app.EnvStats, error) 
 		return nil, err
 	}
 
-	cpuStats := &app.EnvStatCores{
+	cpuStats := &app.EnvStatCoresV1{
 		Quota: &cpuLimit,
 		Used:  &cpuUsed,
 	}
@@ -738,13 +738,13 @@ func (kc *kubeClient) getResourceQuota(namespace string) (*app.EnvStats, error) 
 	}
 
 	memUnits := "bytes"
-	memStats := &app.EnvStatMemory{
+	memStats := &app.EnvStatMemoryV1{
 		Quota: &memLimit,
 		Used:  &memUsed,
 		Units: &memUnits,
 	}
 
-	result := &app.EnvStats{
+	result := &app.EnvStatsV1{
 		Cpucores: cpuStats,
 		Memory:   memStats,
 	}
@@ -806,7 +806,7 @@ func (kc *kubeClient) getPods(namespace string, uid types.UID) ([]v1.Pod, error)
 	return appPods, nil
 }
 
-func (kc *kubeClient) getPodStatus(pods []v1.Pod) (*app.PodStats, error) {
+func (kc *kubeClient) getPodStatus(pods []v1.Pod) (*app.PodStatsV1, error) {
 	var starting, running, stopping int
 	/*
 	 * TODO Logic for pod phases in web console is calculated in the UI:
@@ -831,7 +831,7 @@ func (kc *kubeClient) getPodStatus(pods []v1.Pod) (*app.PodStats, error) {
 	}
 
 	total := len(pods)
-	result := &app.PodStats{
+	result := &app.PodStatsV1{
 		Starting: &starting,
 		Running:  &running,
 		Stopping: &stopping,

--- a/kubernetesV1/apps_metrics.go
+++ b/kubernetesV1/apps_metrics.go
@@ -1,4 +1,4 @@
-package kubernetes
+package kubernetesV1
 
 import (
 	"strings"
@@ -31,18 +31,18 @@ type HawkularGetter interface {
 
 // MetricsInterface provides methods to obtain performance metrics of a deployed application
 type MetricsInterface interface {
-	GetCPUMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error)
+	GetCPUMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error)
 	GetCPUMetricsRange(pods []v1.Pod, namespace string, startTime time.Time, endTime time.Time,
-		limit int) ([]*app.TimedNumberTuple, error)
-	GetMemoryMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error)
+		limit int) ([]*app.TimedNumberTupleV1, error)
+	GetMemoryMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error)
 	GetMemoryMetricsRange(pods []v1.Pod, namespace string, startTime time.Time, endTime time.Time,
-		limit int) ([]*app.TimedNumberTuple, error)
-	GetNetworkSentMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error)
+		limit int) ([]*app.TimedNumberTupleV1, error)
+	GetNetworkSentMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error)
 	GetNetworkSentMetricsRange(pods []v1.Pod, namespace string, startTime time.Time, endTime time.Time,
-		limit int) ([]*app.TimedNumberTuple, error)
-	GetNetworkRecvMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error)
+		limit int) ([]*app.TimedNumberTupleV1, error)
+	GetNetworkRecvMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error)
 	GetNetworkRecvMetricsRange(pods []v1.Pod, namespace string, startTime time.Time, endTime time.Time,
-		limit int) ([]*app.TimedNumberTuple, error)
+		limit int) ([]*app.TimedNumberTupleV1, error)
 }
 
 // HawkularRESTAPI collects methods that call out to the Hawkular metrics server over the network
@@ -108,12 +108,12 @@ func (*defaultGetter) GetHawkularRESTAPI(config *MetricsClientConfig) (HawkularR
 	return helper, nil
 }
 
-func (mc *metricsClient) GetCPUMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error) {
+func (mc *metricsClient) GetCPUMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error) {
 	return mc.getBucketAverage(pods, namespace, cpuDesc, startTime, millicoreToCoreScale)
 }
 
 func (mc *metricsClient) GetCPUMetricsRange(pods []v1.Pod, namespace string,
-	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTuple, error) {
+	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTupleV1, error) {
 	buckets, err := mc.getBucketsInRange(pods, namespace, cpuDesc, startTime, endTime, limit)
 	if err != nil {
 		return nil, err
@@ -123,12 +123,12 @@ func (mc *metricsClient) GetCPUMetricsRange(pods []v1.Pod, namespace string,
 	return results, nil
 }
 
-func (mc *metricsClient) GetMemoryMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error) {
+func (mc *metricsClient) GetMemoryMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error) {
 	return mc.getBucketAverage(pods, namespace, memDesc, startTime, noScale)
 }
 
 func (mc *metricsClient) GetMemoryMetricsRange(pods []v1.Pod, namespace string,
-	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTuple, error) {
+	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTupleV1, error) {
 	buckets, err := mc.getBucketsInRange(pods, namespace, memDesc, startTime, endTime, limit)
 	if err != nil {
 		return nil, err
@@ -138,12 +138,12 @@ func (mc *metricsClient) GetMemoryMetricsRange(pods []v1.Pod, namespace string,
 	return results, nil
 }
 
-func (mc *metricsClient) GetNetworkSentMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error) {
+func (mc *metricsClient) GetNetworkSentMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error) {
 	return mc.getBucketAverage(pods, namespace, netSent, startTime, noScale)
 }
 
 func (mc *metricsClient) GetNetworkSentMetricsRange(pods []v1.Pod, namespace string,
-	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTuple, error) {
+	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTupleV1, error) {
 	buckets, err := mc.getBucketsInRange(pods, namespace, netSent, startTime, endTime, limit)
 	if err != nil {
 		return nil, err
@@ -153,12 +153,12 @@ func (mc *metricsClient) GetNetworkSentMetricsRange(pods []v1.Pod, namespace str
 	return results, nil
 }
 
-func (mc *metricsClient) GetNetworkRecvMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error) {
+func (mc *metricsClient) GetNetworkRecvMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTupleV1, error) {
 	return mc.getBucketAverage(pods, namespace, netRecv, startTime, noScale)
 }
 
 func (mc *metricsClient) GetNetworkRecvMetricsRange(pods []v1.Pod, namespace string,
-	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTuple, error) {
+	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTupleV1, error) {
 	buckets, err := mc.getBucketsInRange(pods, namespace, netRecv, startTime, endTime, limit)
 	if err != nil {
 		return nil, err
@@ -168,20 +168,20 @@ func (mc *metricsClient) GetNetworkRecvMetricsRange(pods []v1.Pod, namespace str
 	return results, nil
 }
 
-func bucketsToTuples(buckets []*hawkular.Bucketpoint, scale float64) []*app.TimedNumberTuple {
-	results := make([]*app.TimedNumberTuple, len(buckets))
+func bucketsToTuples(buckets []*hawkular.Bucketpoint, scale float64) []*app.TimedNumberTupleV1 {
+	results := make([]*app.TimedNumberTupleV1, len(buckets))
 	for idx, bucket := range buckets {
 		results[idx] = bucketToTuple(bucket, scale)
 	}
 	return results
 }
 
-func bucketToTuple(bucket *hawkular.Bucketpoint, scale float64) *app.TimedNumberTuple {
+func bucketToTuple(bucket *hawkular.Bucketpoint, scale float64) *app.TimedNumberTupleV1 {
 	// Use bucket start time as timestamp for data, which is what the OSO web console uses:
 	// https://github.com/openshift/origin-web-console/blob/v3.7.0/app/scripts/directives/deploymentMetrics.js#L250
 	bucketTimeUnix := float64(convertToUnixMillis(bucket.Start))
 	scaledAvg := bucket.Avg * scale
-	result := &app.TimedNumberTuple{
+	result := &app.TimedNumberTupleV1{
 		Value: &scaledAvg,
 		Time:  &bucketTimeUnix,
 	}
@@ -193,7 +193,7 @@ func convertToUnixMillis(t time.Time) int64 {
 }
 
 func (mc *metricsClient) getBucketAverage(pods []v1.Pod, namespace, descTag string,
-	startTime time.Time, scale float64) (*app.TimedNumberTuple, error) {
+	startTime time.Time, scale float64) (*app.TimedNumberTupleV1, error) {
 	result, err := mc.getLatestBucket(pods, namespace, descTag, startTime)
 	if err != nil {
 		return nil, err

--- a/kubernetesV1/apps_metrics_blackbox_test.go
+++ b/kubernetesV1/apps_metrics_blackbox_test.go
@@ -1,4 +1,4 @@
-package kubernetes_test
+package kubernetesV1_test
 
 import (
 	"net/http"
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/app"
-	"github.com/fabric8-services/fabric8-wit/kubernetes"
+	"github.com/fabric8-services/fabric8-wit/kubernetesV1"
 	hawkular "github.com/hawkular/hawkular-client-go/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,7 +43,7 @@ type testMetricsOutput struct {
 	filters    url.Values
 }
 
-func (getter *testHawkularGetter) GetHawkularRESTAPI(config *kubernetes.MetricsClientConfig) (kubernetes.HawkularRESTAPI, error) {
+func (getter *testHawkularGetter) GetHawkularRESTAPI(config *kubernetesV1.MetricsClientConfig) (kubernetesV1.HawkularRESTAPI, error) {
 	helper := &testHawkular{
 		getter: getter,
 		output: &testMetricsOutput{},
@@ -200,12 +200,12 @@ var metricRangeTestCases []*testMetricsInput = []*testMetricsInput{
 func TestGetNetworkRecv(t *testing.T) {
 	testCases := singleMetricTestCases
 	test := &testHawkularGetter{}
-	config := &kubernetes.MetricsClientConfig{
+	config := &kubernetesV1.MetricsClientConfig{
 		MetricsURL:     "myMetricsServer",
 		BearerToken:    "token",
 		HawkularGetter: test,
 	}
-	client, err := kubernetes.NewMetricsClient(config)
+	client, err := kubernetesV1.NewMetricsClient(config)
 	require.NoError(t, err, "Failed to create metrics client")
 
 	for _, testCase := range testCases {
@@ -218,7 +218,7 @@ func TestGetNetworkRecv(t *testing.T) {
 
 		// Check that the result has the correct value and timestamp and that the Hawkular API was called
 		// with the expected values
-		metrics := []*app.TimedNumberTuple{metric}
+		metrics := []*app.TimedNumberTupleV1{metric}
 		output := test.result.output
 		verifyMetrics(metrics, testCase, output, "network/rx_rate", t)
 
@@ -230,12 +230,12 @@ func TestGetNetworkRecv(t *testing.T) {
 func TestGetNetworkRecvRange(t *testing.T) {
 	testCases := metricRangeTestCases
 	test := &testHawkularGetter{}
-	config := &kubernetes.MetricsClientConfig{
+	config := &kubernetesV1.MetricsClientConfig{
 		MetricsURL:     "myMetricsServer",
 		BearerToken:    "token",
 		HawkularGetter: test,
 	}
-	client, err := kubernetes.NewMetricsClient(config)
+	client, err := kubernetesV1.NewMetricsClient(config)
 	require.NoError(t, err, "Failed to create metrics client")
 
 	for _, testCase := range testCases {
@@ -260,12 +260,12 @@ func TestGetNetworkRecvRange(t *testing.T) {
 func TestGetNetworkSent(t *testing.T) {
 	testCases := singleMetricTestCases
 	test := &testHawkularGetter{}
-	config := &kubernetes.MetricsClientConfig{
+	config := &kubernetesV1.MetricsClientConfig{
 		MetricsURL:     "myMetricsServer",
 		BearerToken:    "token",
 		HawkularGetter: test,
 	}
-	client, err := kubernetes.NewMetricsClient(config)
+	client, err := kubernetesV1.NewMetricsClient(config)
 	require.NoError(t, err, "Failed to create metrics client")
 
 	for _, testCase := range testCases {
@@ -278,7 +278,7 @@ func TestGetNetworkSent(t *testing.T) {
 
 		// Check that the result has the correct value and timestamp and that the Hawkular API was called
 		// with the expected values
-		metrics := []*app.TimedNumberTuple{metric}
+		metrics := []*app.TimedNumberTupleV1{metric}
 		output := test.result.output
 		verifyMetrics(metrics, testCase, output, "network/tx_rate", t)
 
@@ -290,12 +290,12 @@ func TestGetNetworkSent(t *testing.T) {
 func TestGetNetworkSentRange(t *testing.T) {
 	testCases := metricRangeTestCases
 	test := &testHawkularGetter{}
-	config := &kubernetes.MetricsClientConfig{
+	config := &kubernetesV1.MetricsClientConfig{
 		MetricsURL:     "myMetricsServer",
 		BearerToken:    "token",
 		HawkularGetter: test,
 	}
-	client, err := kubernetes.NewMetricsClient(config)
+	client, err := kubernetesV1.NewMetricsClient(config)
 	require.NoError(t, err, "Failed to create metrics client")
 
 	for _, testCase := range testCases {
@@ -316,7 +316,7 @@ func TestGetNetworkSentRange(t *testing.T) {
 	}
 }
 
-func verifyMetrics(metrics []*app.TimedNumberTuple, testCase *testMetricsInput, result *testMetricsOutput,
+func verifyMetrics(metrics []*app.TimedNumberTupleV1, testCase *testMetricsInput, result *testMetricsOutput,
 	gaugeDesc string, t *testing.T) {
 	// If limit is specified, check that the number of metrics doesn't exceed that limit
 	numMetrics := len(metrics)


### PR DESCRIPTION
This PR addresses issue #1867.

Various implementation files, directories, function and type names are renamed so that the JSON-API breaking change can co-exist with the old API.  
After the UI has been updated (and deployed all the way to production) to use the new JSON-API endpoints (which are not yet merged into WIT/master), then this code can be deleted in a future PR.

