### PR TITLE
openshift.io #1439 Deprecating  '/:codebaseID/edit' Adding '/:codebaseID/workspaces' and returning more workspace data (id / links)

### DIFF
--- a/codebase/che/client.go
+++ b/codebase/che/client.go
@@ -403,7 +403,7 @@ type WorkspaceRequest struct {
 
 // WorkspaceResponse represents a create workspace response body
 type WorkspaceResponse struct {
-	//ID string `json:"id,omitempty"`
+	ID string `json:"id,omitempty"`
 	//	Branch          string `json:"branch"`
 	Description string `json:"description,omitempty"`
 	//	Location        string `json:"location"`
@@ -420,19 +420,30 @@ type WorkspaceConfig struct {
 	Name string `json:"name"`
 }
 
-// GetIDEURL return the link with rel for ide url
-func (w WorkspaceResponse) GetIDEURL() string {
+// GetHrefByRel return the 'href' of 'rel' of WorkspaceLink
+// {
+//   "href": "https://che.prod-preview.openshift.io/user/wksp-0dae",
+//   "rel": "ide url",
+//   "method": "GET"
+// }
+func (w WorkspaceResponse) GetHrefByRelOfWorkspaceLink(rel string) string {
 	for _, l := range w.Links {
-		if l.Rel == "ide url" {
-			return l.HRef
+		if l.Rel == rel {
+			return l.Href
 		}
 	}
 	return ""
 }
 
+// Following const define commonly used WorkspaceLink rel
+const (
+	IdeUrlRel   = "ide url"
+	SelfLinkRel = "self link"
+)
+
 // WorkspaceLink represents a URL for the location of a workspace
 type WorkspaceLink struct {
-	HRef   string `json:"href"`
+	Href   string `json:"href"`
 	Method string `json:"method"`
 	Rel    string `json:"rel"`
 }

--- a/codebase/che/client_test.go
+++ b/codebase/che/client_test.go
@@ -1,0 +1,30 @@
+package che_test
+
+import (
+	"github.com/fabric8-services/fabric8-wit/codebase/che"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCodebaseToMap(t *testing.T) {
+	// Test for 'ide url'
+	hrefIde := "https://che.prod-preview.openshift.io/user/wksp-3a2"
+	methodIde := "GET"
+	relIde := "ide url"
+
+	// Test for 'self link'
+	hrefSelf := "https://che.prod-preview.openshift.io/wsmaster/api/workspace/workspaceij5jeym0zs9ve2q12"
+	methodSelf := "GET"
+	relSelf := "self link"
+
+	workspaceIdeLink := che.WorkspaceLink{hrefIde, methodIde, relIde}
+	workspaceSelfLink := che.WorkspaceLink{hrefSelf, methodSelf, relSelf}
+
+	workspaceResponse := che.WorkspaceResponse{"id", "description", che.WorkspaceConfig{"workspaceName"}, "RUNNING", []che.WorkspaceLink{workspaceIdeLink, workspaceSelfLink}}
+
+	ideLink := workspaceResponse.GetHrefByRelOfWorkspaceLink(che.IdeUrlRel)
+	selfLink := workspaceResponse.GetHrefByRelOfWorkspaceLink(che.SelfLinkRel)
+
+	assert.Equal(t, hrefIde, ideLink)
+	assert.Equal(t, hrefSelf, selfLink)
+}

--- a/controller/test-files/codebase/show/ok_with_stackId.golden.json
+++ b/controller/test-files/codebase/show/ok_with_stackId.golden.json
@@ -23,6 +23,12 @@
           "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
           "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
+      },
+      "workspaces": {
+        "links": {
+          "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces",
+          "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces"
+        }
       }
     },
     "type": "codebases"

--- a/controller/test-files/codebase/show/ok_without_auth.golden.json
+++ b/controller/test-files/codebase/show/ok_without_auth.golden.json
@@ -23,6 +23,12 @@
           "related": "http:///api/spaces/a8bee527-12d2-4aff-9823-3511c1c8e6b9",
           "self": "http:///api/spaces/a8bee527-12d2-4aff-9823-3511c1c8e6b9"
         }
+      },
+      "workspaces": {
+        "links": {
+          "related": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd/workspaces",
+          "self": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd/workspaces"
+        }
       }
     },
     "type": "codebases"

--- a/controller/test-files/codebase/show/ok_without_stackId.golden.json
+++ b/controller/test-files/codebase/show/ok_without_stackId.golden.json
@@ -23,6 +23,12 @@
           "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
           "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
+      },
+      "workspaces": {
+        "links": {
+          "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces",
+          "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces"
+        }
       }
     },
     "type": "codebases"

--- a/controller/test-files/search/search_codebase_per_url_multi_match.json
+++ b/controller/test-files/search/search_codebase_per_url_multi_match.json
@@ -24,6 +24,12 @@
             "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
             "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
           }
+        },
+        "workspaces": {
+          "links": {
+            "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces",
+            "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces"
+          }
         }
       },
       "type": "codebases"
@@ -51,6 +57,12 @@
           "links": {
             "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
             "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
+          }
+        },
+        "workspaces": {
+          "links": {
+            "related": "http:///api/codebases/00000000-0000-0000-0000-000000000003/workspaces",
+            "self": "http:///api/codebases/00000000-0000-0000-0000-000000000003/workspaces"
           }
         }
       },
@@ -80,6 +92,12 @@
             "related": "http:///api/spaces/00000000-0000-0000-0000-000000000006",
             "self": "http:///api/spaces/00000000-0000-0000-0000-000000000006"
           }
+        },
+        "workspaces": {
+          "links": {
+            "related": "http:///api/codebases/00000000-0000-0000-0000-000000000005/workspaces",
+            "self": "http:///api/codebases/00000000-0000-0000-0000-000000000005/workspaces"
+          }
         }
       },
       "type": "codebases"
@@ -108,6 +126,12 @@
             "related": "http:///api/spaces/00000000-0000-0000-0000-000000000008",
             "self": "http:///api/spaces/00000000-0000-0000-0000-000000000008"
           }
+        },
+        "workspaces": {
+          "links": {
+            "related": "http:///api/codebases/00000000-0000-0000-0000-000000000007/workspaces",
+            "self": "http:///api/codebases/00000000-0000-0000-0000-000000000007/workspaces"
+          }
         }
       },
       "type": "codebases"
@@ -135,6 +159,12 @@
           "links": {
             "related": "http:///api/spaces/00000000-0000-0000-0000-000000000010",
             "self": "http:///api/spaces/00000000-0000-0000-0000-000000000010"
+          }
+        },
+        "workspaces": {
+          "links": {
+            "related": "http:///api/codebases/00000000-0000-0000-0000-000000000009/workspaces",
+            "self": "http:///api/codebases/00000000-0000-0000-0000-000000000009/workspaces"
           }
         }
       },

--- a/controller/test-files/search/search_codebase_per_url_single_match.json
+++ b/controller/test-files/search/search_codebase_per_url_single_match.json
@@ -24,6 +24,12 @@
             "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
             "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
           }
+        },
+        "workspaces": {
+          "links": {
+            "related": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces",
+            "self": "http:///api/codebases/00000000-0000-0000-0000-000000000001/workspaces"
+          }
         }
       },
       "type": "codebases"

--- a/design/codebases.go
+++ b/design/codebases.go
@@ -42,8 +42,10 @@ var codebaseLinks = a.Type("CodebaseLinks", func() {
 	a.UseTrait("GenericLinksTrait")
 	a.Attribute("edit", d.String)
 })
+
 var codebaseRelationships = a.Type("CodebaseRelations", func() {
 	a.Attribute("space", relationGeneric, "This defines the owning space")
+	a.Attribute("workspaces", relationGeneric, "This defines the dependent workspaces")
 })
 
 var codebaseListMeta = a.Type("CodebaseListMeta", func() {
@@ -63,10 +65,13 @@ var workspace = a.Type("Workspace", func() {
 
 var workspaceAttributes = a.Type("WorkspaceAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a workspace. +See also see http://jsonapi.org/format/#document-resource-object-attributes`)
+	a.Attribute("id", d.String, "The workspace id", func() {
+		a.Example("workspacephly8l91tqg0u08x")
+	})
 	a.Attribute("name", d.String, "The workspace name", func() {
 		a.Example("test")
 	})
-	a.Attribute("description", d.String, "The URL of the codebase ", func() {
+	a.Attribute("description", d.String, "The workspace description", func() {
 		a.Example("")
 	})
 	a.Attribute("status", d.String, "The workspace status", func() {
@@ -75,7 +80,15 @@ var workspaceAttributes = a.Type("WorkspaceAttributes", func() {
 })
 
 var workspaceLinks = a.Type("WorkspaceLinks", func() {
-	a.Attribute("open", d.String)
+	a.Attribute("open", d.String, "The workspace 'open' link", func() {
+		a.Example("http://localhost:8080/wsmaster/api/workspace/workspace28t00rschopreajr")
+	})
+	a.Attribute("self", d.String, "The workspace 'self' link", func() {
+		a.Example("http://localhost:8080/wsmaster/api/workspace/workspace28t00rschopreajr")
+	})
+	a.Attribute("ide", d.String, "The workspace 'ide' link", func() {
+		a.Example("http://localhost:8080/che/test")
+	})
 })
 
 var workspaceEditLinks = a.Type("WorkspaceEditLinks", func() {
@@ -143,12 +156,30 @@ var _ = a.Resource("codebase", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
+	// Deprecated: Use 'listWorkspaces' instead
 	a.Action("edit", func() {
 		a.Security("jwt")
 		a.Routing(
 			a.GET("/:codebaseID/edit"),
 		)
-		a.Description("Trigger edit of a given codebase.")
+		a.Description("Deprecated: Trigger edit of a given codebase.")
+		a.Params(func() {
+			a.Param("codebaseID", d.UUID, "Codebase Identifier")
+		})
+		a.Response(d.OK, func() {
+			a.Media(workspaceList)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+	a.Action("listWorkspaces", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("/:codebaseID/workspaces"),
+		)
+		a.Description("Retrieve the list of workspaces that belong to a given codebase")
 		a.Params(func() {
 			a.Param("codebaseID", d.UUID, "Codebase Identifier")
 		})


### PR DESCRIPTION
* Please describe what your change is about.
 Deprecating  '/:codebaseID/edit' Adding '/:codebaseID/workspaces' and returning more workspace data (id / links)
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
https://github.com/openshiftio/openshift.io/issues/1439

Should be merged together with PR to UI: https://github.com/fabric8-ui/fabric8-ui/pull/2521
#