### PR TITLE
Port Hawkular close fix to deployments controller

### DIFF
--- a/controller/apps.go
+++ b/controller/apps.go
@@ -27,16 +27,16 @@ import (
 type AppsController struct {
 	*goa.Controller
 	Config *configuration.Registry
-	KubeClientGetter
+	KubeClientGetterV1
 }
 
-// KubeClientGetter creates an instance of KubeClientInterface
-type KubeClientGetter interface {
-	GetKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error)
+// KubeClientGetterV1 creates an instance of KubeClientInterface
+type KubeClientGetterV1 interface {
+	GetKubeClientV1(ctx context.Context) (kubernetesV1.KubeClientInterface, error)
 }
 
 // Default implementation of KubeClientGetter used by NewAppsController
-type defaultKubeClientGetter struct {
+type defaultKubeClientGetterV1 struct {
 	config *configuration.Registry
 }
 
@@ -45,7 +45,7 @@ func NewAppsController(service *goa.Service, config *configuration.Registry) *Ap
 	return &AppsController{
 		Controller: service.NewController("AppsController"),
 		Config:     config,
-		KubeClientGetter: &defaultKubeClientGetter{
+		KubeClientGetterV1: &defaultKubeClientGetterV1{
 			config: config,
 		},
 	}
@@ -154,7 +154,7 @@ func getTokenDataV1(authClient authservice.Client, ctx context.Context, forServi
 }
 
 // GetKubeClient creates a kube client for the appropriate cluster assigned to the current user
-func (g *defaultKubeClientGetter) GetKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
+func (g *defaultKubeClientGetterV1) GetKubeClientV1(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
 
 	// create Auth API client
 	authClient, err := auth.CreateClient(ctx, g.config)
@@ -211,8 +211,8 @@ func (c *AppsController) SetDeployment(ctx *app.SetDeploymentAppsContext) error 
 		return witerrors.NewBadParameterError("podCount", "missing")
 	}
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -254,8 +254,8 @@ func (c *AppsController) ShowDeploymentStatSeries(ctx *app.ShowDeploymentStatSer
 		return witerrors.NewBadParameterError("end", *ctx.End)
 	}
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -283,8 +283,8 @@ func (c *AppsController) ShowDeploymentStatSeries(ctx *app.ShowDeploymentStatSer
 // ShowDeploymentStats runs the showDeploymentStats action.
 func (c *AppsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsAppsContext) error {
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -320,8 +320,8 @@ func (c *AppsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsAppsCon
 // ShowEnvironment runs the showEnvironment action.
 func (c *AppsController) ShowEnvironment(ctx *app.ShowEnvironmentAppsContext) error {
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -344,8 +344,8 @@ func (c *AppsController) ShowEnvironment(ctx *app.ShowEnvironmentAppsContext) er
 // ShowSpace runs the showSpace action.
 func (c *AppsController) ShowSpace(ctx *app.ShowSpaceAppsContext) error {
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -374,8 +374,8 @@ func (c *AppsController) ShowSpace(ctx *app.ShowSpaceAppsContext) error {
 // ShowSpaceApp runs the showSpaceApp action.
 func (c *AppsController) ShowSpaceApp(ctx *app.ShowSpaceAppAppsContext) error {
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -403,8 +403,8 @@ func (c *AppsController) ShowSpaceApp(ctx *app.ShowSpaceAppAppsContext) error {
 // ShowSpaceAppDeployment runs the showSpaceAppDeployment action.
 func (c *AppsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDeploymentAppsContext) error {
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -432,8 +432,8 @@ func (c *AppsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDeploymentA
 // ShowEnvAppPods runs the showEnvAppPods action.
 func (c *AppsController) ShowEnvAppPods(ctx *app.ShowEnvAppPodsAppsContext) error {
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -453,8 +453,8 @@ func (c *AppsController) ShowEnvAppPods(ctx *app.ShowEnvAppPodsAppsContext) erro
 // ShowSpaceEnvironments runs the showSpaceEnvironments action.
 func (c *AppsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironmentsAppsContext) error {
 
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
+	kc, err := c.GetKubeClientV1(ctx)
+	defer cleanupV1(kc)
 	if err != nil {
 		return witerrors.NewUnauthorizedError("openshift token")
 	}
@@ -474,7 +474,7 @@ func (c *AppsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironmentsApp
 	return ctx.OK(res)
 }
 
-func cleanup(kc kubernetesV1.KubeClientInterface) {
+func cleanupV1(kc kubernetesV1.KubeClientInterface) {
 	if kc != nil {
 		kc.Close()
 	}

--- a/controller/apps_blackbox_test.go
+++ b/controller/apps_blackbox_test.go
@@ -12,28 +12,28 @@ import (
 	"github.com/fabric8-services/fabric8-wit/kubernetesV1"
 )
 
-type testKubeClient struct {
+type testKubeClientV1 struct {
 	closed bool
 	// Don't implement methods we don't yet need
 	kubernetesV1.KubeClientInterface
 }
 
-func (kc *testKubeClient) Close() {
+func (kc *testKubeClientV1) Close() {
 	kc.closed = true
 }
 
-type testKubeClientGetter struct {
-	client *testKubeClient
+type testKubeClientGetterV1 struct {
+	client *testKubeClientV1
 }
 
-func (g *testKubeClientGetter) GetKubeClient(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
+func (g *testKubeClientGetterV1) GetKubeClientV1(ctx context.Context) (kubernetesV1.KubeClientInterface, error) {
 	// Overwrites previous clients created by this getter
-	g.client = &testKubeClient{}
+	g.client = &testKubeClientV1{}
 	// Also return an error to avoid executing remainder of calling method
 	return g.client, errors.New("Test")
 }
 
-func TestAPIMethodsCloseKube(t *testing.T) {
+func TestAPIMethodsCloseKubeV1(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method func(*controller.AppsController) error
@@ -79,9 +79,9 @@ func TestAPIMethodsCloseKube(t *testing.T) {
 		}},
 	}
 	// Check that each API method creating a KubeClientInterface also closes it
-	getter := &testKubeClientGetter{}
+	getter := &testKubeClientGetterV1{}
 	controller := &controller.AppsController{
-		KubeClientGetter: getter,
+		KubeClientGetterV1: getter,
 	}
 	for _, testCase := range testCases {
 		err := testCase.method(controller)

--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -26,6 +26,17 @@ import (
 type DeploymentsController struct {
 	*goa.Controller
 	Config *configuration.Registry
+	KubeClientGetter
+}
+
+// KubeClientGetter creates an instance of KubeClientInterface
+type KubeClientGetter interface {
+	GetKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error)
+}
+
+// Default implementation of KubeClientGetter used by NewDeploymentsController
+type defaultKubeClientGetter struct {
+	config *configuration.Registry
 }
 
 // NewDeploymentsController creates a deployments controller.
@@ -33,6 +44,9 @@ func NewDeploymentsController(service *goa.Service, config *configuration.Regist
 	return &DeploymentsController{
 		Controller: service.NewController("DeploymentsController"),
 		Config:     config,
+		KubeClientGetter: &defaultKubeClientGetter{
+			config: config,
+		},
 	}
 }
 
@@ -147,12 +161,11 @@ func getTokenData(ctx context.Context, authClient authservice.Client, forService
 	return &respType, nil
 }
 
-// getKubeClient createa kube client for the appropriate cluster assigned to the current user.
-// many different errors are possible, so controllers should call getAndCheckKubeClient() instead
-func (c *DeploymentsController) getKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
+// GetKubeClient creates a kube client for the appropriate cluster assigned to the current user
+func (g *defaultKubeClientGetter) GetKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
 
 	// create Auth API client
-	authClient, err := auth.CreateClient(ctx, c.Config)
+	authClient, err := auth.CreateClient(ctx, g.config)
 	if err != nil {
 		log.Error(ctx, nil, "error accessing Auth server %s", tostring(err))
 		return nil, errs.Wrapf(err, "error creating Auth client")
@@ -206,7 +219,8 @@ func (c *DeploymentsController) SetDeployment(ctx *app.SetDeploymentDeploymentsC
 		return errors.NewBadParameterError("podCount", "missing")
 	}
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -248,7 +262,8 @@ func (c *DeploymentsController) ShowDeploymentStatSeries(ctx *app.ShowDeployment
 		return errors.NewBadParameterError("end", *ctx.End)
 	}
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -280,7 +295,8 @@ func convertToTime(unixMillis int64) time.Time {
 // ShowDeploymentStats runs the showDeploymentStats action.
 func (c *DeploymentsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsDeploymentsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -318,7 +334,8 @@ func (c *DeploymentsController) ShowDeploymentStats(ctx *app.ShowDeploymentStats
 // ShowEnvironment runs the showEnvironment action.
 func (c *DeploymentsController) ShowEnvironment(ctx *app.ShowEnvironmentDeploymentsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -343,7 +360,8 @@ func (c *DeploymentsController) ShowEnvironment(ctx *app.ShowEnvironmentDeployme
 // ShowSpace runs the showSpace action.
 func (c *DeploymentsController) ShowSpace(ctx *app.ShowSpaceDeploymentsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -375,7 +393,8 @@ func (c *DeploymentsController) ShowSpace(ctx *app.ShowSpaceDeploymentsContext) 
 // ShowSpaceApp runs the showSpaceApp action.
 func (c *DeploymentsController) ShowSpaceApp(ctx *app.ShowSpaceAppDeploymentsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -405,7 +424,8 @@ func (c *DeploymentsController) ShowSpaceApp(ctx *app.ShowSpaceAppDeploymentsCon
 // ShowSpaceAppDeployment runs the showSpaceAppDeployment action.
 func (c *DeploymentsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDeploymentDeploymentsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -435,7 +455,8 @@ func (c *DeploymentsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDepl
 // ShowEnvAppPods runs the showEnvAppPods action.
 func (c *DeploymentsController) ShowEnvAppPods(ctx *app.ShowEnvAppPodsDeploymentsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -456,7 +477,8 @@ func (c *DeploymentsController) ShowEnvAppPods(ctx *app.ShowEnvAppPodsDeployment
 // ShowSpaceEnvironments runs the showSpaceEnvironments action.
 func (c *DeploymentsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironmentsDeploymentsContext) error {
 
-	kc, err := c.getKubeClient(ctx)
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
 	if err != nil {
 		return errors.NewUnauthorizedError("openshift token")
 	}
@@ -474,4 +496,10 @@ func (c *DeploymentsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironm
 	}
 
 	return ctx.OK(res)
+}
+
+func cleanup(kc kubernetes.KubeClientInterface) {
+	if kc != nil {
+		kc.Close()
+	}
 }

--- a/controller/deployments_blackbox_test.go
+++ b/controller/deployments_blackbox_test.go
@@ -1,0 +1,93 @@
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabric8-services/fabric8-wit/app"
+	"github.com/fabric8-services/fabric8-wit/controller"
+	"github.com/fabric8-services/fabric8-wit/kubernetes"
+)
+
+type testKubeClient struct {
+	closed bool
+	// Don't implement methods we don't yet need
+	kubernetes.KubeClientInterface
+}
+
+func (kc *testKubeClient) Close() {
+	kc.closed = true
+}
+
+type testKubeClientGetter struct {
+	client *testKubeClient
+}
+
+func (g *testKubeClientGetter) GetKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
+	// Overwrites previous clients created by this getter
+	g.client = &testKubeClient{}
+	// Also return an error to avoid executing remainder of calling method
+	return g.client, errors.New("Test")
+}
+
+func TestAPIMethodsCloseKube(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method func(*controller.DeploymentsController) error
+	}{
+		{"SetDeployment", func(ctrl *controller.DeploymentsController) error {
+			count := 1
+			ctx := &app.SetDeploymentDeploymentsContext{
+				PodCount: &count,
+			}
+			return ctrl.SetDeployment(ctx)
+		}},
+		{"ShowDeploymentStatSeries", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowDeploymentStatSeriesDeploymentsContext{}
+			return ctrl.ShowDeploymentStatSeries(ctx)
+		}},
+		{"ShowDeploymentStats", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowDeploymentStatsDeploymentsContext{}
+			return ctrl.ShowDeploymentStats(ctx)
+		}},
+		{"ShowEnvironment", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowEnvironmentDeploymentsContext{}
+			return ctrl.ShowEnvironment(ctx)
+		}},
+		{"ShowSpace", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowSpaceDeploymentsContext{}
+			return ctrl.ShowSpace(ctx)
+		}},
+		{"ShowSpaceApp", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowSpaceAppDeploymentsContext{}
+			return ctrl.ShowSpaceApp(ctx)
+		}},
+		{"ShowSpaceAppDeployment", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowSpaceAppDeploymentDeploymentsContext{}
+			return ctrl.ShowSpaceAppDeployment(ctx)
+		}},
+		{"ShowEnvAppPods", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowEnvAppPodsDeploymentsContext{}
+			return ctrl.ShowEnvAppPods(ctx)
+		}},
+		{"ShowSpaceEnvironments", func(ctrl *controller.DeploymentsController) error {
+			ctx := &app.ShowSpaceEnvironmentsDeploymentsContext{}
+			return ctrl.ShowSpaceEnvironments(ctx)
+		}},
+	}
+	// Check that each API method creating a KubeClientInterface also closes it
+	getter := &testKubeClientGetter{}
+	controller := &controller.DeploymentsController{
+		KubeClientGetter: getter,
+	}
+	for _, testCase := range testCases {
+		err := testCase.method(controller)
+		assert.Error(t, err, "Expected error \"Test\": "+testCase.name)
+		// Check Close was called before returning
+		assert.NotNil(t, getter.client, "No Kube client created: "+testCase.name)
+		assert.True(t, getter.client.closed, "Kube client not closed: "+testCase.name)
+	}
+}

--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -71,6 +71,7 @@ type KubeClientInterface interface {
 	GetEnvironments() ([]*app.SimpleEnvironment, error)
 	GetEnvironment(envName string) (*app.SimpleEnvironment, error)
 	GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error)
+	Close()
 }
 
 type kubeClient struct {
@@ -166,6 +167,12 @@ func (*defaultGetter) GetKubeRESTAPI(config *KubeClientConfig) (KubeRESTAPI, err
 
 func (*defaultGetter) GetMetrics(config *MetricsClientConfig) (Metrics, error) {
 	return NewMetricsClient(config)
+}
+
+// Close releases any resources held by this KubeClientInterface
+func (kc *kubeClient) Close() {
+	// Metrics client needs to be closed to stop Hawkular go-routine from spinning
+	kc.Metrics.Close()
 }
 
 // GetSpace returns a space matching the provided name, containing all applications that belong to it

--- a/kubernetes/deployments_metrics_blackbox_test.go
+++ b/kubernetes/deployments_metrics_blackbox_test.go
@@ -40,6 +40,7 @@ type testMetricsOutput struct {
 	metricType hawkular.MetricType
 	namespace  string
 	filters    url.Values
+	closed     bool
 }
 
 func (getter *testHawkularGetter) GetHawkularRESTAPI(config *kubernetes.MetricsClientConfig) (kubernetes.HawkularRESTAPI, error) {
@@ -69,6 +70,10 @@ func (helper *testHawkular) ReadBuckets(metricType hawkular.MetricType, namespac
 
 	buckets := helper.getter.input.buckets
 	return buckets, nil
+}
+
+func (helper *testHawkular) Close() {
+	helper.output.closed = true
 }
 
 var singleMetricTestCases []*testMetricsInput = []*testMetricsInput{
@@ -305,6 +310,21 @@ func TestGetNetworkSentRange(t *testing.T) {
 		// Verify the remaining filters
 		verifyMetricRangeFilters(testCase, output.filters, t)
 	}
+}
+
+func TestCloseHawkular(t *testing.T) {
+	test := &testHawkularGetter{}
+	config := &kubernetes.MetricsClientConfig{
+		MetricsURL:     "myMetricsServer",
+		BearerToken:    "token",
+		HawkularGetter: test,
+	}
+	client, err := kubernetes.NewMetricsClient(config)
+	require.NoError(t, err, "Failed to create metrics client")
+
+	// Check that MetricsInterface.Close invokes Hawkular's Client.Close
+	client.Close()
+	require.True(t, test.result.output.closed, "Hawkular client not closed")
 }
 
 func verifyMetrics(metrics []*app.TimedNumberTuple, testCase *testMetricsInput, result *testMetricsOutput,


### PR DESCRIPTION
A new JSON-API compliant version of the "apps" controller named "deployments" was recently added by https://github.com/fabric8-services/fabric8-wit/pull/1870. This new controller also needs the fix to properly release Hawkular resources added by https://github.com/fabric8-services/fabric8-wit/pull/1875.

This PR is simply a port of the above fix, with name conflicts resolved using the "V1" suffix used throughout the older apps controller.