### PR TITLE
move COPY cmds in Dockerfile.deploy to end

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -8,9 +8,6 @@ ENV F8_INSTALL_PREFIX=/usr/local/wit
 ENV F8_USER_NAME=wit
 RUN useradd --no-create-home -s /bin/bash ${F8_USER_NAME}
 
-COPY bin/wit ${F8_INSTALL_PREFIX}/bin/wit
-COPY config.yaml ${F8_INSTALL_PREFIX}/etc/config.yaml
-
 # Install little pcp pmcd server for metrics collection
 # would prefer only pmcd, and not the /bin/pm*tools etc.
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
@@ -21,6 +18,8 @@ RUN yum install -y pcp pcp-pmda-prometheus && yum clean all && \
 COPY ./wit+pmcd.sh /wit+pmcd.sh
 EXPOSE 44321
 
+COPY bin/wit ${F8_INSTALL_PREFIX}/bin/wit
+COPY config.yaml ${F8_INSTALL_PREFIX}/etc/config.yaml
 
 # From here onwards, any RUN, CMD, or ENTRYPOINT will be run under the following user
 USER ${F8_USER_NAME}


### PR DESCRIPTION
This will help reduce build cycle while doing development in containers.

Right now the way COPY commands are placed require all subsequent layers
to be built. Which has a time consuming yum install as well.
