### PR TITLE
Eliminate some more duplicate names for deployments API refactoring

### DIFF
--- a/controller/apps.go
+++ b/controller/apps.go
@@ -44,7 +44,7 @@ func tostring(item interface{}) string {
 	return string(bytes)
 }
 
-func getAndCheckOSIOClient(ctx context.Context) *OSIOClientV1 {
+func getAndCheckOSIOClientV1(ctx context.Context) *OSIOClientV1 {
 
 	// defaults
 	host := "localhost"
@@ -75,7 +75,7 @@ func getAndCheckOSIOClient(ctx context.Context) *OSIOClientV1 {
 func (c *AppsController) getSpaceNameFromSpaceID(ctx context.Context, spaceID uuid.UUID) (*string, error) {
 	// TODO - add a cache in AppsController - but will break if user can change space name
 	// use WIT API to convert Space UUID to Space name
-	osioclient := getAndCheckOSIOClient(ctx)
+	osioclient := getAndCheckOSIOClientV1(ctx)
 
 	osioSpace, err := osioclient.GetSpaceByID(ctx, spaceID)
 	if err != nil {
@@ -84,9 +84,9 @@ func (c *AppsController) getSpaceNameFromSpaceID(ctx context.Context, spaceID uu
 	return osioSpace.Attributes.Name, nil
 }
 
-func getNamespaceName(ctx context.Context) (*string, error) {
+func getNamespaceNameV1(ctx context.Context) (*string, error) {
 
-	osioclient := getAndCheckOSIOClient(ctx)
+	osioclient := getAndCheckOSIOClientV1(ctx)
 	kubeSpaceAttr, err := osioclient.GetNamespaceByType(ctx, nil, "user")
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func getNamespaceName(ctx context.Context) (*string, error) {
 	return kubeSpaceAttr.Name, nil
 }
 
-func getUser(authClient authservice.Client, ctx context.Context) (*authservice.User, error) {
+func getUserV1(authClient authservice.Client, ctx context.Context) (*authservice.User, error) {
 	// get the user definition (for cluster URL)
 	resp, err := authClient.ShowUser(ctx, authservice.ShowUserPath(), nil, nil)
 	if err != nil {
@@ -122,7 +122,7 @@ func getUser(authClient authservice.Client, ctx context.Context) (*authservice.U
 	return &respType, nil
 }
 
-func getTokenData(authClient authservice.Client, ctx context.Context, forService string) (*authservice.TokenData, error) {
+func getTokenDataV1(authClient authservice.Client, ctx context.Context, forService string) (*authservice.TokenData, error) {
 
 	resp, err := authClient.RetrieveToken(ctx, authservice.RetrieveTokenPath(), forService, nil)
 	if err != nil {
@@ -157,7 +157,7 @@ func (c *AppsController) getKubeClient(ctx context.Context) (kubernetesV1.KubeCl
 		return nil, err
 	}
 
-	authUser, err := getUser(*authClient, ctx)
+	authUser, err := getUserV1(*authClient, ctx)
 	if err != nil {
 		log.Error(ctx, nil, "error accessing Auth server"+tostring(err))
 		return nil, err
@@ -169,7 +169,7 @@ func (c *AppsController) getKubeClient(ctx context.Context) (kubernetesV1.KubeCl
 	}
 
 	// get the openshift/kubernetes auth info for the cluster OpenShift API
-	osauth, err := getTokenData(*authClient, ctx, *authUser.Data.Attributes.Cluster)
+	osauth, err := getTokenDataV1(*authClient, ctx, *authUser.Data.Attributes.Cluster)
 	if err != nil {
 		log.Error(ctx, nil, "error getting openshift credentials:"+tostring(err))
 		return nil, err
@@ -178,7 +178,7 @@ func (c *AppsController) getKubeClient(ctx context.Context) (kubernetesV1.KubeCl
 	kubeURL := *authUser.Data.Attributes.Cluster
 	kubeToken := *osauth.AccessToken
 
-	kubeNamespaceName, err := getNamespaceName(ctx)
+	kubeNamespaceName, err := getNamespaceNameV1(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (c *AppsController) ShowDeploymentStatSeries(ctx *app.ShowDeploymentStatSer
 		return witerrors.NewNotFoundError("deployment", ctx.DeployName)
 	}
 
-	res := &app.SimpleDeploymentStatSeriesSingle{
+	res := &app.SimpleDeploymentStatSeriesV1Single{
 		Data: statSeries,
 	}
 
@@ -305,7 +305,7 @@ func (c *AppsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsAppsCon
 		return witerrors.NewNotFoundError("deployment", ctx.DeployName)
 	}
 
-	res := &app.SimpleDeploymentStatsSingle{
+	res := &app.SimpleDeploymentStatsV1Single{
 		Data: deploymentStats,
 	}
 
@@ -328,7 +328,7 @@ func (c *AppsController) ShowEnvironment(ctx *app.ShowEnvironmentAppsContext) er
 		return witerrors.NewNotFoundError("environment", ctx.EnvName)
 	}
 
-	res := &app.SimpleEnvironmentSingle{
+	res := &app.SimpleEnvironmentV1Single{
 		Data: env,
 	}
 
@@ -357,7 +357,7 @@ func (c *AppsController) ShowSpace(ctx *app.ShowSpaceAppsContext) error {
 		return witerrors.NewNotFoundError("space", *kubeSpaceName)
 	}
 
-	res := &app.SimpleSpaceSingle{
+	res := &app.SimpleSpaceV1Single{
 		Data: space,
 	}
 
@@ -385,7 +385,7 @@ func (c *AppsController) ShowSpaceApp(ctx *app.ShowSpaceAppAppsContext) error {
 		return witerrors.NewNotFoundError("application", ctx.AppName)
 	}
 
-	res := &app.SimpleApplicationSingle{
+	res := &app.SimpleApplicationV1Single{
 		Data: theapp,
 	}
 
@@ -413,7 +413,7 @@ func (c *AppsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDeploymentA
 		return witerrors.NewNotFoundError("deployment statistics", ctx.DeployName)
 	}
 
-	res := &app.SimpleDeploymentSingle{
+	res := &app.SimpleDeploymentV1Single{
 		Data: deploymentStats,
 	}
 
@@ -456,7 +456,7 @@ func (c *AppsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironmentsApp
 		return witerrors.NewNotFoundError("environments", ctx.SpaceID.String())
 	}
 
-	res := &app.SimpleEnvironmentList{
+	res := &app.SimpleEnvironmentV1List{
 		Data: envs,
 	}
 

--- a/design/apps.go
+++ b/design/apps.go
@@ -92,22 +92,22 @@ var simpleDeploymentStatSeriesV1 = a.Type("SimpleDeploymentStatSeriesV1", func()
 })
 
 var simpleSpaceSingleV1 = JSONSingle(
-	"SimpleSpace", "Holds a single response to a space request",
+	"SimpleSpaceV1", "Holds a single response to a space request",
 	simpleSpaceV1,
 	nil)
 
 var simpleAppSingleV1 = JSONSingle(
-	"SimpleApplication", "Holds a single response to a space/application request",
+	"SimpleApplicationV1", "Holds a single response to a space/application request",
 	simpleAppV1,
 	nil)
 
 var simpleEnvironmentSingleV1 = JSONSingle(
-	"SimpleEnvironment", "Holds a single response to a space/environment request",
+	"SimpleEnvironmentV1", "Holds a single response to a space/environment request",
 	simpleEnvironmentV1,
 	nil)
 
 var simpleEnvironmentMultipleV1 = JSONList(
-	"SimpleEnvironment", "Holds a response to a space/environment request",
+	"SimpleEnvironmentV1", "Holds a response to a space/environment request",
 	simpleEnvironmentV1,
 	nil,
 	nil)
@@ -118,28 +118,28 @@ var simplePodV1 = a.Type("SimplePodV1", func() {
 })
 
 var simplePodMultipleV1 = JSONList(
-	"SimplePod", "Holds a list of pods",
+	"SimplePodV1", "Holds a list of pods",
 	simplePodV1,
 	nil,
 	nil)
 
 var simpleDeploymentSingleV1 = JSONSingle(
-	"SimpleDeployment", "Holds a single response to a space/application/deployment request",
+	"SimpleDeploymentV1", "Holds a single response to a space/application/deployment request",
 	simpleDeploymentV1,
 	nil)
 
 var simpleDeploymentStatsSingleV1 = JSONSingle(
-	"SimpleDeploymentStats", "Holds a single response to a space/application/deployment/stats request",
+	"SimpleDeploymentStatsV1", "Holds a single response to a space/application/deployment/stats request",
 	simpleDeploymentStatsV1,
 	nil)
 
 var simpleDeploymentStatSeriesSingleV1 = JSONSingle(
-	"SimpleDeploymentStatSeries", "HOlds a response to a stat series query",
+	"SimpleDeploymentStatSeriesV1", "HOlds a response to a stat series query",
 	simpleDeploymentStatSeriesV1,
 	nil)
 
 var simpleEnvironmentStatSingleV1 = JSONSingle(
-	"EnvStats", "Holds a single response to a pipeline/stats request",
+	"EnvStatsV1", "Holds a single response to a pipeline/stats request",
 	envStatsV1,
 	nil)
 


### PR DESCRIPTION
This patch renames some more types that were missed in PR #1868

When merging the JSON-API code, some more duplicate type names / function names were found.