### PR TITLE
add check to see codebase exists in space

### DIFF
--- a/controller/deployments_osioclient.go
+++ b/controller/deployments_osioclient.go
@@ -112,7 +112,7 @@ func (osioclient *OSIOClient) GetUserServices(ctx context.Context) (*app.UserSer
 			"err":         err,
 			"path":        witclient.ShowUserServicePath(),
 			"http_status": status,
-		}, "failed to user service from WIT service due to HTTP error %s", status)
+		}, "failed to user service from WIT service due to HTTP error %d", status)
 		return nil, errs.Errorf("failed to GET %s due to status code %d", witclient.ShowUserServicePath(), status)
 	}
 

--- a/controller/space_codebases.go
+++ b/controller/space_codebases.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/login"
 	"github.com/fabric8-services/fabric8-wit/rest"
+
 	"github.com/goadesign/goa"
 )
 

--- a/controller/space_codebases_test.go
+++ b/controller/space_codebases_test.go
@@ -1,23 +1,24 @@
 package controller_test
 
 import (
+	"context"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 
-	"context"
-
+	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	"github.com/fabric8-services/fabric8-wit/application"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
-
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/space"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
+	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
+
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,11 @@ func TestRunSpaceCodebaseREST(t *testing.T) {
 func (rest *TestSpaceCodebaseREST) SetupTest() {
 	rest.DBTestSuite.SetupTest()
 	rest.db = gormapplication.NewGormDB(rest.DB)
+}
+
+func (rest *TestSpaceCodebaseREST) SecuredControllerWithIdentity(idn *account.Identity) (*goa.Service, *SpaceCodebasesController) {
+	svc := testsupport.ServiceAsUser("SpaceCodebase-Service", *idn)
+	return svc, NewSpaceCodebasesController(svc, rest.db)
 }
 
 func (rest *TestSpaceCodebaseREST) SecuredController() (*goa.Service, *SpaceCodebasesController) {
@@ -107,7 +113,7 @@ func (rest *TestSpaceCodebaseREST) TestListCodebase() {
 	var createdSpacesUuids1 []uuid.UUID
 
 	for i := 0; i < 3; i++ {
-		repoURL := strings.Replace(repo, "core", "core"+strconv.Itoa(i), -1)
+		repoURL := strings.Replace(repo, "wit", "wit"+strconv.Itoa(i), -1)
 		stackId := "stackId"
 		spaceCodebaseContext := createSpaceCodebase(repoURL, &stackId)
 		_, c := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, spaceId, spaceCodebaseContext)
@@ -158,6 +164,22 @@ func (rest *TestSpaceCodebaseREST) TestFailCreateCodebaseNotAuthorized() {
 
 	svc, ctrl := rest.UnSecuredController()
 	test.CreateSpaceCodebasesUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4(), ci)
+}
+
+func (rest *TestSpaceCodebaseREST) TestFailCreateCodebaseExistingCodebase() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	// Create first codebase
+	fxt := tf.NewTestFixture(t, rest.DB, tf.Codebases(1))
+
+	svc, ctrl := rest.SecuredControllerWithIdentity(fxt.Identities[0])
+
+	// add another codebase with same url, should fail
+	spaceCodebaseContext := createSpaceCodebase(fxt.Codebases[0].URL, fxt.Codebases[0].StackID)
+	_, err := test.CreateSpaceCodebasesConflict(t, svc.Context, svc, ctrl,
+		fxt.Codebases[0].SpaceID, spaceCodebaseContext)
+	require.NotNil(t, err)
 }
 
 func (rest *TestSpaceCodebaseREST) TestFailListCodebaseByMissingSpace() {

--- a/design/codebases.go
+++ b/design/codebases.go
@@ -76,7 +76,7 @@ var workspaceAttributes = a.Type("WorkspaceAttributes", func() {
 		a.Example("")
 	})
 	a.Attribute("status", d.String, "The workspace status", func() {
-		a.Example("STOPPED");
+		a.Example("STOPPED")
 	})
 })
 
@@ -336,5 +336,6 @@ var _ = a.Resource("space_codebases", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.Forbidden, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 })

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -379,6 +379,9 @@ func GetMigrations() Migrations {
 	// Version 83
 	m = append(m, steps{ExecuteSQLFile("083-index-comments-parent.sql")})
 
+	// Version 84
+	m = append(m, steps{ExecuteSQLFile("084-codebases-spaceid-url-index.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -129,6 +129,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration80", testMigration80)
 	t.Run("TestMigration81", testMigration81)
 	t.Run("TestMigration82", testMigration82)
+	t.Run("TestMigration84", testMigration84)
 
 	// Perform the migration
 	err = migration.Migrate(sqlDB, databaseName)
@@ -699,6 +700,10 @@ func testMigration84(t *testing.T) {
 
 	// try to add duplicate entry, which should fail
 	assert.NotNil(t, runSQLscript(sqlDB, "084-codebases-spaceid-url-idx-violate.sql"))
+
+	// see that the existing space is not the deleted one but the one that is
+	// available in the valid one
+	assert.Nil(t, runSQLscript(sqlDB, "084-codebases-spaceid-url-idx-test.sql"))
 
 	// cleanup
 	assert.Nil(t, runSQLscript(sqlDB, "084-codebases-spaceid-url-idx-cleanup.sql"))

--- a/migration/sql-files/084-codebases-spaceid-url-index.sql
+++ b/migration/sql-files/084-codebases-spaceid-url-index.sql
@@ -1,0 +1,15 @@
+-- Delete duplicate entries of codebases in same space
+-- See here: https://wiki.postgresql.org/wiki/Deleting_duplicates
+DELETE FROM codebases
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT id, ROW_NUMBER() OVER (partition BY url, space_id ORDER BY id) AS rnum
+        FROM codebases
+    ) t
+    WHERE t.rnum > 1
+);
+
+-- From now on ensure we have codebase only once in space
+CREATE UNIQUE INDEX codebases_spaceid_url_idx
+ON codebases (url, space_id) WHERE deleted_at IS NULL;

--- a/migration/sql-files/084-codebases-spaceid-url-index.sql
+++ b/migration/sql-files/084-codebases-spaceid-url-index.sql
@@ -4,7 +4,7 @@ DELETE FROM codebases
 WHERE id IN (
     SELECT id
     FROM (
-        SELECT id, ROW_NUMBER() OVER (partition BY url, space_id ORDER BY id) AS rnum
+        SELECT id, ROW_NUMBER() OVER (partition BY url, space_id ORDER BY deleted_at DESC) AS rnum
         FROM codebases
     ) t
     WHERE t.rnum > 1

--- a/migration/sql-test-files/084-codebases-spaceid-url-idx-cleanup.sql
+++ b/migration/sql-test-files/084-codebases-spaceid-url-idx-cleanup.sql
@@ -2,9 +2,9 @@
 DELETE FROM codebases
 WHERE
     (url = 'https://github.com/fabric8-services/fabric8-wit/' AND
-    space_id = '86af5178-9b41-469b-9096-57e5155c3f31');
+    space_id = '48d8987f-d7c2-454f-b67c-4cad74199b26');
 
 -- Delete entries from spaces
 DELETE FROM spaces
 WHERE
-    id = '86af5178-9b41-469b-9096-57e5155c3f31';
+    id = '48d8987f-d7c2-454f-b67c-4cad74199b26';

--- a/migration/sql-test-files/084-codebases-spaceid-url-idx-cleanup.sql
+++ b/migration/sql-test-files/084-codebases-spaceid-url-idx-cleanup.sql
@@ -1,0 +1,10 @@
+-- Delete entries from codebases
+DELETE FROM codebases
+WHERE
+    (url = 'https://github.com/fabric8-services/fabric8-wit/' AND
+    space_id = '86af5178-9b41-469b-9096-57e5155c3f31');
+
+-- Delete entries from spaces
+DELETE FROM spaces
+WHERE
+    id = '86af5178-9b41-469b-9096-57e5155c3f31';

--- a/migration/sql-test-files/084-codebases-spaceid-url-idx-setup.sql
+++ b/migration/sql-test-files/084-codebases-spaceid-url-idx-setup.sql
@@ -1,0 +1,26 @@
+-- Create space for this test
+INSERT INTO
+    spaces(id, name)
+VALUES
+    ('86af5178-9b41-469b-9096-57e5155c3f31', 'foobarspace');
+
+-- Insert in codebase an entry for spaceid and url
+INSERT INTO
+    codebases(url, space_id)
+VALUES
+    ('https://github.com/fabric8-services/fabric8-wit/',
+     '86af5178-9b41-469b-9096-57e5155c3f31');
+
+-- Repeat the above sql command to create duplicate entry
+INSERT INTO
+    codebases(url, space_id)
+VALUES
+    ('https://github.com/fabric8-services/fabric8-wit/',
+     '86af5178-9b41-469b-9096-57e5155c3f31');
+
+-- Repeat the above sql command to create duplicate entry
+INSERT INTO
+    codebases(url, space_id)
+VALUES
+    ('https://github.com/fabric8-services/fabric8-wit/',
+     '86af5178-9b41-469b-9096-57e5155c3f31');

--- a/migration/sql-test-files/084-codebases-spaceid-url-idx-setup.sql
+++ b/migration/sql-test-files/084-codebases-spaceid-url-idx-setup.sql
@@ -2,25 +2,32 @@
 INSERT INTO
     spaces(id, name)
 VALUES
-    ('86af5178-9b41-469b-9096-57e5155c3f31', 'foobarspace');
+    ('48d8987f-d7c2-454f-b67c-4cad74199b26', 'foobarspace');
 
--- Insert in codebase an entry for spaceid and url
+
+-- Insert in codebase an entry for spaceid and url that is deleted before
 INSERT INTO
-    codebases(url, space_id)
+    codebases(url, space_id, id, deleted_at)
 VALUES
     ('https://github.com/fabric8-services/fabric8-wit/',
-     '86af5178-9b41-469b-9096-57e5155c3f31');
-
--- Repeat the above sql command to create duplicate entry
-INSERT INTO
-    codebases(url, space_id)
-VALUES
-    ('https://github.com/fabric8-services/fabric8-wit/',
-     '86af5178-9b41-469b-9096-57e5155c3f31');
+     '48d8987f-d7c2-454f-b67c-4cad74199b26',
+     '6bef707f-e2a4-4a39-95b8-8b51c4d8589d',
+     '2018-03-10 05:28:33.262133+00');
 
 -- Repeat the above sql command to create duplicate entry
+-- but which is not deleted before.
 INSERT INTO
-    codebases(url, space_id)
+    codebases(url, space_id, id)
 VALUES
     ('https://github.com/fabric8-services/fabric8-wit/',
-     '86af5178-9b41-469b-9096-57e5155c3f31');
+     '48d8987f-d7c2-454f-b67c-4cad74199b26',
+     '97bd2bc3-106a-41d8-a1d9-3fdd6d2df1f7');
+
+-- Insert in codebase an entry for spaceid and url that is deleted before
+INSERT INTO
+    codebases(url, space_id, id, deleted_at)
+VALUES
+    ('https://github.com/fabric8-services/fabric8-wit/',
+     '48d8987f-d7c2-454f-b67c-4cad74199b26',
+     '25feb91f-dbed-40ce-bb46-335a4d741213',
+     '2018-03-10 05:28:33.262133+00');

--- a/migration/sql-test-files/084-codebases-spaceid-url-idx-test.sql
+++ b/migration/sql-test-files/084-codebases-spaceid-url-idx-test.sql
@@ -1,0 +1,4 @@
+-- Try to create duplicate entry
+SELECT *
+FROM codebases
+WHERE id='97bd2bc3-106a-41d8-a1d9-3fdd6d2df1f7';

--- a/migration/sql-test-files/084-codebases-spaceid-url-idx-violate.sql
+++ b/migration/sql-test-files/084-codebases-spaceid-url-idx-violate.sql
@@ -1,0 +1,6 @@
+-- Try to create duplicate entry
+INSERT INTO
+    codebases(url, space_id)
+VALUES
+    ('https://github.com/fabric8-services/fabric8-wit/',
+     '86af5178-9b41-469b-9096-57e5155c3f31');

--- a/migration/sql-test-files/084-codebases-spaceid-url-idx-violate.sql
+++ b/migration/sql-test-files/084-codebases-spaceid-url-idx-violate.sql
@@ -3,4 +3,4 @@ INSERT INTO
     codebases(url, space_id)
 VALUES
     ('https://github.com/fabric8-services/fabric8-wit/',
-     '86af5178-9b41-469b-9096-57e5155c3f31');
+     '48d8987f-d7c2-454f-b67c-4cad74199b26');


### PR DESCRIPTION
When adding/associating codebase with a space, there is a possibility
that user tries to add an already existing codebase.

This commit adds a check to see if the codebase user is trying to add
already exists in space.

Fixes https://github.com/fabric8-services/fabric8-wit/issues/1294