### PR TITLE
Add Deployments API for deleting a deployment

### DIFF
--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -323,7 +323,7 @@ func (c *DeploymentsController) DeleteDeployment(ctx *app.DeleteDeploymentDeploy
 			"err":        err,
 			"space_name": *kubeSpaceName,
 		}, "error deleting deployment")
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
 
 	return ctx.OK([]byte{})

--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -303,6 +303,27 @@ func (c *DeploymentsController) SetDeployment(ctx *app.SetDeploymentDeploymentsC
 	return ctx.OK([]byte{})
 }
 
+// DeleteDeployment runs the deleteDeployment action.
+func (c *DeploymentsController) DeleteDeployment(ctx *app.DeleteDeploymentDeploymentsContext) error {
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
+	if err != nil {
+		return errors.NewUnauthorizedError("openshift token")
+	}
+
+	kubeSpaceName, err := c.getSpaceNameFromSpaceID(ctx, ctx.SpaceID)
+	if err != nil {
+		return errors.NewNotFoundError("osio space", ctx.SpaceID.String())
+	}
+
+	err = kc.DeleteDeployment(*kubeSpaceName, ctx.AppName, ctx.DeployName)
+	if err != nil {
+		return errors.NewInternalError(ctx, errs.Wrapf(err, "error deleting deployment %s", ctx.DeployName))
+	}
+
+	return ctx.OK([]byte{})
+}
+
 // ShowDeploymentStatSeries runs the showDeploymentStatSeries action.
 func (c *DeploymentsController) ShowDeploymentStatSeries(ctx *app.ShowDeploymentStatSeriesDeploymentsContext) error {
 

--- a/controller/deployments_blackbox_test.go
+++ b/controller/deployments_blackbox_test.go
@@ -3,33 +3,92 @@ package controller_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/goatest"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/fabric8-services/fabric8-wit/app"
+	"github.com/fabric8-services/fabric8-wit/app/test"
+	"github.com/fabric8-services/fabric8-wit/configuration"
 	"github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/kubernetes"
-	"github.com/stretchr/testify/require"
 )
 
 type testKubeClient struct {
-	closed bool
+	fixture       *deploymentsTestFixture
+	closed        bool
+	deleteResults *deleteTestResults
 	// Don't implement methods we don't yet need
 	kubernetes.KubeClientInterface
+}
+
+type testOSIOClient struct {
+	fixture *deploymentsTestFixture
+	// Don't implement methods we don't yet need
+	controller.OpenshiftIOClient
 }
 
 func (kc *testKubeClient) Close() {
 	kc.closed = true
 }
 
-type testKubeClientGetter struct {
-	client *testKubeClient
+type deploymentsTestFixture struct {
+	kube         *testKubeClient
+	spaceMapping map[string]string
+	deploymentsTestErrors
 }
 
-func (g *testKubeClientGetter) GetKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
+type deploymentsTestErrors struct {
+	getKubeClientError    error
+	deleteDeploymentError error
+}
+
+func (fixture *deploymentsTestFixture) GetKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
 	// Overwrites previous clients created by this getter
-	g.client = &testKubeClient{}
-	// Also return an error to avoid executing remainder of calling method
-	return g.client, errors.New("Test")
+	fixture.kube = &testKubeClient{
+		fixture: fixture,
+	}
+	return fixture.kube, fixture.getKubeClientError
+}
+
+type deleteTestResults struct {
+	spaceName string
+	appName   string
+	envName   string
+}
+
+func (c *testKubeClient) DeleteDeployment(spaceName string, appName string, envName string) error {
+	c.deleteResults = &deleteTestResults{
+		spaceName: spaceName,
+		appName:   appName,
+		envName:   envName,
+	}
+	return c.fixture.deleteDeploymentError
+}
+
+func (fixture *deploymentsTestFixture) GetAndCheckOSIOClient(ctx context.Context) (controller.OpenshiftIOClient, error) {
+	return &testOSIOClient{
+		fixture: fixture,
+	}, nil
+}
+
+func (c *testOSIOClient) GetSpaceByID(ctx context.Context, spaceID uuid.UUID) (*app.Space, error) {
+	var spaceName *string
+	uuidString := spaceID.String()
+	name, pres := c.fixture.spaceMapping[uuidString]
+	if pres {
+		spaceName = &name
+	}
+	space := &app.Space{
+		Attributes: &app.SpaceAttributes{
+			Name: spaceName,
+		},
+	}
+	return space, nil
 }
 
 func TestAPIMethodsCloseKube(t *testing.T) {
@@ -78,15 +137,114 @@ func TestAPIMethodsCloseKube(t *testing.T) {
 		}},
 	}
 	// Check that each API method creating a KubeClientInterface also closes it
-	getter := &testKubeClientGetter{}
+	fixture := &deploymentsTestFixture{
+		// Also return an error to avoid executing remainder of calling method
+		deploymentsTestErrors: deploymentsTestErrors{
+			getKubeClientError: errors.New("Test"),
+		},
+	}
 	controller := &controller.DeploymentsController{
-		KubeClientGetter: getter,
+		ClientGetter: fixture,
 	}
 	for _, testCase := range testCases {
 		err := testCase.method(controller)
 		require.Error(t, err, "Expected error \"Test\": "+testCase.name)
 		// Check Close was called before returning
-		require.NotNil(t, getter.client, "No Kube client created: "+testCase.name)
-		require.True(t, getter.client.closed, "Kube client not closed: "+testCase.name)
+		require.NotNil(t, fixture.kube, "No Kube client created: "+testCase.name)
+		require.True(t, fixture.kube.closed, "Kube client not closed: "+testCase.name)
 	}
+}
+
+func TestDeleteDeployment(t *testing.T) {
+	const uuidStr = "ed3b4c4d-5a47-44ec-8b73-9a0fbc902184"
+	const spaceName = "mySpace"
+	const appName = "myApp"
+	const envName = "myEnv"
+
+	expectedResults := &deleteTestResults{
+		spaceName: spaceName,
+		appName:   appName,
+		envName:   envName,
+	}
+	testCases := []struct {
+		testName   string
+		deleteFunc func(t goatest.TInterface, ctx context.Context, service *goa.Service, ctrl app.DeploymentsController,
+			spaceID uuid.UUID, appName string, deployName string) (http.ResponseWriter, *app.JSONAPIErrors)
+		spaceUUID       string
+		expectedResults *deleteTestResults
+		deploymentsTestErrors
+	}{
+		{
+			testName: "Basic",
+			deleteFunc: func(t goatest.TInterface, ctx context.Context, service *goa.Service, ctrl app.DeploymentsController,
+				spaceID uuid.UUID, appName string, deployName string) (http.ResponseWriter, *app.JSONAPIErrors) {
+				// Wrap test method to return additional *app.JSONAPIErrors value
+				return test.DeleteDeploymentDeploymentsOK(t, ctx, service, ctrl, spaceID, appName, deployName), nil
+			},
+			spaceUUID:       uuidStr,
+			expectedResults: expectedResults,
+		},
+		{
+			testName:   "Delete Failure",
+			deleteFunc: test.DeleteDeploymentDeploymentsInternalServerError,
+			spaceUUID:  uuidStr,
+			deploymentsTestErrors: deploymentsTestErrors{
+				deleteDeploymentError: errors.New("TEST"), // Return expected error from DeleteDeployment
+			},
+			expectedResults: expectedResults,
+		},
+		{
+			testName:   "Space Not Found",
+			deleteFunc: test.DeleteDeploymentDeploymentsNotFound,
+			spaceUUID:  "9de7a4bc-d098-4867-809c-759e2cd824f4", // Different UUID
+		},
+		{
+			testName:   "Auth Failure",
+			deleteFunc: test.DeleteDeploymentDeploymentsUnauthorized,
+			spaceUUID:  uuidStr,
+			deploymentsTestErrors: deploymentsTestErrors{
+				getKubeClientError: errors.New("TEST"), // Return expected error from GetKubeClient
+			},
+		},
+	}
+	fixture := &deploymentsTestFixture{
+		spaceMapping: map[string]string{uuidStr: spaceName},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			fixture.deploymentsTestErrors = testCase.deploymentsTestErrors
+
+			// Create controller and install our test fixture
+			svc, controller, err := createDeploymentsController()
+			require.NoError(t, err, "Failed to create controller")
+			controller.ClientGetter = fixture
+
+			spUUID, err := uuid.FromString(testCase.spaceUUID)
+			require.NoError(t, err, "Bad UUID")
+			// Invoke Goa-generated test method used by this test case
+			testCase.deleteFunc(t, svc.Context, svc, controller, spUUID, appName, envName)
+
+			// Check arguments passed to DeleteDeployment
+			if testCase.expectedResults != nil {
+				results := fixture.kube.deleteResults
+				require.NotNil(t, results, "DeleteDeployment not called")
+				require.Equal(t, testCase.expectedResults.spaceName, results.spaceName, "Incorrect space name")
+				require.Equal(t, testCase.expectedResults.appName, results.appName, "Incorrect application name")
+				require.Equal(t, testCase.expectedResults.envName, results.envName, "Incorrect environment name")
+			}
+
+			// Check KubeClient is closed
+			require.True(t, fixture.kube.closed, "KubeClient is still open")
+		})
+	}
+}
+
+func createDeploymentsController() (*goa.Service, *controller.DeploymentsController, error) {
+	svc := goa.New("deployment-service-test")
+	config, err := configuration.New("../config.yaml")
+	if err != nil {
+		return nil, nil, err
+	}
+	return svc, controller.NewDeploymentsController(svc, config), nil
 }

--- a/controller/deployments_osioclient.go
+++ b/controller/deployments_osioclient.go
@@ -59,7 +59,7 @@ var _ OpenshiftIOClient = &OSIOClient{}
 var _ OpenshiftIOClient = (*OSIOClient)(nil)
 
 // NewOSIOClient creates an openshift IO client given an http request context
-func NewOSIOClient(ctx context.Context, scheme string, host string) *OSIOClient {
+func NewOSIOClient(ctx context.Context, scheme string, host string) OpenshiftIOClient {
 	wc := witclient.New(goaclient.HTTPClientDoer(http.DefaultClient))
 	wc.Host = host
 	wc.Scheme = scheme
@@ -68,7 +68,7 @@ func NewOSIOClient(ctx context.Context, scheme string, host string) *OSIOClient 
 }
 
 // CreateOSIOClient factory method replaced during unit testing
-func CreateOSIOClient(witclient WitClient, responseReader ResponseReader) *OSIOClient {
+func CreateOSIOClient(witclient WitClient, responseReader ResponseReader) OpenshiftIOClient {
 	client := new(OSIOClient)
 	client.wc = witclient
 	client.responseReader = responseReader

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -306,6 +306,22 @@ var _ = a.Resource("deployments", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
 
+	a.Action("deleteDeployment", func() {
+		a.Routing(
+			a.DELETE("/spaces/:spaceID/applications/:appName/deployments/:deployName"),
+		)
+		a.Description("Delete a deployment of an application")
+		a.Params(func() {
+			a.Param("spaceID", d.UUID, "ID of the space")
+			a.Param("appName", d.String, "Name of the application")
+			a.Param("deployName", d.String, "Name of the deployment")
+		})
+		a.Response(d.OK)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+
 	a.Action("showSpaceEnvironments", func() {
 		a.Routing(
 			a.GET("/spaces/:spaceID/environments"),

--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -542,14 +542,21 @@ func (kc *kubeClient) DeleteDeployment(spaceName string, appName string, envName
 	if err != nil {
 		return errs.WithStack(err)
 	}
+	// Delete routes
+	err = kc.deleteRoutes(appName, envNS)
+	if err != nil {
+		return err
+	}
+	// Delete services
+	err = kc.deleteServices(appName, envNS)
+	if err != nil {
+		return err
+	}
 	// Delete DC (will also delete RCs and pods)
 	err = kc.deleteDeploymentConfig(spaceName, appName, envNS)
 	if err != nil {
-		return errs.WithStack(err)
+		return err
 	}
-	// Delete routes
-	//err = kc.deleteRoutes(appName, envNS)
-	// Delete services
 	return nil
 }
 
@@ -856,7 +863,6 @@ func (kc *kubeClient) deleteDeploymentConfig(spaceName string, appName string, n
 	opts := metaV1.DeleteOptions{
 		PropagationPolicy: &policy,
 	}
-
 	// API states this should return a Status object, but it returns the DC instead,
 	// just check for no HTTP error
 	err = kc.sendResource(dcURL, "DELETE", opts)
@@ -1616,6 +1622,54 @@ func scoreRoute(route *route) int {
 		score++
 	}
 	return score
+}
+
+func (kc *kubeClient) deleteServices(appName string, envNS string) error {
+	// Delete all dependent objects before deleting the service
+	policy := metaV1.DeletePropagationForeground
+	delOpts := &metaV1.DeleteOptions{
+		PropagationPolicy: &policy,
+	}
+	// Delete all services in namespace with matching 'app' label
+	listOpts := metaV1.ListOptions{
+		LabelSelector: "app=" + appName,
+	}
+	// The API server rejects deleting services by label, so get all
+	// services with the label, and delete one-by-one
+	services, err := kc.Services(envNS).List(listOpts)
+	if err != nil {
+		return errs.WithStack(err)
+	}
+	for _, service := range services.Items {
+		err = kc.Services(envNS).Delete(service.Name, delOpts)
+		if err != nil {
+			return errs.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func (kc *kubeClient) deleteRoutes(appName string, envNS string) error {
+	// Delete all routes in namespace with matching 'app' label
+	queryParam := url.QueryEscape("app=" + appName)
+	routesURL := fmt.Sprintf("/oapi/v1/namespaces/%s/routes?labelSelector=%s", envNS, queryParam)
+	// Delete all dependent objects before deleting the route
+	policy := metaV1.DeletePropagationForeground
+	opts := metaV1.DeleteOptions{
+		PropagationPolicy: &policy,
+	}
+	reqBody, err := json.Marshal(opts)
+	if err != nil {
+		return errs.WithStack(err)
+	}
+	// API states this should return a Status object, but it returns the route instead,
+	// just check for no HTTP error
+	resp, err := kc.sendResource(routesURL, "DELETE", reqBody, "application/json")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(resp))
+	return nil
 }
 
 // Derived from: https://github.com/fabric8-services/fabric8-tenant/blob/master/openshift/kube_token.go

--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -851,10 +851,12 @@ func (oc *openShiftAPIClient) GetDeploymentConfig(namespace string, name string)
 }
 
 func (kc *kubeClient) deleteDeploymentConfig(spaceName string, appName string, namespace string) error {
-	// Check that the deployment config belongs to the expected space
-	_, err := kc.getDeploymentConfig(namespace, appName, spaceName)
+	// Check that the deployment config exists and belongs to the expected space
+	dc, err := kc.getDeploymentConfig(namespace, appName, spaceName)
 	if err != nil {
 		return err
+	} else if dc == nil {
+		return errs.Errorf("deployment config %s does not exist in %s", appName, namespace)
 	}
 
 	dcURL := fmt.Sprintf("/oapi/v1/namespaces/%s/deploymentconfigs/%s", namespace, appName)


### PR DESCRIPTION
This PR adds functionality to delete an OpenShift deployment from an environment consisting of the following resources:
- Deployment Configs
- Replication Controllers
- Pods
- Services
- Routes

This functionality is exposed via the `DELETE` method on the endpoint: `/deployments/spaces/{spaceID}/applications/{appName}/deployments/{environmentName}`. This API fixes https://github.com/openshiftio/openshift.io/issues/1663.

I have written tests for both the new controller and Kubernetes code in a separate feature branch:
https://github.com/ebaron/fabric8-wit/tree/delete-tests. ~~These tests depend on the test fixture introduced in #1894, which has not been merged yet. Once that PR is merged, I can add the tests to this PR.~~ The unit tests have now been added to this PR.