### PR TITLE
Update Replication Controller selection logic to mirror the web console

### DIFF
--- a/kubernetes/deployments_kubeclient_whitebox_test.go
+++ b/kubernetes/deployments_kubeclient_whitebox_test.go
@@ -1,0 +1,94 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func TestGetMostRecentByDeploymentVersion(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		rcs            map[string]*v1.ReplicationController
+		expectedRCName string
+		shouldFail     bool
+	}{
+		{
+			testName: "Basic",
+			rcs: map[string]*v1.ReplicationController{
+				"world": createRC("world", "1"),
+				"hello": createRC("hello", "2"),
+			},
+			expectedRCName: "hello",
+		},
+		{
+			testName: "Empty",
+			rcs:      map[string]*v1.ReplicationController{},
+		},
+		{
+			testName: "Version Not Number",
+			rcs: map[string]*v1.ReplicationController{
+				"world": createRC("world", "1"),
+				"hello": createRC("hello", "Not a number"),
+			},
+			shouldFail: true,
+		},
+		{
+			testName: "First Without Version",
+			rcs: map[string]*v1.ReplicationController{
+				"world": createRC("world", ""),
+				"hello": createRC("hello", "2"),
+			},
+			expectedRCName: "hello",
+		},
+		{
+			testName: "Second Without Version",
+			rcs: map[string]*v1.ReplicationController{
+				"world": createRC("world", "1"),
+				"hello": createRC("hello", ""),
+			},
+			expectedRCName: "world",
+		},
+		{
+			testName: "Both Without Version",
+			rcs: map[string]*v1.ReplicationController{
+				"hello": createRC("hello", ""),
+				"world": createRC("world", ""),
+			},
+			expectedRCName: "world",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			result, err := getMostRecentByDeploymentVersion(testCase.rcs)
+			if testCase.shouldFail {
+				require.Error(t, err, "Expected an error")
+			} else {
+				require.NoError(t, err, "Unexpected error occurred")
+				if len(testCase.expectedRCName) == 0 {
+					require.Nil(t, result, "Expected nil result")
+				} else {
+					require.NotNil(t, result, "Expected result to not be nil")
+					require.Equal(t, testCase.expectedRCName, result.Name)
+				}
+			}
+		})
+	}
+}
+
+func createRC(name string, version string) *v1.ReplicationController {
+	annotations := make(map[string]string)
+	if len(version) > 0 {
+		annotations["openshift.io/deployment-config.latest-version"] = version
+	}
+	return &v1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+	}
+}

--- a/test/kubernetes/replicationcontroller-scaled-down.json
+++ b/test/kubernetes/replicationcontroller-scaled-down.json
@@ -1,0 +1,497 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/deployer-pod.completed-at": "2018-01-25 16:33:26 +0000 UTC",
+                    "openshift.io/deployer-pod.created-at": "2018-01-25 16:33:03 +0000 UTC",
+                    "openshift.io/deployer-pod.name": "myApp-1-deploy",
+                    "openshift.io/deployment-config.latest-version": "1",
+                    "openshift.io/deployment-config.name": "myApp",
+                    "openshift.io/deployment.phase": "Complete",
+                    "openshift.io/deployment.replicas": "1",
+                    "openshift.io/deployment.status-reason": "config change",
+                    "openshift.io/encoded-deployment-config": "{\"kind\":\"DeploymentConfig\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"myApp\",\"namespace\":\"my-run\",\"selfLink\":\"/apis/apps.openshift.io/v1/namespaces/my-run/deploymentconfigs/myApp\",\"uid\":\"8db1c9ba-91b5-46c6-be99-576245f42b3b\",\"resourceVersion\":\"837362058\",\"generation\":2,\"creationTimestamp\":\"2018-01-25T16:33:02Z\",\"labels\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myApp/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myApp\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myApp\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myApp\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myApp\"}},\"spec\":{\"strategy\":{\"type\":\"Rolling\",\"rollingParams\":{\"updatePeriodSeconds\":1,\"intervalSeconds\":1,\"timeoutSeconds\":3600,\"maxUnavailable\":\"25%\",\"maxSurge\":\"25%\"},\"resources\":{},\"activeDeadlineSeconds\":21600},\"triggers\":[{\"type\":\"ConfigChange\"},{\"type\":\"ImageChange\",\"imageChangeParams\":{\"automatic\":true,\"containerNames\":[\"myApp\"],\"from\":{\"kind\":\"ImageStreamTag\",\"namespace\":\"my-run\",\"name\":\"myApp:1.0.2\"},\"lastTriggeredImage\":\"127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\"}}],\"replicas\":1,\"revisionHistoryLimit\":2,\"test\":false,\"selector\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\"},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myApp/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myApp\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myApp\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myApp\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myApp\"}},\"spec\":{\"containers\":[{\"name\":\"myApp\",\"image\":\"127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\",\"ports\":[{\"name\":\"http\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"prometheus\",\"containerPort\":9779,\"protocol\":\"TCP\"},{\"name\":\"jolokia\",\"containerPort\":8778,\"protocol\":\"TCP\"}],\"env\":[{\"name\":\"KUBERNETES_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"apiVersion\":\"v1\",\"fieldPath\":\"metadata.namespace\"}}}],\"resources\":{\"limits\":{\"memory\":\"250Mi\"}},\"livenessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":180,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"readinessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"IfNotPresent\",\"securityContext\":{\"privileged\":false}}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\"}}},\"status\":{\"latestVersion\":1,\"observedGeneration\":2,\"replicas\":0,\"updatedReplicas\":0,\"availableReplicas\":0,\"unavailableReplicas\":0,\"details\":{\"message\":\"config change\",\"causes\":[{\"type\":\"ConfigChange\"}]},\"conditions\":[{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2018-01-25T16:33:02Z\",\"lastTransitionTime\":\"2018-01-25T16:33:02Z\",\"message\":\"Deployment config does not have minimum availability.\"}]}}\n"
+                },
+                "creationTimestamp": "2018-01-24T16:33:03Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myApp",
+                    "group": "myGroup",
+                    "openshift.io/deployment-config.name": "myApp",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myApp-1",
+                "namespace": "my-run",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps.openshift.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DeploymentConfig",
+                        "name": "myApp",
+                        "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+                    }
+                ],
+                "resourceVersion": "838024576",
+                "selfLink": "/api/v1/namespaces/my-run/replicationcontrollers/myApp-1",
+                "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+            },
+            "spec": {
+                "replicas": 2,
+                "selector": {
+                    "app": "myApp",
+                    "deployment": "myApp-1",
+                    "deploymentconfig": "myApp",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myApp/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myApp\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myApp",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myApp",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myApp",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myApp",
+                            "openshift.io/deployment.name": "myApp-1"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myApp",
+                            "deployment": "myApp-1",
+                            "deploymentconfig": "myApp",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myApp",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 2,
+                "fullyLabeledReplicas": 2,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/deployer-pod.completed-at": "2018-01-25 16:33:26 +0000 UTC",
+                    "openshift.io/deployer-pod.created-at": "2018-01-25 16:33:03 +0000 UTC",
+                    "openshift.io/deployer-pod.name": "myApp-1-deploy",
+                    "openshift.io/deployment-config.latest-version": "2",
+                    "openshift.io/deployment-config.name": "myApp",
+                    "openshift.io/deployment.phase": "Complete",
+                    "openshift.io/deployment.replicas": "0",
+                    "openshift.io/deployment.status-reason": "config change",
+                    "openshift.io/encoded-deployment-config": "{\"kind\":\"DeploymentConfig\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"myApp\",\"namespace\":\"my-run\",\"selfLink\":\"/apis/apps.openshift.io/v1/namespaces/my-run/deploymentconfigs/myApp\",\"uid\":\"8db1c9ba-91b5-46c6-be99-576245f42b3b\",\"resourceVersion\":\"837362058\",\"generation\":2,\"creationTimestamp\":\"2018-01-25T16:33:02Z\",\"labels\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myApp/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myApp\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myApp\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myApp\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myApp\"}},\"spec\":{\"strategy\":{\"type\":\"Rolling\",\"rollingParams\":{\"updatePeriodSeconds\":1,\"intervalSeconds\":1,\"timeoutSeconds\":3600,\"maxUnavailable\":\"25%\",\"maxSurge\":\"25%\"},\"resources\":{},\"activeDeadlineSeconds\":21600},\"triggers\":[{\"type\":\"ConfigChange\"},{\"type\":\"ImageChange\",\"imageChangeParams\":{\"automatic\":true,\"containerNames\":[\"myApp\"],\"from\":{\"kind\":\"ImageStreamTag\",\"namespace\":\"my-run\",\"name\":\"myApp:1.0.2\"},\"lastTriggeredImage\":\"127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\"}}],\"replicas\":1,\"revisionHistoryLimit\":2,\"test\":false,\"selector\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\"},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myApp/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myApp\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myApp\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myApp\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myApp\"}},\"spec\":{\"containers\":[{\"name\":\"myApp\",\"image\":\"127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\",\"ports\":[{\"name\":\"http\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"prometheus\",\"containerPort\":9779,\"protocol\":\"TCP\"},{\"name\":\"jolokia\",\"containerPort\":8778,\"protocol\":\"TCP\"}],\"env\":[{\"name\":\"KUBERNETES_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"apiVersion\":\"v1\",\"fieldPath\":\"metadata.namespace\"}}}],\"resources\":{\"limits\":{\"memory\":\"250Mi\"}},\"livenessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":180,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"readinessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"IfNotPresent\",\"securityContext\":{\"privileged\":false}}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\"}}},\"status\":{\"latestVersion\":1,\"observedGeneration\":2,\"replicas\":0,\"updatedReplicas\":0,\"availableReplicas\":0,\"unavailableReplicas\":0,\"details\":{\"message\":\"config change\",\"causes\":[{\"type\":\"ConfigChange\"}]},\"conditions\":[{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2018-01-25T16:33:02Z\",\"lastTransitionTime\":\"2018-01-25T16:33:02Z\",\"message\":\"Deployment config does not have minimum availability.\"}]}}\n"
+                },
+                "creationTimestamp": "2018-01-25T16:33:03Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myApp",
+                    "group": "myGroup",
+                    "openshift.io/deployment-config.name": "myApp",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myApp-2",
+                "namespace": "my-run",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps.openshift.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DeploymentConfig",
+                        "name": "myApp",
+                        "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+                    }
+                ],
+                "resourceVersion": "838024576",
+                "selfLink": "/api/v1/namespaces/my-run/replicationcontrollers/myApp-2",
+                "uid": "f3e4c398-9e17-4758-bf2a-f8f8ce61bf5f"
+            },
+            "spec": {
+                "replicas": 0,
+                "selector": {
+                    "app": "myApp",
+                    "deployment": "myApp-2",
+                    "deploymentconfig": "myApp",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myApp/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myApp\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myApp",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myApp",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myApp",
+                            "openshift.io/deployment-config.latest-version": "2",
+                            "openshift.io/deployment-config.name": "myApp",
+                            "openshift.io/deployment.name": "myApp-2"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myApp",
+                            "deployment": "myApp-2",
+                            "deploymentconfig": "myApp",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myApp",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 0,
+                "fullyLabeledReplicas": 0,
+                "observedGeneration": 3,
+                "readyReplicas": 0,
+                "replicas": 0
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/deployer-pod.completed-at": "2018-01-25 16:33:26 +0000 UTC",
+                    "openshift.io/deployer-pod.created-at": "2018-01-25 16:33:03 +0000 UTC",
+                    "openshift.io/deployer-pod.name": "myApp-1-deploy",
+                    "openshift.io/deployment-config.latest-version": "3",
+                    "openshift.io/deployment-config.name": "myApp",
+                    "openshift.io/deployment.phase": "Failed",
+                    "openshift.io/deployment.replicas": "0",
+                    "openshift.io/deployment.status-reason": "config change",
+                    "openshift.io/encoded-deployment-config": "{\"kind\":\"DeploymentConfig\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"myApp\",\"namespace\":\"my-run\",\"selfLink\":\"/apis/apps.openshift.io/v1/namespaces/my-run/deploymentconfigs/myApp\",\"uid\":\"8db1c9ba-91b5-46c6-be99-576245f42b3b\",\"resourceVersion\":\"837362058\",\"generation\":2,\"creationTimestamp\":\"2018-01-25T16:33:02Z\",\"labels\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myApp/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myApp\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myApp\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myApp\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myApp\"}},\"spec\":{\"strategy\":{\"type\":\"Rolling\",\"rollingParams\":{\"updatePeriodSeconds\":1,\"intervalSeconds\":1,\"timeoutSeconds\":3600,\"maxUnavailable\":\"25%\",\"maxSurge\":\"25%\"},\"resources\":{},\"activeDeadlineSeconds\":21600},\"triggers\":[{\"type\":\"ConfigChange\"},{\"type\":\"ImageChange\",\"imageChangeParams\":{\"automatic\":true,\"containerNames\":[\"myApp\"],\"from\":{\"kind\":\"ImageStreamTag\",\"namespace\":\"my-run\",\"name\":\"myApp:1.0.2\"},\"lastTriggeredImage\":\"127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\"}}],\"replicas\":1,\"revisionHistoryLimit\":2,\"test\":false,\"selector\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\"},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"myApp\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myApp/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myApp\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myApp\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myApp\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myApp\"}},\"spec\":{\"containers\":[{\"name\":\"myApp\",\"image\":\"127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\",\"ports\":[{\"name\":\"http\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"prometheus\",\"containerPort\":9779,\"protocol\":\"TCP\"},{\"name\":\"jolokia\",\"containerPort\":8778,\"protocol\":\"TCP\"}],\"env\":[{\"name\":\"KUBERNETES_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"apiVersion\":\"v1\",\"fieldPath\":\"metadata.namespace\"}}}],\"resources\":{\"limits\":{\"memory\":\"250Mi\"}},\"livenessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":180,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"readinessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"IfNotPresent\",\"securityContext\":{\"privileged\":false}}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\"}}},\"status\":{\"latestVersion\":1,\"observedGeneration\":2,\"replicas\":0,\"updatedReplicas\":0,\"availableReplicas\":0,\"unavailableReplicas\":0,\"details\":{\"message\":\"config change\",\"causes\":[{\"type\":\"ConfigChange\"}]},\"conditions\":[{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2018-01-25T16:33:02Z\",\"lastTransitionTime\":\"2018-01-25T16:33:02Z\",\"message\":\"Deployment config does not have minimum availability.\"}]}}\n"
+                },
+                "creationTimestamp": "2018-01-23T16:33:03Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myApp",
+                    "group": "myGroup",
+                    "openshift.io/deployment-config.name": "myApp",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myApp-3",
+                "namespace": "my-run",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps.openshift.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DeploymentConfig",
+                        "name": "myApp",
+                        "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+                    }
+                ],
+                "resourceVersion": "838024576",
+                "selfLink": "/api/v1/namespaces/my-run/replicationcontrollers/myApp-3",
+                "uid": "b3be15cb-2353-43be-ae86-947ab885adfe"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "app": "myApp",
+                    "deployment": "myApp-3",
+                    "deploymentconfig": "myApp",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myApp/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myApp\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myApp",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myApp",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myApp",
+                            "openshift.io/deployment-config.latest-version": "3",
+                            "openshift.io/deployment-config.name": "myApp",
+                            "openshift.io/deployment.name": "myApp-3"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myApp",
+                            "deployment": "myApp-3",
+                            "deploymentconfig": "myApp",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myApp",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 0,
+                "fullyLabeledReplicas": 0,
+                "observedGeneration": 3,
+                "readyReplicas": 0,
+                "replicas": 0
+            }
+        }
+
+
+    ],
+    "kind": "ReplicationControllerList",
+    "metadata": {},
+    "resourceVersion": "",
+    "selfLink": ""
+}


### PR DESCRIPTION
This PR addresses https://github.com/openshiftio/openshift.io/issues/2356. Currently, if there are multiple replication controllers present for a given deployment config, we always use the most recently created one. This PR changes this to use the following algorithm which is also used by the OpenShift web console.

1. Consider replication controllers that are in-progress or currently have replicas.
2. Also consider the most recently created RC in the "Completed" state. (Assures we have something to show when scaled down)
3. From those, choose the RC with the highest deployment version according to the relevant annotation. If for some reason the annotations are missing, compare RC names lexicographically.

There is a new blackbox test that verifies that the expected replication controller is selected even when scaled down. I also added a whitebox test for some of the finer details of the selection algorithm.