### PR TITLE
TypeGroup: Remove unused relationships

### DIFF
--- a/controller/test-files/work_item_type_group/list/ok.witg.golden.json
+++ b/controller/test-files/work_item_type_group/list/ok.witg.golden.json
@@ -14,42 +14,24 @@
         "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000001"
       },
       "relationships": {
-        "defaultType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
-          }
-        },
-        "nextGroup": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
-            "type": "workitemtypegroups"
-          },
-          "links": {
-            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
-          }
-        },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "spacetemplates"
           }
         },
         "typeList": {
           "data": [
             {
-              "id": "00000000-0000-0000-0000-000000000002",
+              "id": "00000000-0000-0000-0000-000000000003",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000004",
               "type": "workitemtypes"
             },
             {
               "id": "00000000-0000-0000-0000-000000000005",
-              "type": "workitemtypes"
-            },
-            {
-              "id": "00000000-0000-0000-0000-000000000006",
               "type": "workitemtypes"
             }
           ]
@@ -66,41 +48,14 @@
         "show-in-sidebar": true,
         "updated-at": "0001-01-01T00:00:00Z"
       },
-      "id": "00000000-0000-0000-0000-000000000004",
+      "id": "00000000-0000-0000-0000-000000000006",
       "links": {
-        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
+        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000006"
       },
       "relationships": {
-        "defaultType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000007",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000007"
-          }
-        },
-        "nextGroup": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000008",
-            "type": "workitemtypegroups"
-          },
-          "links": {
-            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000008"
-          }
-        },
-        "prevGroup": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000001",
-            "type": "workitemtypegroups"
-          },
-          "links": {
-            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000001"
-          }
-        },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "spacetemplates"
           }
         },
@@ -111,7 +66,7 @@
               "type": "workitemtypes"
             },
             {
-              "id": "00000000-0000-0000-0000-000000000009",
+              "id": "00000000-0000-0000-0000-000000000008",
               "type": "workitemtypes"
             }
           ]
@@ -128,41 +83,14 @@
         "show-in-sidebar": true,
         "updated-at": "0001-01-01T00:00:00Z"
       },
-      "id": "00000000-0000-0000-0000-000000000008",
+      "id": "00000000-0000-0000-0000-000000000009",
       "links": {
-        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000008"
+        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000009"
       },
       "relationships": {
-        "defaultType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000010",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000010"
-          }
-        },
-        "nextGroup": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000011",
-            "type": "workitemtypegroups"
-          },
-          "links": {
-            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000011"
-          }
-        },
-        "prevGroup": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
-            "type": "workitemtypegroups"
-          },
-          "links": {
-            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
-          }
-        },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "spacetemplates"
           }
         },
@@ -173,7 +101,7 @@
               "type": "workitemtypes"
             },
             {
-              "id": "00000000-0000-0000-0000-000000000012",
+              "id": "00000000-0000-0000-0000-000000000011",
               "type": "workitemtypes"
             }
           ]
@@ -190,32 +118,14 @@
         "show-in-sidebar": false,
         "updated-at": "0001-01-01T00:00:00Z"
       },
-      "id": "00000000-0000-0000-0000-000000000011",
+      "id": "00000000-0000-0000-0000-000000000012",
       "links": {
-        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000011"
+        "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000012"
       },
       "relationships": {
-        "defaultType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000013",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000013"
-          }
-        },
-        "prevGroup": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000008",
-            "type": "workitemtypegroups"
-          },
-          "links": {
-            "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000008"
-          }
-        },
         "spaceTemplate": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "spacetemplates"
           }
         },
@@ -226,7 +136,7 @@
               "type": "workitemtypes"
             },
             {
-              "id": "00000000-0000-0000-0000-000000000012",
+              "id": "00000000-0000-0000-0000-000000000011",
               "type": "workitemtypes"
             },
             {
@@ -240,6 +150,6 @@
     }
   ],
   "links": {
-    "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003/workitemtypegroups"
+    "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000002/workitemtypegroups"
   }
 }

--- a/controller/test-files/work_item_type_group/show/ok.witg.golden.json
+++ b/controller/test-files/work_item_type_group/show/ok.witg.golden.json
@@ -13,42 +13,24 @@
       "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000001"
     },
     "relationships": {
-      "defaultType": {
-        "data": {
-          "id": "00000000-0000-0000-0000-000000000002",
-          "type": "workitemtypes"
-        },
-        "links": {
-          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
-        }
-      },
-      "nextGroup": {
-        "data": {
-          "id": "00000000-0000-0000-0000-000000000004",
-          "type": "workitemtypegroups"
-        },
-        "links": {
-          "related": "http:///api/workitemtypegroups/00000000-0000-0000-0000-000000000004"
-        }
-      },
       "spaceTemplate": {
         "data": {
-          "id": "00000000-0000-0000-0000-000000000003",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spacetemplates"
         }
       },
       "typeList": {
         "data": [
           {
-            "id": "00000000-0000-0000-0000-000000000002",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          {
+            "id": "00000000-0000-0000-0000-000000000004",
             "type": "workitemtypes"
           },
           {
             "id": "00000000-0000-0000-0000-000000000005",
-            "type": "workitemtypes"
-          },
-          {
-            "id": "00000000-0000-0000-0000-000000000006",
             "type": "workitemtypes"
           }
         ]

--- a/controller/work_item_type_group.go
+++ b/controller/work_item_type_group.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/space"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/goadesign/goa"
-	uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemTypeGroupController implements the work_item_type_group resource.
@@ -53,10 +52,7 @@ func ConvertTypeGroup(request *http.Request, tg workitem.WorkItemTypeGroup) *app
 	spaceTemplateID := space.SystemSpace
 	spaceTemplateIDStr := spaceTemplateID.String()
 	workitemtypes := "workitemtypes"
-	// TODO(kwk): Replace system space once we have space templates
-	defaultWorkItemTypeRelatedURL := rest.AbsoluteURL(request, app.WorkitemtypeHref(space.SystemSpace, tg.DefaultType))
 	workItemTypeGroupRelatedURL := rest.AbsoluteURL(request, app.WorkItemTypeGroupHref(tg.ID))
-	defaultIDStr := tg.DefaultType.String()
 	createdAt := tg.CreatedAt.UTC()
 	updatedAt := tg.UpdatedAt.UTC()
 	// Every work item type group except the one in the "iteration" bucket are
@@ -78,15 +74,6 @@ func ConvertTypeGroup(request *http.Request, tg workitem.WorkItemTypeGroup) *app
 			ShowInSidebar: &showInSidebar,
 		},
 		Relationships: &app.WorkItemTypeGroupRelationships{
-			DefaultType: &app.RelationGeneric{
-				Data: &app.GenericData{
-					ID:   &defaultIDStr,
-					Type: &workitemtypes,
-				},
-				Links: &app.GenericLinks{
-					Related: &defaultWorkItemTypeRelatedURL,
-				},
-			},
 			TypeList: &app.RelationGenericList{
 				Data: make([]*app.GenericData, len(tg.TypeList)),
 			},
@@ -97,33 +84,6 @@ func ConvertTypeGroup(request *http.Request, tg workitem.WorkItemTypeGroup) *app
 				},
 			},
 		},
-	}
-
-	if tg.PrevGroupID != uuid.Nil {
-		prevGroupRelatedURL := rest.AbsoluteURL(request, app.WorkItemTypeGroupHref(tg.PrevGroupID))
-		prevIDStr := tg.PrevGroupID.String()
-		res.Relationships.PrevGroup = &app.RelationGeneric{
-			Data: &app.GenericData{
-				ID:   &prevIDStr,
-				Type: &APIWorkItemTypeGroups,
-			},
-			Links: &app.GenericLinks{
-				Related: &prevGroupRelatedURL,
-			},
-		}
-	}
-	if tg.NextGroupID != uuid.Nil {
-		nextGroupRelatedURL := rest.AbsoluteURL(request, app.WorkItemTypeGroupHref(tg.NextGroupID))
-		nextIDStr := tg.NextGroupID.String()
-		res.Relationships.NextGroup = &app.RelationGeneric{
-			Data: &app.GenericData{
-				ID:   &nextIDStr,
-				Type: &APIWorkItemTypeGroups,
-			},
-			Links: &app.GenericLinks{
-				Related: &nextGroupRelatedURL,
-			},
-		}
 	}
 
 	for i, witID := range tg.TypeList {

--- a/design/work_item_type_group.go
+++ b/design/work_item_type_group.go
@@ -52,11 +52,8 @@ var workItemTypeGroupAttributes = a.Type("WorkItemTypeGroupAttributes", func() {
 })
 
 var workItemTypeGroupsRelationships = a.Type("WorkItemTypeGroupRelationships", func() {
-	a.Attribute("defaultType", relationGeneric, "The default work item type from the type list")
 	a.Attribute("typeList", relationGenericList, "List of work item types attached to the type group")
 	a.Attribute("spaceTemplate", relationGeneric, "The space template to which this group belongs")
-	a.Attribute("nextGroup", relationGeneric, "The type group (if any) that comes after this one in the list")
-	a.Attribute("prevGroup", relationGeneric, "The type group (if any) that comes before this one in the list")
 })
 
 var _ = a.Resource("work_item_type_groups", func() {

--- a/workitem/typegroup.go
+++ b/workitem/typegroup.go
@@ -34,14 +34,11 @@ const (
 // WorkItemTypeGroup represents the node in the group of work item types
 type WorkItemTypeGroup struct {
 	gormsupport.Lifecycle
-	ID          uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
-	Bucket      TypeBucket
-	Name        string      // the name to be displayed to user (is unique)
-	TypeList    []uuid.UUID // TODO(kwk): We need to store this outside of this structure in the DB
-	DefaultType uuid.UUID   // the work item type that is supposed to be used with the quick add for example.
-	Icon        string
-	PrevGroupID uuid.UUID
-	NextGroupID uuid.UUID
+	ID       uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
+	Bucket   TypeBucket
+	Name     string      // the name to be displayed to user (is unique)
+	TypeList []uuid.UUID // TODO(kwk): We need to store this outside of this structure in the DB
+	Icon     string
 }
 
 // TypeGroups returns the list of work item type groups
@@ -63,8 +60,6 @@ func TypeGroups() []WorkItemTypeGroup {
 				SystemFundamental,
 				SystemPapercuts,
 			},
-			DefaultType: SystemScenario,
-			NextGroupID: experiencesID,
 		},
 		{
 			ID:     experiencesID,
@@ -75,9 +70,6 @@ func TypeGroups() []WorkItemTypeGroup {
 				SystemExperience,
 				SystemValueProposition,
 			},
-			DefaultType: SystemExperience,
-			PrevGroupID: scenariosID,
-			NextGroupID: requirementsID,
 		},
 		// There's always only one group in the "Requirement" bucket
 		{
@@ -89,9 +81,6 @@ func TypeGroups() []WorkItemTypeGroup {
 				SystemFeature,
 				SystemBug,
 			},
-			DefaultType: SystemFeature,
-			PrevGroupID: experiencesID,
-			NextGroupID: executionID,
 		},
 		// There's always only one group in the "Iteration" bucket
 		{
@@ -104,8 +93,6 @@ func TypeGroups() []WorkItemTypeGroup {
 				SystemBug,
 				SystemFeature,
 			},
-			DefaultType: SystemTask,
-			PrevGroupID: requirementsID,
 		},
 	}
 }


### PR DESCRIPTION
This removes the `defaultType`, `nextGroup` and `prevGroup` relationships from a work item type group. This will make it easier to persist type groups in the database later.
