### PR TITLE
Returns workitem children list according to order of execution

### DIFF
--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -426,7 +426,7 @@ func (r *GormWorkItemLinkRepository) ListWorkItemChildren(ctx context.Context, p
 		}
 		db = db.Limit(*limit)
 	}
-	db = db.Select("count(*) over () as cnt2 , *")
+	db = db.Select("count(*) over () as cnt2 , *").Order("execution_order desc")
 
 	rows, err := db.Rows()
 	if err != nil {

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -82,9 +82,14 @@ func (s *linkRepoBlackBoxTest) TestChildrenOrderOfExecution() {
 		require.NoError(t, err)
 		require.Len(t, res, 3)
 
-		assert.Equal(t, fxt.WorkItems[1].Fields[workitem.SystemOrder], res[2].Fields[workitem.SystemOrder].(float64))
-		assert.Equal(t, fxt.WorkItems[2].Fields[workitem.SystemOrder], res[1].Fields[workitem.SystemOrder].(float64))
-		assert.Equal(t, fxt.WorkItems[3].Fields[workitem.SystemOrder], res[0].Fields[workitem.SystemOrder].(float64))
+		var expectedOrder []interface{}
+		for i := 1; i < 4; i++ {
+			expectedOrder = append(expectedOrder, fxt.WorkItems[i].Fields[workitem.SystemOrder])
+		}
+		for i, v := range expectedOrder {
+			i = len(expectedOrder) - 1 - i
+			require.Equal(t, v, res[i].Fields[workitem.SystemOrder])
+		}
 	})
 }
 

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -63,38 +63,6 @@ func (s *linkRepoBlackBoxTest) TestList() {
 	})
 }
 
-func (s *linkRepoBlackBoxTest) TestChildrenOrderOfExecution() {
-	// tests order of workitem children returned by list is according to the
-	// "order of execution" specified
-	s.T().Run("ok - child work items order", func(t *testing.T) {
-		fxt := tf.NewTestFixture(t, s.DB,
-			tf.WorkItems(4), // parent + child 1-3
-			tf.WorkItemLinkTypes(1, func(fxt *tf.TestFixture, idx int) error {
-				fxt.WorkItemLinkTypes[idx].ForwardName = "parent of"
-				return nil
-			}),
-			tf.WorkItemLinks(3, func(fxt *tf.TestFixture, idx int) error {
-				fxt.WorkItemLinks[idx].SourceID = fxt.WorkItems[0].ID
-				fxt.WorkItemLinks[idx].TargetID = fxt.WorkItems[idx+1].ID
-				return nil
-			}),
-		)
-
-		res, _, err := s.workitemLinkRepo.ListWorkItemChildren(s.Ctx, fxt.WorkItems[0].ID, nil, nil)
-		require.NoError(t, err)
-		require.Len(t, res, 3)
-
-		var expectedOrder []interface{}
-		for i := 1; i < 4; i++ {
-			expectedOrder = append(expectedOrder, fxt.WorkItems[i].Fields[workitem.SystemOrder])
-		}
-		for i, v := range expectedOrder {
-			i = len(expectedOrder) - 1 - i
-			require.Equal(t, v, res[i].Fields[workitem.SystemOrder])
-		}
-	})
-}
-
 func (s *linkRepoBlackBoxTest) TestChildrenReorderAbove() {
 	s.T().Run("ok - child work items reorder above", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB,

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -64,6 +64,7 @@ func (s *linkRepoBlackBoxTest) TestList() {
 }
 
 func (s *linkRepoBlackBoxTest) TestChildrenReorderAbove() {
+	// Tests reorder child work item above
 	s.T().Run("ok - child work items reorder above", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB,
 			tf.Identities(1),
@@ -97,6 +98,7 @@ func (s *linkRepoBlackBoxTest) TestChildrenReorderAbove() {
 }
 
 func (s *linkRepoBlackBoxTest) TestChildrenReorderBelow() {
+	// Tests reorder child work item below
 	s.T().Run("ok - child work items reorder below", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB,
 			tf.Identities(1),
@@ -130,6 +132,7 @@ func (s *linkRepoBlackBoxTest) TestChildrenReorderBelow() {
 }
 
 func (s *linkRepoBlackBoxTest) TestChildrenReorderTop() {
+	// Tests reorder child work item top
 	s.T().Run("ok - child work items reorder top", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB,
 			tf.Identities(1),
@@ -163,6 +166,7 @@ func (s *linkRepoBlackBoxTest) TestChildrenReorderTop() {
 }
 
 func (s *linkRepoBlackBoxTest) TestChildrenReorderBottom() {
+	// Tests reorder child work item bottom
 	s.T().Run("ok - child work items reorder bottom", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB,
 			tf.Identities(1),

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -161,6 +161,72 @@ func (s *linkRepoBlackBoxTest) TestChildrenReorderBelow() {
 	})
 }
 
+func (s *linkRepoBlackBoxTest) TestChildrenReorderTop() {
+	s.T().Run("ok - child work items reorder top", func(t *testing.T) {
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.Identities(1),
+			tf.Spaces(1),
+			tf.WorkItems(3), // parent + child 1-2
+			tf.WorkItemLinkTypes(1, func(fxt *tf.TestFixture, idx int) error {
+				fxt.WorkItemLinkTypes[idx].ForwardName = "parent of"
+				return nil
+			}),
+			tf.WorkItemLinks(2, func(fxt *tf.TestFixture, idx int) error {
+				fxt.WorkItemLinks[idx].SourceID = fxt.WorkItems[0].ID
+				fxt.WorkItemLinks[idx].TargetID = fxt.WorkItems[idx+1].ID
+				return nil
+			}),
+		)
+		s.workitemRepo.Reorder(s.Ctx, fxt.Spaces[0].ID, workitem.DirectionTop, nil, *fxt.WorkItems[2], fxt.Identities[0].ID)
+
+		res, _, err := s.workitemLinkRepo.ListWorkItemChildren(s.Ctx, fxt.WorkItems[0].ID, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+
+		var expectedOrder []interface{}
+		for i := 1; i < 3; i++ {
+			expectedOrder = append(expectedOrder, fxt.WorkItems[i].ID)
+		}
+		for i, v := range expectedOrder {
+			i = len(expectedOrder) - 1 - i
+			require.Equal(t, v, res[i].ID)
+		}
+	})
+}
+
+func (s *linkRepoBlackBoxTest) TestChildrenReorderBottom() {
+	s.T().Run("ok - child work items reorder bottom", func(t *testing.T) {
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.Identities(1),
+			tf.Spaces(1),
+			tf.WorkItems(3), // parent + child 1-2
+			tf.WorkItemLinkTypes(1, func(fxt *tf.TestFixture, idx int) error {
+				fxt.WorkItemLinkTypes[idx].ForwardName = "parent of"
+				return nil
+			}),
+			tf.WorkItemLinks(2, func(fxt *tf.TestFixture, idx int) error {
+				fxt.WorkItemLinks[idx].SourceID = fxt.WorkItems[0].ID
+				fxt.WorkItemLinks[idx].TargetID = fxt.WorkItems[idx+1].ID
+				return nil
+			}),
+		)
+		s.workitemRepo.Reorder(s.Ctx, fxt.Spaces[0].ID, workitem.DirectionBottom, nil, *fxt.WorkItems[1], fxt.Identities[0].ID)
+
+		res, _, err := s.workitemLinkRepo.ListWorkItemChildren(s.Ctx, fxt.WorkItems[0].ID, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+
+		var expectedOrder []interface{}
+		for i := 1; i < 3; i++ {
+			expectedOrder = append(expectedOrder, fxt.WorkItems[i].ID)
+		}
+		for i, v := range expectedOrder {
+			i = len(expectedOrder) - 1 - i
+			require.Equal(t, v, res[i].ID)
+		}
+	})
+}
+
 func (s *linkRepoBlackBoxTest) TestWorkItemHasChildren() {
 	s.T().Run("work item has no child after deletion", func(t *testing.T) {
 		// given a work item link


### PR DESCRIPTION
* fixes #1846
* Adds tests for workitem children reorder 