### PR TITLE
Add close method to release Hawkular resources

### DIFF
--- a/controller/apps.go
+++ b/controller/apps.go
@@ -26,6 +26,17 @@ import (
 type AppsController struct {
 	*goa.Controller
 	Config *configuration.Registry
+	KubeClientGetter
+}
+
+// KubeClientGetter creates an instance of KubeClientInterface
+type KubeClientGetter interface {
+	GetKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error)
+}
+
+// Default implementation of KubeClientGetter used by NewAppsController
+type defaultKubeClientGetter struct {
+	config *configuration.Registry
 }
 
 // NewAppsController creates a apps controller.
@@ -33,6 +44,9 @@ func NewAppsController(service *goa.Service, config *configuration.Registry) *Ap
 	return &AppsController{
 		Controller: service.NewController("AppsController"),
 		Config:     config,
+		KubeClientGetter: &defaultKubeClientGetter{
+			config: config,
+		},
 	}
 }
 
@@ -146,12 +160,11 @@ func getTokenDataV1(authClient authservice.Client, ctx context.Context, forServi
 	return &respType, nil
 }
 
-// getKubeClient createa kube client for the appropriate cluster assigned to the current user.
-// many different errors are possible, so controllers should call getAndCheckKubeClient() instead
-func (c *AppsController) getKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
+// GetKubeClient creates a kube client for the appropriate cluster assigned to the current user
+func (g *defaultKubeClientGetter) GetKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
 
 	// create Auth API client
-	authClient, err := auth.CreateClient(ctx, c.Config)
+	authClient, err := auth.CreateClient(ctx, g.config)
 	if err != nil {
 		log.Error(ctx, nil, "error accessing Auth server"+tostring(err))
 		return nil, err
@@ -205,7 +218,8 @@ func (c *AppsController) SetDeployment(ctx *app.SetDeploymentAppsContext) error 
 		return witerrors.NewBadParameterError("podCount", "missing")
 	}
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -247,7 +261,8 @@ func (c *AppsController) ShowDeploymentStatSeries(ctx *app.ShowDeploymentStatSer
 		return witerrors.NewBadParameterError("end", *ctx.End)
 	}
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -279,7 +294,8 @@ func convertToTime(unixMillis int64) time.Time {
 // ShowDeploymentStats runs the showDeploymentStats action.
 func (c *AppsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsAppsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -315,7 +331,8 @@ func (c *AppsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsAppsCon
 // ShowEnvironment runs the showEnvironment action.
 func (c *AppsController) ShowEnvironment(ctx *app.ShowEnvironmentAppsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -338,7 +355,8 @@ func (c *AppsController) ShowEnvironment(ctx *app.ShowEnvironmentAppsContext) er
 // ShowSpace runs the showSpace action.
 func (c *AppsController) ShowSpace(ctx *app.ShowSpaceAppsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -367,7 +385,8 @@ func (c *AppsController) ShowSpace(ctx *app.ShowSpaceAppsContext) error {
 // ShowSpaceApp runs the showSpaceApp action.
 func (c *AppsController) ShowSpaceApp(ctx *app.ShowSpaceAppAppsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -395,7 +414,8 @@ func (c *AppsController) ShowSpaceApp(ctx *app.ShowSpaceAppAppsContext) error {
 // ShowSpaceAppDeployment runs the showSpaceAppDeployment action.
 func (c *AppsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDeploymentAppsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -423,7 +443,8 @@ func (c *AppsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDeploymentA
 // ShowEnvAppPods runs the showEnvAppPods action.
 func (c *AppsController) ShowEnvAppPods(ctx *app.ShowEnvAppPodsAppsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -443,7 +464,8 @@ func (c *AppsController) ShowEnvAppPods(ctx *app.ShowEnvAppPodsAppsContext) erro
 // ShowSpaceEnvironments runs the showSpaceEnvironments action.
 func (c *AppsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironmentsAppsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -461,4 +483,10 @@ func (c *AppsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironmentsApp
 	}
 
 	return ctx.OK(res)
+}
+
+func cleanup(kc kubernetesV1.KubeClientInterface) {
+	if kc != nil {
+		kc.Close()
+	}
 }

--- a/controller/apps_blackbox_test.go
+++ b/controller/apps_blackbox_test.go
@@ -1,0 +1,93 @@
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabric8-services/fabric8-wit/app"
+	"github.com/fabric8-services/fabric8-wit/controller"
+	"github.com/fabric8-services/fabric8-wit/kubernetesV1"
+)
+
+type testKubeClient struct {
+	closed bool
+	// Don't implement methods we don't yet need
+	kubernetesV1.KubeClientInterface
+}
+
+func (kc *testKubeClient) Close() {
+	kc.closed = true
+}
+
+type testKubeClientGetter struct {
+	client *testKubeClient
+}
+
+func (g *testKubeClientGetter) GetKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
+	// Overwrites previous clients created by this getter
+	g.client = &testKubeClient{}
+	// Also return an error to avoid executing remainder of calling method
+	return g.client, errors.New("Test")
+}
+
+func TestAPIMethodsCloseKube(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method func(*controller.AppsController) error
+	}{
+		{"SetDeployment", func(ctrl *controller.AppsController) error {
+			count := 1
+			ctx := &app.SetDeploymentAppsContext{
+				PodCount: &count,
+			}
+			return ctrl.SetDeployment(ctx)
+		}},
+		{"ShowDeploymentStatSeries", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowDeploymentStatSeriesAppsContext{}
+			return ctrl.ShowDeploymentStatSeries(ctx)
+		}},
+		{"ShowDeploymentStats", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowDeploymentStatsAppsContext{}
+			return ctrl.ShowDeploymentStats(ctx)
+		}},
+		{"ShowEnvironment", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowEnvironmentAppsContext{}
+			return ctrl.ShowEnvironment(ctx)
+		}},
+		{"ShowSpace", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowSpaceAppsContext{}
+			return ctrl.ShowSpace(ctx)
+		}},
+		{"ShowSpaceApp", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowSpaceAppAppsContext{}
+			return ctrl.ShowSpaceApp(ctx)
+		}},
+		{"ShowSpaceAppDeployment", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowSpaceAppDeploymentAppsContext{}
+			return ctrl.ShowSpaceAppDeployment(ctx)
+		}},
+		{"ShowEnvAppPods", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowEnvAppPodsAppsContext{}
+			return ctrl.ShowEnvAppPods(ctx)
+		}},
+		{"ShowSpaceEnvironments", func(ctrl *controller.AppsController) error {
+			ctx := &app.ShowSpaceEnvironmentsAppsContext{}
+			return ctrl.ShowSpaceEnvironments(ctx)
+		}},
+	}
+	// Check that each API method creating a KubeClientInterface also closes it
+	getter := &testKubeClientGetter{}
+	controller := &controller.AppsController{
+		KubeClientGetter: getter,
+	}
+	for _, testCase := range testCases {
+		err := testCase.method(controller)
+		assert.Error(t, err, "Expected error \"Test\": "+testCase.name)
+		// Check Close was called before returning
+		assert.NotNil(t, getter.client, "No Kube client created: "+testCase.name)
+		assert.True(t, getter.client.closed, "Kube client not closed: "+testCase.name)
+	}
+}

--- a/kubernetesV1/apps_kubeclient.go
+++ b/kubernetesV1/apps_kubeclient.go
@@ -68,6 +68,7 @@ type KubeClientInterface interface {
 	GetEnvironments() ([]*app.SimpleEnvironmentV1, error)
 	GetEnvironment(envName string) (*app.SimpleEnvironmentV1, error)
 	GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error)
+	Close()
 }
 
 type kubeClient struct {
@@ -153,6 +154,12 @@ func (*defaultGetter) GetKubeRESTAPI(config *KubeClientConfig) (KubeRESTAPI, err
 
 func (*defaultGetter) GetMetrics(config *MetricsClientConfig) (MetricsInterface, error) {
 	return NewMetricsClient(config)
+}
+
+// Close releases any resources held by this KubeClientInterface
+func (kc *kubeClient) Close() {
+	// Metrics client needs to be closed to stop Hawkular go-routine from spinning
+	kc.MetricsInterface.Close()
 }
 
 // GetSpace returns a space matching the provided name, containing all applications that belong to it


### PR DESCRIPTION
This PR fixes a resource leak caused by creating a new Hawkular go-routine each time the Deployments API is invoked. See #https://github.com/openshiftio/openshift.io/issues/2087 for more details.

The main change is adding a new Close method to KubeClientInterface, which the apps controller uses when finished with a particular client instance. I have added tests to verify that each Deployments API method invokes Close before returning.


