### PR TITLE
search: fixup for #1912

### DIFF
--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -516,7 +516,17 @@ func (q Query) generateExpression() (criteria.Expression, error) {
 			}
 		} else {
 			key, ok := searchKeyMap[child.Name]
-			if !ok {
+			// check that none of the default table joins handles this column:
+			var handledByJoin bool
+			joins := workitem.DefaultTableJoins()
+			for _, j := range joins {
+				if j.HandlesFieldName(child.Name) {
+					handledByJoin = true
+					key = child.Name
+					break
+				}
+			}
+			if !ok && !handledByJoin {
 				return nil, errors.NewBadParameterError("key not found", child.Name)
 			}
 			left := criteria.Field(key)

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -107,6 +107,29 @@ func (s *searchRepositoryBlackboxTest) TestSearchWithJoin() {
 			}
 			require.Empty(t, toBeFound, "failed to found all work items: %+s", toBeFound)
 		})
+		t.Run("matching name in child", func(t *testing.T) {
+			// when
+			filter := fmt.Sprintf(`{"$AND":[{"iteration.name": "%s"},{"space":"%s"}]}`, fxt.Iterations[0].Name, fxt.Spaces[0].ID)
+			res, count, _, _, err := s.searchRepo.Filter(context.Background(), filter, nil, nil, nil)
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, uint64(7), count)
+			toBeFound := id.Slice{
+				fxt.WorkItems[0].ID,
+				fxt.WorkItems[1].ID,
+				fxt.WorkItems[2].ID,
+				fxt.WorkItems[3].ID,
+				fxt.WorkItems[4].ID,
+				fxt.WorkItems[5].ID,
+				fxt.WorkItems[6].ID,
+			}.ToMap()
+			for _, wi := range res {
+				_, ok := toBeFound[wi.ID]
+				require.True(t, ok, "unknown work item found: %s", wi.ID)
+				delete(toBeFound, wi.ID)
+			}
+			require.Empty(t, toBeFound, "failed to found all work items: %+s", toBeFound)
+		})
 	})
 }
 

--- a/workitem/expression_compiler.go
+++ b/workitem/expression_compiler.go
@@ -92,14 +92,14 @@ func (c *expressionCompiler) getFieldName(fieldName string) (mappedFieldName str
 
 	mappedFieldName, isColumnField := fieldMap[fieldName]
 	if isColumnField {
-		return mappedFieldName, false
+		return WorkItemStorage{}.TableName() + "." + mappedFieldName, false
 	}
 
 	if strings.Contains(fieldName, ".") {
 		// leave field untouched
 		return fieldName, true
 	}
-	return fieldName, false
+	return WorkItemStorage{}.TableName() + "." + fieldName, false
 }
 
 // DefaultTableJoins returns the default list of joinable tables used when

--- a/workitem/expression_compiler_blackbox_test.go
+++ b/workitem/expression_compiler_blackbox_test.go
@@ -15,12 +15,12 @@ func TestField(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 	expect(t, c.Equals(c.Field("foo.bar"), c.Literal(23)), "(Fields@>'{\"foo.bar\" : 23}')", []interface{}{}, nil)
-	expect(t, c.Equals(c.Field("foo"), c.Literal(23)), "(foo = ?)", []interface{}{23}, nil)
-	expect(t, c.Equals(c.Field("Type"), c.Literal("abcd")), "(type = ?)", []interface{}{"abcd"}, nil)
-	expect(t, c.Not(c.Field("Type"), c.Literal("abcd")), "(type != ?)", []interface{}{"abcd"}, nil)
-	expect(t, c.Not(c.Field("Version"), c.Literal("abcd")), "(version != ?)", []interface{}{"abcd"}, nil)
-	expect(t, c.Not(c.Field("Number"), c.Literal("abcd")), "(number != ?)", []interface{}{"abcd"}, nil)
-	expect(t, c.Not(c.Field("SpaceID"), c.Literal("abcd")), "(space_id != ?)", []interface{}{"abcd"}, nil)
+	expect(t, c.Equals(c.Field("foo"), c.Literal(23)), "(work_items.foo = ?)", []interface{}{23}, nil)
+	expect(t, c.Equals(c.Field("Type"), c.Literal("abcd")), "(work_items.type = ?)", []interface{}{"abcd"}, nil)
+	expect(t, c.Not(c.Field("Type"), c.Literal("abcd")), "(work_items.type != ?)", []interface{}{"abcd"}, nil)
+	expect(t, c.Not(c.Field("Version"), c.Literal("abcd")), "(work_items.version != ?)", []interface{}{"abcd"}, nil)
+	expect(t, c.Not(c.Field("Number"), c.Literal("abcd")), "(work_items.number != ?)", []interface{}{"abcd"}, nil)
+	expect(t, c.Not(c.Field("SpaceID"), c.Literal("abcd")), "(work_items.space_id != ?)", []interface{}{"abcd"}, nil)
 
 	t.Run("test join", func(t *testing.T) {
 		expect(t, c.Equals(c.Field("iteration.name"), c.Literal("abcd")), `(iter.name = ?)`, []interface{}{"abcd"}, []string{"iteration"})
@@ -60,11 +60,11 @@ func TestIsNull(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 	expect(t, c.IsNull("system.assignees"), "(Fields->>'system.assignees' IS NULL)", []interface{}{}, nil)
-	expect(t, c.IsNull("ID"), "(id IS NULL)", []interface{}{}, nil)
-	expect(t, c.IsNull("Type"), "(type IS NULL)", []interface{}{}, nil)
-	expect(t, c.IsNull("Version"), "(version IS NULL)", []interface{}{}, nil)
-	expect(t, c.IsNull("Number"), "(number IS NULL)", []interface{}{}, nil)
-	expect(t, c.IsNull("SpaceID"), "(space_id IS NULL)", []interface{}{}, nil)
+	expect(t, c.IsNull("ID"), "(work_items.id IS NULL)", []interface{}{}, nil)
+	expect(t, c.IsNull("Type"), "(work_items.type IS NULL)", []interface{}{}, nil)
+	expect(t, c.IsNull("Version"), "(work_items.version IS NULL)", []interface{}{}, nil)
+	expect(t, c.IsNull("Number"), "(work_items.number IS NULL)", []interface{}{}, nil)
+	expect(t, c.IsNull("SpaceID"), "(work_items.space_id IS NULL)", []interface{}{}, nil)
 }
 
 func expect(t *testing.T, expr c.Expression, expectedClause string, expectedParameters []interface{}, expectedJoins []string) {


### PR DESCRIPTION
We have two places in `search.Query.generateExpression()` where we inspect a field name. One was missing in #1912. Now I've added a test to ensure it is covered.

Fixes:

        Bad value for parameter 'key not found': 'iteration.name'

Also fixes the following follow-up problem by adding the explicit table name to the resolved column names in the expression compiler:

        pq: column reference "space_id" is ambiguous