### PR TITLE
Add missing "bc" to docker build container

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -15,6 +15,7 @@ RUN yum --enablerepo=centosplus install -y --quiet \
       tar \
       wget \
       which \
+      bc \
     && yum clean all
 
 RUN test -n $USE_GO_VERSION_FROM_WEBSITE \


### PR DESCRIPTION
Fixes this error on CI build:

```
/bin/sh: bc: command not found
```

This supersedes #1907 because this PR does only one small thing compared to #1907.