### PR TITLE
List ancestor IDs in search results

### DIFF
--- a/controller/search.go
+++ b/controller/search.go
@@ -201,6 +201,9 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 			sortedAncestorIDs := make(id.Slice, len(ancestorIDs))
 			i := 0
 			for _, wi := range response.Data {
+				if len(ancestorIDs) <= 0 {
+					break
+				}
 				_, ok := ancestorIDs[*wi.ID]
 				if ok {
 					sortedAncestorIDs[i] = *wi.ID
@@ -209,6 +212,9 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 				}
 			}
 			for _, ifObj := range response.Included {
+				if len(ancestorIDs) <= 0 {
+					break
+				}
 				var wi *app.WorkItem
 				switch v := ifObj.(type) {
 				case app.WorkItem:

--- a/controller/test-files/search/show/in_topology_A-B-C-D_and_B-E_search_for_B_and_C/include_children.res.payload.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C-D_and_B-E_search_for_B_and_C/include_children.res.payload.golden.json
@@ -325,6 +325,10 @@
     "last": "http:///api/search?page[offset]=0\u0026page[limit]=20\u0026filter[expression]={\"$AND\":[{\"space\":\"00000000-0000-0000-0000-000000000003\"}, {\"$OR\": [{\"title\":\"B\"}, {\"title\":\"C\"}]}], \"$OPTS\":{\"tree-view\": true}}"
   },
   "meta": {
+    "ancestorIDs": [
+      "00000000-0000-0000-0000-000000000001",
+      "00000000-0000-0000-0000-000000000005"
+    ],
     "totalCount": 2
   }
 }

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B,C_with_tree-view=true.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B,C_with_tree-view=true.res.golden.json
@@ -246,6 +246,10 @@
     "last": "http:///api/search?page[offset]=0\u0026page[limit]=20\u0026filter[expression]={\"$AND\": [{\"$OR\": [{\"title\":\"C\"}, {\"title\":\"B\"}]}, {\"space\": \"00000000-0000-0000-0000-000000000003\"}],\"$OPTS\":{\"tree-view\": true}}"
   },
   "meta": {
+    "ancestorIDs": [
+      "00000000-0000-0000-0000-000000000001",
+      "00000000-0000-0000-0000-000000000005"
+    ],
     "totalCount": 2
   }
 }

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B_with_tree-view=true.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B_with_tree-view=true.res.golden.json
@@ -164,6 +164,9 @@
     "last": "http:///api/search?page[offset]=0\u0026page[limit]=20\u0026filter[expression]={\"$AND\": [{\"title\":\"B\"}, {\"space\": \"00000000-0000-0000-0000-000000000003\"}],\"$OPTS\":{\"tree-view\": true}}"
   },
   "meta": {
+    "ancestorIDs": [
+      "00000000-0000-0000-0000-000000000005"
+    ],
     "totalCount": 1
   }
 }

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/C_with_tree-view=true.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/C_with_tree-view=true.res.golden.json
@@ -243,6 +243,10 @@
     "last": "http:///api/search?page[offset]=0\u0026page[limit]=20\u0026filter[expression]={\"$AND\": [{\"title\":\"C\"}, {\"space\": \"00000000-0000-0000-0000-000000000003\"}],\"$OPTS\":{\"tree-view\": true}}"
   },
   "meta": {
+    "ancestorIDs": [
+      "00000000-0000-0000-0000-000000000006",
+      "00000000-0000-0000-0000-000000000005"
+    ],
     "totalCount": 1
   }
 }

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/D_with_tree-view=true.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/D_with_tree-view=true.res.golden.json
@@ -164,6 +164,9 @@
     "last": "http:///api/search?page[offset]=0\u0026page[limit]=20\u0026filter[expression]={\"$AND\": [{\"title\":\"D\"}, {\"space\": \"00000000-0000-0000-0000-000000000003\"}],\"$OPTS\":{\"tree-view\": true}}"
   },
   "meta": {
+    "ancestorIDs": [
+      "00000000-0000-0000-0000-000000000005"
+    ],
     "totalCount": 1
   }
 }

--- a/design/media_types.go
+++ b/design/media_types.go
@@ -33,6 +33,7 @@ var pagingLinks = a.Type("pagingLinks", func() {
 
 var meta = a.Type("workItemListResponseMeta", func() {
 	a.Attribute("totalCount", d.Integer)
+	a.Attribute("ancestorIDs", a.ArrayOf(d.UUID), "array of work item IDs in the \"included\" array that are ancestors")
 	a.Required("totalCount")
 })
 


### PR DESCRIPTION
The UI team asked for this because since 3e88355c2b8a081660d95b923e31e3a6b4e00520 we put ancestors and siblings to matches in the "included" array. The ancestors will be shown expanded in the UI whereas the siblings don't. But that's just UI work.

Co-authored-by: Pranav Gore <pranavgore09@gmail.com>