### PR TITLE
Use Go 1.10 version from website when running tests with coverage

### DIFF
--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -25,7 +25,7 @@ PACKAGE_PATH=$(GOPATH_IN_CONTAINER)/src/$(PACKAGE_NAME)
 ## Builds the docker image used to build the software.
 docker-image-builder:
 	@echo "Building docker image $(DOCKER_IMAGE_CORE)"
-	docker build --build-arg USE_GO_VERSION_FROM_WEBSITE=$(USE_GO_VERSION_FROM_WEBSITE) -t $(DOCKER_IMAGE_CORE) -f $(CUR_DIR)/Dockerfile.builder $(CUR_DIR)
+	docker build --quiet --build-arg USE_GO_VERSION_FROM_WEBSITE=$(USE_GO_VERSION_FROM_WEBSITE) -t $(DOCKER_IMAGE_CORE) -f $(CUR_DIR)/Dockerfile.builder $(CUR_DIR)
 
 .PHONY: docker-image-deploy
 ## Creates a runnable image using the artifacts from the bin directory.

--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -25,7 +25,7 @@ PACKAGE_PATH=$(GOPATH_IN_CONTAINER)/src/$(PACKAGE_NAME)
 ## Builds the docker image used to build the software.
 docker-image-builder:
 	@echo "Building docker image $(DOCKER_IMAGE_CORE)"
-	docker build --quiet -t $(DOCKER_IMAGE_CORE) -f $(CUR_DIR)/Dockerfile.builder $(CUR_DIR)
+	docker build --build-arg USE_GO_VERSION_FROM_WEBSITE=$(USE_GO_VERSION_FROM_WEBSITE) -t $(DOCKER_IMAGE_CORE) -f $(CUR_DIR)/Dockerfile.builder $(CUR_DIR)
 
 .PHONY: docker-image-deploy
 ## Creates a runnable image using the artifacts from the bin directory.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,12 +2,13 @@ FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
+ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 # Some packages might seem weird but they are required by the RVM installer.
 RUN yum --enablerepo=centosplus install -y --quiet \
       findutils \
       git \
-      golang \
+      $(test -z $USE_GO_VERSION_FROM_WEBSITE && echo "golang") \
       make \
       mercurial \
       procps-ng \
@@ -16,9 +17,18 @@ RUN yum --enablerepo=centosplus install -y --quiet \
       which \
     && yum clean all
 
+RUN test -n $USE_GO_VERSION_FROM_WEBSITE \
+    && cd /tmp \
+    && wget --no-verbose https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
+    && echo "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33  go1.10.linux-amd64.tar.gz" > checksum \
+    && sha256sum -c checksum \
+    && tar -C /usr/local -xzf go1.10.linux-amd64.tar.gz \
+    && rm -f go1.10.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+
 # Get glide for Go package management
 RUN cd /tmp \
-    && wget https://github.com/Masterminds/glide/releases/download/v0.11.1/glide-v0.11.1-linux-amd64.tar.gz \
+    && wget --no-verbose https://github.com/Masterminds/glide/releases/download/v0.11.1/glide-v0.11.1-linux-amd64.tar.gz \
     && tar xzf glide-v*.tar.gz \
     && mv linux-amd64/glide /usr/bin \
     && rm -rfv glide-v* linux-amd64

--- a/cico_run_coverage.sh
+++ b/cico_run_coverage.sh
@@ -2,6 +2,8 @@
 
 . cico_setup.sh
 
+export USE_GO_VERSION_FROM_WEBSITE=1
+
 cico_setup;
 
 run_tests_with_coverage;


### PR DESCRIPTION
@aslakknutsen observed quite an improvement in speed when running tests with coverage with Golang 1.10:

make target | Go 1.8.4 (current CentOS version) | Go 1.10 (version from golang website)
-----| ------------ | -------------
`test-unit-no-coverage` | 42s | 13s
`test-unit` | 20m38s | 48s

That's why i've introduced a [docker build arg](https://docs.docker.com/engine/reference/builder/#arg) `USE_GO_VERSION_FROM_WEBSITE`. It defaults to `0` and is only set to `1` through an environment variable when running `cico_run_coverage.sh`.

Running the coverage calculation with a newer Go version is fine because we proof correctness of tests with the current CentOS version of Go already.

@aslakknutsen I'm not sure you've tweaked the test runs as well, so please let me know if more is needed.