### PR TITLE
Replace $WITGROUP with typegroup.name

### DIFF
--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -34,7 +34,7 @@ const (
 	NOT      = "$NOT"
 	IN       = "$IN"
 	SUBSTR   = "$SUBSTR"
-	WITGROUP = "$WITGROUP"
+	WITGROUP = "typegroup.name"
 	OPTS     = "$OPTS"
 
 	OptParentExistsKey = "parent-exists"


### PR DESCRIPTION
`typegroup.name` instead of `$WITGROUP` will be the new field to query for typegroups and the special handling for wit groups in the `search_repository.go` will go away soon. But in order to give the UI a chance to replace `$WITGROUP` with `typegroup.name` I wanted to get this change in as early as possible.