### PR TITLE
Revert "Replace $WITGROUP with typegroup.name"

### DIFF
--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -34,7 +34,7 @@ const (
 	NOT      = "$NOT"
 	IN       = "$IN"
 	SUBSTR   = "$SUBSTR"
-	WITGROUP = "typegroup.name"
+	WITGROUP = "$WITGROUP"
 	OPTS     = "$OPTS"
 
 	OptParentExistsKey = "parent-exists"


### PR DESCRIPTION
Reverts fabric8-services/fabric8-wit#1929

Broke preview and blocking prod rollout:

```
error listing work items for expression '{"$AND":[{"space":{"$EQ":"8764603a-6e8a-4cfb-be9f-26abbb09534a"}},{"$WITGROUP":{"$EQ":"Experiences"}}],"$OPTS":{"tree-view":true}}': failed to parse filter string: Bad value for parameter 'key not found': '$WITGROUP'
```