### PR TITLE
Add Deployment quotas data

### DIFF
--- a/design/deployments.go
+++ b/design/deployments.go
@@ -70,8 +70,15 @@ var simpleDeploymentAttributes = a.Type("SimpleDeploymentAttributes", func() {
 	a.Attribute("version", d.String)
 	a.Attribute("pods", a.ArrayOf(a.ArrayOf(d.String)))
 	a.Attribute("pod_total", d.Integer)
+	a.Attribute("pods_quota", podsQuota)
 	a.Required("name")
 	a.Required("pods")
+})
+
+var podsQuota = a.Type("PodsQuota", func() {
+	a.Description(`resource quotas for pods of a deployment`)
+	a.Attribute("cpucores", d.Number)
+	a.Attribute("memory", d.Number)
 })
 
 var simpleEnvironment = a.Type("SimpleEnvironment", func() {

--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -378,6 +378,13 @@ func (kc *kubeClient) GetDeployment(spaceName string, appName string, envName st
 	if err != nil {
 		return nil, errs.WithStack(err)
 	}
+
+	// Get the quota for all pods in the deployment
+	podsQuota, err := kc.getPodsQuota(pods)
+	if err != nil {
+		return nil, err
+	}
+
 	// Get the status of each pod in the deployment
 	podStats, total := kc.getPodStatus(pods)
 
@@ -408,10 +415,11 @@ func (kc *kubeClient) GetDeployment(spaceName string, appName string, envName st
 	result := &app.SimpleDeployment{
 		Type: "deployment",
 		Attributes: &app.SimpleDeploymentAttributes{
-			Name:     envName,
-			Version:  &verString,
-			Pods:     podStats,
-			PodTotal: &total,
+			Name:      envName,
+			Version:   &verString,
+			Pods:      podStats,
+			PodTotal:  &total,
+			PodsQuota: podsQuota,
 		},
 		ID:    envName,
 		Links: links,
@@ -977,6 +985,33 @@ func (kc *kubeClient) getPods(namespace string, uid types.UID) ([]*v1.Pod, error
 	}
 
 	return appPods, nil
+}
+
+func (kc *kubeClient) getPodsQuota(pods []*v1.Pod) (*app.PodsQuota, error) {
+	cores := float64(0)
+	memory := float64(0)
+
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			cpu, err := quantityToFloat64(*container.Resources.Limits.Cpu())
+			if err != nil {
+				return nil, errs.WithStack(err)
+			}
+			mem, err := quantityToFloat64(*container.Resources.Limits.Memory())
+			if err != nil {
+				return nil, errs.WithStack(err)
+			}
+			cores += cpu
+			memory += mem
+		}
+	}
+
+	result := &app.PodsQuota{
+		Cpucores: &cores,
+		Memory:   &memory,
+	}
+
+	return result, nil
 }
 
 // Pod status constants


### PR DESCRIPTION
This PR addresses the backend work for [1], adding deployment specific quota information.

This PR is complete, but relies on [2], which is included as the first commit in this PR. When [2] is merged, that commit will be removed, and this PR will be rebased onto master.

Edit:
[2] has been merged and removed from this PR. This PR is ready to merge.

[1] https://github.com/openshiftio/openshift.io/issues/2183
[2] https://github.com/fabric8-services/fabric8-wit/pull/1894