### PR TITLE
WIP: Ordered TableJoins with delegation and optional where

### DIFF
--- a/workitem/expression_compiler.go
+++ b/workitem/expression_compiler.go
@@ -17,7 +17,7 @@ const (
 // Compile takes an expression and compiles it to a where clause for use with
 // gorm.DB.Where(). Returns the number of expected parameters for the query and a
 // slice of errors if something goes wrong.
-func Compile(where criteria.Expression) (whereClause string, parameters []interface{}, joins map[string]TableJoin, err []error) {
+func Compile(where criteria.Expression) (whereClause string, parameters []interface{}, joins []*TableJoin, err []error) {
 	compiler := newExpressionCompiler()
 
 	criteria.IteratePostOrder(where, bubbleUpJSONContext(&compiler))
@@ -29,20 +29,24 @@ func Compile(where criteria.Expression) (whereClause string, parameters []interf
 		c = ""
 	}
 
-	if err := compiler.joins.ActivateRequiredJoins(); err != nil {
-		compiler.err = append(compiler.err, err)
+	// Make sure we don't return all possible joins but only the once that were
+	// activated. Returning them as a slice preserves the correct order of
+	// joins.
+	joins, e := compiler.joins.GetOrderdActivatedJoins()
+	if e != nil {
+		compiler.err = append(compiler.err, e)
 	}
 
-	// Make sure we don't return all possible joins but only the once that were activated
-	joins = map[string]TableJoin{}
-	for k, j := range compiler.joins {
-		if j.Active {
-			joins[k] = *j
+	for _, j := range joins {
+		if j.Where == "" {
+			continue
 		}
+		if c != "" {
+			c += " AND "
+		}
+		c += j.Where
 	}
-	if len(joins) <= 0 {
-		joins = nil
-	}
+
 	return c, compiler.parameters, joins, compiler.err
 }
 
@@ -117,7 +121,7 @@ func (c *expressionCompiler) getFieldName(fieldName string) (mappedFieldName str
 // DefaultTableJoins returns the default list of joinable tables used when
 // creating a new expression compiler.
 func DefaultTableJoins() TableJoinMap {
-	return TableJoinMap{
+	res := TableJoinMap{
 		"iteration": {
 			TableName:        "iterations",
 			TableAlias:       "iter",
@@ -146,13 +150,6 @@ func DefaultTableJoins() TableJoinMap {
 			PrefixActivators: []string{"wit.", "workitemtype.", "work_item_type.", "type."},
 			AllowedColumns:   []string{"name"},
 		},
-		"space": {
-			TableName:        "spaces",
-			TableAlias:       "space",
-			On:               "space.id = " + WorkItemStorage{}.TableName() + ".space_id",
-			PrefixActivators: []string{"space."},
-			AllowedColumns:   []string{"name"},
-		},
 		"creator": {
 			TableName:        "users",
 			TableAlias:       "creator",
@@ -160,7 +157,15 @@ func DefaultTableJoins() TableJoinMap {
 			PrefixActivators: []string{"creator.", "author."},
 			AllowedColumns:   []string{"full_name"},
 		},
+		"space": {
+			TableName:        "spaces",
+			TableAlias:       "space",
+			On:               Column("space", "id") + "=" + Column(WorkItemStorage{}.TableName(), "space_id"),
+			PrefixActivators: []string{"space."},
+			AllowedColumns:   []string{"name"},
+		},
 	}
+	return res
 }
 
 func newExpressionCompiler() expressionCompiler {

--- a/workitem/expression_compiler_blackbox_test.go
+++ b/workitem/expression_compiler_blackbox_test.go
@@ -138,7 +138,7 @@ func expect(t *testing.T, expr c.Expression, expectedClause string, expectedPara
 		require.Equal(t, expectedParameters, parameters, "parameters mismatch")
 	})
 	t.Run("check joins", func(t *testing.T) {
-		require.Equal(t, expectedJoins, joins)
+		require.Equal(t, expectedJoins, joins, "joins mismatch")
 	})
 }
 

--- a/workitem/table_join.go
+++ b/workitem/table_join.go
@@ -144,7 +144,7 @@ func (j *TableJoin) TranslateFieldName(fieldName string) (string, error) {
 				return "", errs.Errorf(`delegated join "%s" for field "%s" must not point to nil`, prefix, fieldName)
 			}
 			delegator = dele
-			// ensure the other join is activate (just to be safe) if it
+			// ensure the other join is active (just to be safe) if it
 			// wasn't activated yet.
 			delegator.Active = true
 			break

--- a/workitem/table_join.go
+++ b/workitem/table_join.go
@@ -34,6 +34,10 @@ type TableJoin struct {
 	// On is the ON part of the JOIN.
 	On string // e.g. `fields@> concat('{"system.iteration": "', iter.ID, '"}')::jsonb`
 
+	// Where defines what condition to place in the main WHERE clause of the
+	// query final query.
+	Where string
+
 	// PrefixActivators can hold a number of prefix strings that cause this join
 	// object to be activated.
 	PrefixActivators []string // e.g. []string{"iteration."}
@@ -57,6 +61,10 @@ type TableJoin struct {
 	// looks like. If you ask for "A" and that requires "B", then "B" is also
 	// added automatically.
 	ActivateOtherJoins []string
+
+	// All prefixes in the map keys that would normally be handled by this join
+	// will be handled by the join specified here (if any).
+	DelegateTo map[string]*TableJoin
 
 	// TODO(kwk): Maybe introduce a column mapping table here: ColumnMapping map[string]string
 }
@@ -112,6 +120,7 @@ func (j *TableJoin) TranslateFieldName(fieldName string) (string, error) {
 	for _, t := range j.PrefixActivators {
 		if strings.HasPrefix(fieldName, t) {
 			prefix = t
+			break
 		}
 	}
 	col := strings.TrimPrefix(fieldName, prefix)
@@ -127,17 +136,32 @@ func (j *TableJoin) TranslateFieldName(fieldName string) (string, error) {
 
 	// now we have the final column name
 
+	// Check if this field should be handled by another one table join
+	delegator := j
+	for prefix, dele := range j.DelegateTo {
+		if strings.HasPrefix(fieldName, prefix) {
+			if dele == nil {
+				return "", errs.Errorf(`delegated join "%s" for field "%s" must not point to nil`, prefix, fieldName)
+			}
+			delegator = dele
+			// ensure the other join is activate (just to be safe) if it
+			// wasn't activated yet.
+			delegator.Active = true
+			break
+		}
+	}
+
 	// if no columns are explicitly allowed, then this column is allowed by
 	// default.
-	columnIsAllowed := (j.AllowedColumns == nil || len(j.AllowedColumns) == 0)
-	for _, c := range j.AllowedColumns {
+	columnIsAllowed := (delegator.AllowedColumns == nil || len(delegator.AllowedColumns) == 0)
+	for _, c := range delegator.AllowedColumns {
 		if c == col {
 			columnIsAllowed = true
 			break
 		}
 	}
 	// check if a column is explicitly disallowed
-	for _, c := range j.DisallowedColumns {
+	for _, c := range delegator.DisallowedColumns {
 		if c == col {
 			columnIsAllowed = false
 			break
@@ -149,9 +173,9 @@ func (j *TableJoin) TranslateFieldName(fieldName string) (string, error) {
 
 	// Remember what foreign columns where queried for. Later we can use
 	// Validate() to see if those columns do exist or not.
-	j.HandledFields = append(j.HandledFields, col)
+	delegator.HandledFields = append(delegator.HandledFields, col)
 
-	return Column(j.TableAlias, col), nil
+	return Column(delegator.TableAlias, col), nil
 }
 
 // TableJoinMap is used to store join in the expression compiler
@@ -182,5 +206,63 @@ func (joins *TableJoinMap) ActivateRequiredJoins() error {
 			}
 		}
 	}
+	return nil
+}
+
+// GetOrderdActivatedJoins returns a slice of activated joins in a proper order,
+// beginning with the join that activates no other join, and ending with the
+// join that activates another join but isn't activated by another join itself.
+func (joins *TableJoinMap) GetOrderdActivatedJoins() ([]*TableJoin, error) {
+	if err := joins.ActivateRequiredJoins(); err != nil {
+		return nil, errs.Wrap(err, "failed to get activate required joins")
+	}
+
+	orderer := activationOrderer{
+		m:              *joins,
+		alreadyVisited: map[*TableJoin]struct{}{},
+	}
+
+	for name := range *joins {
+		if err := orderer.visitDepthFirst(name); err != nil {
+			return nil, errs.Wrapf(err, `failed to visit "%s" join`, name)
+		}
+	}
+	return orderer.orderedActivatedJoins, nil
+}
+
+type activationOrderer struct {
+	m                     TableJoinMap
+	alreadyVisited        map[*TableJoin]struct{}
+	orderedActivatedJoins []*TableJoin
+}
+
+func (o *activationOrderer) visitDepthFirst(name string) error {
+	j, ok := o.m[name]
+	if !ok {
+		return errs.Errorf(`join "%s" not found`, name)
+	}
+
+	_, alreadyVisited := o.alreadyVisited[j]
+	if alreadyVisited {
+		return nil
+	}
+
+	o.alreadyVisited[j] = struct{}{}
+
+	if !j.Active {
+		return nil
+	}
+
+	for _, subJoinName := range j.ActivateOtherJoins {
+		if err := o.visitDepthFirst(subJoinName); err != nil {
+			return errs.Errorf(`failed to visit "%s" join`, subJoinName)
+		}
+	}
+
+	if o.orderedActivatedJoins == nil {
+		o.orderedActivatedJoins = []*TableJoin{}
+	}
+	o.orderedActivatedJoins = append(o.orderedActivatedJoins, j)
+
 	return nil
 }


### PR DESCRIPTION
This change consist of three parts:

1. The `workitem.Compile` function now returns a slice of ordered table join pointers instead of an unordered map. I analyse all joins (depth first) and begin with the joins that don't activate another join. I end with joins that activate joins that came before them. Essentially, this is not possible in SQL and this first part addresses exactly this problem:
```sql
SELECT foo.id FROM foo
LEFT JOIN a ON a.id = b.id -- b is not yet known here (move down in order to fix this)
LEFT JOIN b ON b.id = foo.id;
```
2. One can delegate the handling of fields with a certain prefix to another table join now. This is needed in my space templates branch in order to get a correct order when a access to a field is required over multiple joins and the joins depend on each other.
3. Optionally a table join can also add to the `WHERE` clause that returns from the `workitem.Compile` function now. I found out this was needed in my space templates branch. Sometimes you simply cannot put all criteria in the `ON` because some tables are not *yet* known to the system and no matter how you order them, you cannot solve it.