### PR TITLE
Expose additional cluster URLs from tenant service

### DIFF
--- a/controller/user_service.go
+++ b/controller/user_service.go
@@ -52,13 +52,16 @@ func convert(t *tenant.TenantSingle) *app.UserServiceSingle {
 	var ns []*app.NamespaceAttributes
 	for _, tn := range t.Data.Attributes.Namespaces {
 		ns = append(ns, &app.NamespaceAttributes{
-			CreatedAt:  tn.CreatedAt,
-			UpdatedAt:  tn.UpdatedAt,
-			Name:       tn.Name,
-			State:      tn.State,
-			Version:    tn.Version,
-			Type:       tn.Type,
-			ClusterURL: tn.ClusterURL,
+			CreatedAt:         tn.CreatedAt,
+			UpdatedAt:         tn.UpdatedAt,
+			Name:              tn.Name,
+			State:             tn.State,
+			Version:           tn.Version,
+			Type:              tn.Type,
+			ClusterURL:        tn.ClusterURL,
+			ClusterConsoleURL: tn.ClusterConsoleURL,
+			ClusterMetricsURL: tn.ClusterMetricsURL,
+			ClusterAppDomain:  tn.ClusterAppDomain,
 		})
 	}
 	id := uuid.UUID(*t.Data.ID)

--- a/design/user_service.go
+++ b/design/user_service.go
@@ -44,6 +44,12 @@ var namespaceAttributes = a.Type("NamespaceAttributes", func() {
 	})
 	a.Attribute("cluster-url", d.String, "The cluster url", func() {
 	})
+	a.Attribute("cluster-console-url", d.String, "The cluster console url", func() {
+	})
+	a.Attribute("cluster-metrics-url", d.String, "The cluster metrics url", func() {
+	})
+	a.Attribute("cluster-app-domain", d.String, "The cluster app domain", func() {
+	})
 	a.Attribute("type", d.String, "The tenant namespaces", func() {
 		a.Enum("che", "jenkins", "stage", "test", "run")
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0be95f5803d025af2b443969c3ce1ee5075b16472021c2c12e07ccb7a7883317
-updated: 2018-01-28T17:29:26.874439733+01:00
+hash: 07b8ab33e5b3fdecf96b31fdd29b307f872dc87d657a83094368cff81d335d90
+updated: 2018-01-29T05:14:18.625729376+01:00
 imports:
 - name: github.com/ajg/form
   version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
@@ -64,7 +64,7 @@ imports:
   subpackages:
   - design
 - name: github.com/fabric8-services/fabric8-tenant
-  version: 5ce38dea6287d9bac7789a8bc24556867a4fcee6
+  version: 284c295d606b71447bd5f9831f1b5fb6f899a2d4
   subpackages:
   - design
 - name: github.com/fatih/structs

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,7 @@ homepage: https://github.com/fabric8-services/fabric8-wit
 license: Apache-2.0
 import:
 - package: github.com/fabric8-services/fabric8-tenant
+  version: 284c295d606b71447bd5f9831f1b5fb6f899a2d4
   subpackages:
   - design
 - package: github.com/fabric8-services/fabric8-notification


### PR DESCRIPTION
URLs used by UI, Proxy, Che etc to handle a multi-cluster
setup.

Fixes #1859