### PR TITLE
fix(search): support old "$WITGROUP" as well as new "typegroup.name" fields

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -459,7 +459,7 @@ func (s *searchControllerTestSuite) TestSearchByWorkItemTypeGroup() {
 				// given
 				filter := fmt.Sprintf(`
 				{"$AND": [
-					{"`+search.paramName+`": "Scenarios"},
+					{"`+paramName+`": "Scenarios"},
 					{"space": "%s"}
 				]}`, fxt.Spaces[0].ID)
 				// when
@@ -477,7 +477,7 @@ func (s *searchControllerTestSuite) TestSearchByWorkItemTypeGroup() {
 				// given
 				filter := fmt.Sprintf(`
 				{"$AND": [
-					{"`+search.paramName+`": "Experiences"},
+					{"`+paramName+`": "Experiences"},
 					{"space": "%s"}
 				]}`, fxt.Spaces[0].ID)
 				// when
@@ -493,7 +493,7 @@ func (s *searchControllerTestSuite) TestSearchByWorkItemTypeGroup() {
 				// given
 				filter := fmt.Sprintf(`
 				{"$AND": [
-					{"`+search.paramName+`": "Requirements"},
+					{"`+paramName+`": "Requirements"},
 					{"space": "%s"}
 				]}`, fxt.Spaces[0].ID)
 				// when
@@ -511,7 +511,7 @@ func (s *searchControllerTestSuite) TestSearchByWorkItemTypeGroup() {
 				// given
 				filter := fmt.Sprintf(`
 				{"$AND": [
-					{"`+search.paramName+`": "Execution"},
+					{"`+paramName+`": "Execution"},
 					{"space": "%s"}
 				]}`, fxt.Spaces[0].ID)
 				// when
@@ -534,7 +534,7 @@ func (s *searchControllerTestSuite) TestSearchByWorkItemTypeGroup() {
 				fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment())
 				filter := fmt.Sprintf(`
 				{"$AND": [
-					{"`+search.paramName+`": "%s"},
+					{"`+paramName+`": "%s"},
 					{"space": "%s"}
 				]}`, "unknown work item type group", fxt.Spaces[0].ID)
 				// when

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -405,141 +405,143 @@ func (s *searchControllerTestSuite) TestSearchFilter() {
 }
 
 func (s *searchControllerTestSuite) TestSearchByWorkItemTypeGroup() {
-	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
-		// given
-		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment())
-		svc := testsupport.ServiceAsUser("TestUpdateWI-Service", *fxt.Identities[0])
-		workitemsCtrl := NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
-		// given work items of different types and in different states
-		type testWI struct {
-			Title          string
-			WorkItemTypeID uuid.UUID
-			State          string
-			SpaceID        uuid.UUID
-		}
-		testWIs := []testWI{
-			{"closed feature", workitem.SystemFeature, workitem.SystemStateClosed, fxt.Spaces[0].ID},
-			{"open feature", workitem.SystemFeature, workitem.SystemStateOpen, fxt.Spaces[0].ID},
-			{"closed bug", workitem.SystemBug, workitem.SystemStateClosed, fxt.Spaces[0].ID},
-			{"open bug", workitem.SystemBug, workitem.SystemStateOpen, fxt.Spaces[0].ID},
-			{"open experience", workitem.SystemExperience, workitem.SystemStateOpen, fxt.Spaces[0].ID},
-			{"closed experience", workitem.SystemExperience, workitem.SystemStateClosed, fxt.Spaces[0].ID},
-			{"open task", workitem.SystemTask, workitem.SystemStateOpen, fxt.Spaces[0].ID},
-			{"closed task", workitem.SystemTask, workitem.SystemStateClosed, fxt.Spaces[0].ID},
-			{"open scenario", workitem.SystemScenario, workitem.SystemStateOpen, fxt.Spaces[0].ID},
-			{"closed scenario", workitem.SystemScenario, workitem.SystemStateClosed, fxt.Spaces[0].ID},
-			{"open fundamental", workitem.SystemFundamental, workitem.SystemStateOpen, fxt.Spaces[0].ID},
-			{"closed fundamental", workitem.SystemFundamental, workitem.SystemStateClosed, fxt.Spaces[0].ID},
-		}
-		for _, wi := range testWIs {
-			payload := minimumRequiredCreateWithTypeAndSpace(wi.WorkItemTypeID, wi.SpaceID)
-			payload.Data.Attributes[workitem.SystemTitle] = wi.Title
-			payload.Data.Attributes[workitem.SystemState] = wi.State
-			_, _ = test.CreateWorkitemsCreated(t, svc.Context, svc, workitemsCtrl, wi.SpaceID, &payload)
-		}
-
-		// helper function that checks if the given to be found work item titles
-		// exist in the result list that originate from a search query.
-		checkToBeFound := func(t *testing.T, toBeFound map[string]struct{}, results []*app.WorkItem) {
-			require.Len(t, results, len(toBeFound))
-			for _, wi := range results {
-				title, ok := wi.Attributes[workitem.SystemTitle].(string)
-				require.True(t, ok)
-				_, ok = toBeFound[title]
-				if ok {
-					delete(toBeFound, title)
-				}
-			}
-			require.Empty(t, toBeFound, "not all work items could be found: %+v", toBeFound)
-		}
-
-		// when
-		t.Run("Scenarios", func(t *testing.T) {
-			// given
-			filter := fmt.Sprintf(`
-				{"$AND": [
-					{"`+search.WITGROUP+`": "Scenarios"},
-					{"space": "%s"}
-				]}`, fxt.Spaces[0].ID)
-			// when
-			_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-			// then
-			toBeFound := map[string]struct{}{
-				"open scenario":      {},
-				"closed scenario":    {},
-				"open fundamental":   {},
-				"closed fundamental": {},
-			}
-			checkToBeFound(t, toBeFound, sr.Data)
-		})
-		t.Run("Experiences", func(t *testing.T) {
-			// given
-			filter := fmt.Sprintf(`
-				{"$AND": [
-					{"`+search.WITGROUP+`": "Experiences"},
-					{"space": "%s"}
-				]}`, fxt.Spaces[0].ID)
-			// when
-			_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-			// then
-			toBeFound := map[string]struct{}{
-				"open experience":   {},
-				"closed experience": {},
-			}
-			checkToBeFound(t, toBeFound, sr.Data)
-		})
-		t.Run("Requirements", func(t *testing.T) {
-			// given
-			filter := fmt.Sprintf(`
-				{"$AND": [
-					{"`+search.WITGROUP+`": "Requirements"},
-					{"space": "%s"}
-				]}`, fxt.Spaces[0].ID)
-			// when
-			_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-			// then
-			toBeFound := map[string]struct{}{
-				"open feature":   {},
-				"closed feature": {},
-				"open bug":       {},
-				"closed bug":     {},
-			}
-			checkToBeFound(t, toBeFound, sr.Data)
-		})
-		t.Run("Execution", func(t *testing.T) {
-			// given
-			filter := fmt.Sprintf(`
-				{"$AND": [
-					{"`+search.WITGROUP+`": "Execution"},
-					{"space": "%s"}
-				]}`, fxt.Spaces[0].ID)
-			// when
-			_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-			// then
-			toBeFound := map[string]struct{}{
-				"open task":      {},
-				"closed task":    {},
-				"open bug":       {},
-				"closed bug":     {},
-				"open feature":   {},
-				"closed feature": {},
-			}
-			checkToBeFound(t, toBeFound, sr.Data)
-		})
-	})
-	s.T().Run(http.StatusText(http.StatusBadRequest), func(t *testing.T) {
-		t.Run("unknown hierarchy", func(t *testing.T) {
+	for _, paramName := range []string{search.WITGROUP, search.TypeGroupName} {
+		s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
 			// given
 			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment())
-			filter := fmt.Sprintf(`
+			svc := testsupport.ServiceAsUser("TestUpdateWI-Service", *fxt.Identities[0])
+			workitemsCtrl := NewWorkitemsController(svc, gormapplication.NewGormDB(s.DB), s.Configuration)
+			// given work items of different types and in different states
+			type testWI struct {
+				Title          string
+				WorkItemTypeID uuid.UUID
+				State          string
+				SpaceID        uuid.UUID
+			}
+			testWIs := []testWI{
+				{"closed feature", workitem.SystemFeature, workitem.SystemStateClosed, fxt.Spaces[0].ID},
+				{"open feature", workitem.SystemFeature, workitem.SystemStateOpen, fxt.Spaces[0].ID},
+				{"closed bug", workitem.SystemBug, workitem.SystemStateClosed, fxt.Spaces[0].ID},
+				{"open bug", workitem.SystemBug, workitem.SystemStateOpen, fxt.Spaces[0].ID},
+				{"open experience", workitem.SystemExperience, workitem.SystemStateOpen, fxt.Spaces[0].ID},
+				{"closed experience", workitem.SystemExperience, workitem.SystemStateClosed, fxt.Spaces[0].ID},
+				{"open task", workitem.SystemTask, workitem.SystemStateOpen, fxt.Spaces[0].ID},
+				{"closed task", workitem.SystemTask, workitem.SystemStateClosed, fxt.Spaces[0].ID},
+				{"open scenario", workitem.SystemScenario, workitem.SystemStateOpen, fxt.Spaces[0].ID},
+				{"closed scenario", workitem.SystemScenario, workitem.SystemStateClosed, fxt.Spaces[0].ID},
+				{"open fundamental", workitem.SystemFundamental, workitem.SystemStateOpen, fxt.Spaces[0].ID},
+				{"closed fundamental", workitem.SystemFundamental, workitem.SystemStateClosed, fxt.Spaces[0].ID},
+			}
+			for _, wi := range testWIs {
+				payload := minimumRequiredCreateWithTypeAndSpace(wi.WorkItemTypeID, wi.SpaceID)
+				payload.Data.Attributes[workitem.SystemTitle] = wi.Title
+				payload.Data.Attributes[workitem.SystemState] = wi.State
+				_, _ = test.CreateWorkitemsCreated(t, svc.Context, svc, workitemsCtrl, wi.SpaceID, &payload)
+			}
+
+			// helper function that checks if the given to be found work item titles
+			// exist in the result list that originate from a search query.
+			checkToBeFound := func(t *testing.T, toBeFound map[string]struct{}, results []*app.WorkItem) {
+				require.Len(t, results, len(toBeFound))
+				for _, wi := range results {
+					title, ok := wi.Attributes[workitem.SystemTitle].(string)
+					require.True(t, ok)
+					_, ok = toBeFound[title]
+					if ok {
+						delete(toBeFound, title)
+					}
+				}
+				require.Empty(t, toBeFound, "not all work items could be found: %+v", toBeFound)
+			}
+
+			// when
+			t.Run("Scenarios", func(t *testing.T) {
+				// given
+				filter := fmt.Sprintf(`
 				{"$AND": [
-					{"`+search.WITGROUP+`": "%s"},
+					{"`+search.paramName+`": "Scenarios"},
+					{"space": "%s"}
+				]}`, fxt.Spaces[0].ID)
+				// when
+				_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
+				// then
+				toBeFound := map[string]struct{}{
+					"open scenario":      {},
+					"closed scenario":    {},
+					"open fundamental":   {},
+					"closed fundamental": {},
+				}
+				checkToBeFound(t, toBeFound, sr.Data)
+			})
+			t.Run("Experiences", func(t *testing.T) {
+				// given
+				filter := fmt.Sprintf(`
+				{"$AND": [
+					{"`+search.paramName+`": "Experiences"},
+					{"space": "%s"}
+				]}`, fxt.Spaces[0].ID)
+				// when
+				_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
+				// then
+				toBeFound := map[string]struct{}{
+					"open experience":   {},
+					"closed experience": {},
+				}
+				checkToBeFound(t, toBeFound, sr.Data)
+			})
+			t.Run("Requirements", func(t *testing.T) {
+				// given
+				filter := fmt.Sprintf(`
+				{"$AND": [
+					{"`+search.paramName+`": "Requirements"},
+					{"space": "%s"}
+				]}`, fxt.Spaces[0].ID)
+				// when
+				_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
+				// then
+				toBeFound := map[string]struct{}{
+					"open feature":   {},
+					"closed feature": {},
+					"open bug":       {},
+					"closed bug":     {},
+				}
+				checkToBeFound(t, toBeFound, sr.Data)
+			})
+			t.Run("Execution", func(t *testing.T) {
+				// given
+				filter := fmt.Sprintf(`
+				{"$AND": [
+					{"`+search.paramName+`": "Execution"},
+					{"space": "%s"}
+				]}`, fxt.Spaces[0].ID)
+				// when
+				_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
+				// then
+				toBeFound := map[string]struct{}{
+					"open task":      {},
+					"closed task":    {},
+					"open bug":       {},
+					"closed bug":     {},
+					"open feature":   {},
+					"closed feature": {},
+				}
+				checkToBeFound(t, toBeFound, sr.Data)
+			})
+		})
+		s.T().Run(http.StatusText(http.StatusBadRequest), func(t *testing.T) {
+			t.Run("unknown hierarchy", func(t *testing.T) {
+				// given
+				fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment())
+				filter := fmt.Sprintf(`
+				{"$AND": [
+					{"`+search.paramName+`": "%s"},
 					{"space": "%s"}
 				]}`, "unknown work item type group", fxt.Spaces[0].ID)
-			// when
-			_, _ = test.ShowSearchBadRequest(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
+				// when
+				_, _ = test.ShowSearchBadRequest(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
+			})
 		})
-	})
+	}
 }
 
 // It creates 1 space

--- a/search/query_language_whitebox_test.go
+++ b/search/query_language_whitebox_test.go
@@ -657,85 +657,87 @@ func TestWorkItemTypeGroup(t *testing.T) {
 		return e
 	}
 
-	t.Run(WITGROUP+" as a query child", func(t *testing.T) {
-		for _, typeGroup := range typeGroups {
-			t.Run(typeGroup.Name, func(t *testing.T) {
-				// given
-				spaceName := "openshiftio"
-				q := Query{
-					Name: OR,
-					Children: []Query{
-						{Name: "space", Value: &spaceName},
-						{Name: WITGROUP, Value: &typeGroup.Name},
-					},
-				}
-				// when
-				actualExpr, _ := q.generateExpression()
-				// then
-				expectedExpr := c.Or(
-					c.Equals(
-						c.Field("SpaceID"),
-						c.Literal(spaceName),
-					),
-					typeGroupToExpr(typeGroup, false),
-				)
-				expectEqualExpr(t, expectedExpr, actualExpr)
-			})
-		}
-	})
+	for _, paramName := range []string{WITGROUP, TypeGroupName} {
+		t.Run(paramName+" as a query child", func(t *testing.T) {
+			for _, typeGroup := range typeGroups {
+				t.Run(typeGroup.Name, func(t *testing.T) {
+					// given
+					spaceName := "openshiftio"
+					q := Query{
+						Name: OR,
+						Children: []Query{
+							{Name: "space", Value: &spaceName},
+							{Name: paramName, Value: &typeGroup.Name},
+						},
+					}
+					// when
+					actualExpr, _ := q.generateExpression()
+					// then
+					expectedExpr := c.Or(
+						c.Equals(
+							c.Field("SpaceID"),
+							c.Literal(spaceName),
+						),
+						typeGroupToExpr(typeGroup, false),
+					)
+					expectEqualExpr(t, expectedExpr, actualExpr)
+				})
+			}
+		})
 
-	t.Run(WITGROUP+" as a query child using NOT", func(t *testing.T) {
-		for _, typeGroup := range typeGroups {
-			t.Run(typeGroup.Name, func(t *testing.T) {
-				// given
-				spaceName := "openshiftio"
-				q := Query{
-					Name: OR,
-					Children: []Query{
-						{Name: "space", Value: &spaceName},
-						{Name: WITGROUP, Value: &typeGroup.Name, Negate: true},
-					},
-				}
-				// when
-				actualExpr, _ := q.generateExpression()
-				// then
-				expectedExpr := c.Or(
-					c.Equals(
-						c.Field("SpaceID"),
-						c.Literal(spaceName),
-					),
-					typeGroupToExpr(typeGroup, true),
-				)
-				expectEqualExpr(t, expectedExpr, actualExpr)
-			})
-		}
-	})
+		t.Run(paramName+" as a query child using NOT", func(t *testing.T) {
+			for _, typeGroup := range typeGroups {
+				t.Run(typeGroup.Name, func(t *testing.T) {
+					// given
+					spaceName := "openshiftio"
+					q := Query{
+						Name: OR,
+						Children: []Query{
+							{Name: "space", Value: &spaceName},
+							{Name: paramName, Value: &typeGroup.Name, Negate: true},
+						},
+					}
+					// when
+					actualExpr, _ := q.generateExpression()
+					// then
+					expectedExpr := c.Or(
+						c.Equals(
+							c.Field("SpaceID"),
+							c.Literal(spaceName),
+						),
+						typeGroupToExpr(typeGroup, true),
+					)
+					expectEqualExpr(t, expectedExpr, actualExpr)
+				})
+			}
+		})
 
-	t.Run(WITGROUP+" as a top-level expression", func(t *testing.T) {
-		for _, typeGroup := range typeGroups {
-			t.Run(typeGroup.Name, func(t *testing.T) {
-				// given
-				q := Query{Name: WITGROUP, Value: &typeGroup.Name}
-				// when
-				actualExpr, _ := q.generateExpression()
-				// then
-				expectedExpr := typeGroupToExpr(typeGroup, false)
-				expectEqualExpr(t, expectedExpr, actualExpr)
-			})
-		}
-	})
+		t.Run(paramName+" as a top-level expression", func(t *testing.T) {
+			for _, typeGroup := range typeGroups {
+				t.Run(typeGroup.Name, func(t *testing.T) {
+					// given
+					q := Query{Name: paramName, Value: &typeGroup.Name}
+					// when
+					actualExpr, _ := q.generateExpression()
+					// then
+					expectedExpr := typeGroupToExpr(typeGroup, false)
+					expectEqualExpr(t, expectedExpr, actualExpr)
+				})
+			}
+		})
 
-	t.Run(WITGROUP+" as a top-level expression using NOT", func(t *testing.T) {
-		for _, typeGroup := range typeGroups {
-			t.Run(typeGroup.Name, func(t *testing.T) {
-				// given
-				q := Query{Name: WITGROUP, Value: &typeGroup.Name, Negate: true}
-				// when
-				actualExpr, _ := q.generateExpression()
-				// then
-				expectedExpr := typeGroupToExpr(typeGroup, true)
-				expectEqualExpr(t, expectedExpr, actualExpr)
-			})
-		}
-	})
+		t.Run(paramName+" as a top-level expression using NOT", func(t *testing.T) {
+			for _, typeGroup := range typeGroups {
+				t.Run(typeGroup.Name, func(t *testing.T) {
+					// given
+					q := Query{Name: paramName, Value: &typeGroup.Name, Negate: true}
+					// when
+					actualExpr, _ := q.generateExpression()
+					// then
+					expectedExpr := typeGroupToExpr(typeGroup, true)
+					expectEqualExpr(t, expectedExpr, actualExpr)
+				})
+			}
+		})
+	}
 }

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -37,6 +37,9 @@ const (
 	WITGROUP = "$WITGROUP"
 	OPTS     = "$OPTS"
 
+	// This is the replacement for $WITGROUP in the upcoming changes.
+	TypeGroupName = "typegroup.name"
+
 	OptParentExistsKey = "parent-exists"
 	OptTreeViewKey     = "tree-view"
 )
@@ -402,32 +405,34 @@ func (q Query) determineLiteralType(key string, val string) criteria.Expression 
 	}
 }
 
-// handleWitGroup Here we handle the "$WITGROUP" query parameter which we translate from a
-// simple
+// handleWitGroup Here we handle the "$WITGROUP" and "typegroup.name" query
+// parameter which we translate from a simple
 //
-// "$WITGROUP = y"
+// "$WITGROUP = y" or "typegroup.name = y"
 //
 // expression into an
 //
 // "Type in (y1, y2, y3, ... ,yn)"
 //
-// expression where yi represents the i-th work item type associated with
-// the work item type group y.
+// expression where yi represents the i-th work item type associated with the
+// work item type group y.
 func handleWitGroup(q Query, expArr *[]criteria.Expression) error {
-	if q.Name != WITGROUP {
+	if q.Name != WITGROUP && q.Name != "typegroup.name" {
 		return nil
 	}
 	if expArr == nil {
 		return errs.New("expression array must not be nil")
 	}
 
+	paramName := q.Name
+
 	typeGroupName := q.Value
 	if typeGroupName == nil {
-		return errors.NewBadParameterError(WITGROUP, typeGroupName).Expected("not nil")
+		return errors.NewBadParameterError(paramName, typeGroupName).Expected("not nil")
 	}
 	typeGroup := workitem.TypeGroupByName(*typeGroupName)
 	if typeGroup == nil {
-		return errors.NewBadParameterError(WITGROUP, *typeGroupName).Expected("existing " + WITGROUP)
+		return errors.NewBadParameterError(paramName, *typeGroupName).Expected("existing " + paramName)
 	}
 	var e criteria.Expression
 	if !q.Negate {
@@ -463,7 +468,7 @@ func (q Query) generateExpression() (criteria.Expression, error) {
 	var myexpr []criteria.Expression
 	currentOperator := q.Name
 
-	if q.Name == WITGROUP {
+	if q.Name == WITGROUP || q.Name == TypeGroupName {
 		err := handleWitGroup(q, &myexpr)
 		if err != nil {
 			return nil, errs.Wrap(err, "failed to handle hierarchy in top-level element")
@@ -509,10 +514,10 @@ func (q Query) generateExpression() (criteria.Expression, error) {
 				return nil, err
 			}
 			myexpr = append(myexpr, exp)
-		} else if child.Name == WITGROUP {
+		} else if child.Name == WITGROUP || child.Name == TypeGroupName {
 			err := handleWitGroup(child, &myexpr)
 			if err != nil {
-				return nil, errs.Wrap(err, "failed to handle "+WITGROUP+" in child element")
+				return nil, errs.Wrap(err, "failed to handle "+child.Name+" in child element")
 			}
 		} else {
 			key, ok := searchKeyMap[child.Name]

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -417,7 +417,7 @@ func (q Query) determineLiteralType(key string, val string) criteria.Expression 
 // expression where yi represents the i-th work item type associated with the
 // work item type group y.
 func handleWitGroup(q Query, expArr *[]criteria.Expression) error {
-	if q.Name != WITGROUP && q.Name != "typegroup.name" {
+	if q.Name != WITGROUP && q.Name != TypeGroupName {
 		return nil
 	}
 	if expArr == nil {

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -222,12 +222,13 @@ func TestIsOperator(t *testing.T) {
 		"   ": false,
 		"foo": false,
 		uuid.NewV4().String(): false,
-		EQ:       false,
-		NE:       false,
-		NOT:      false,
-		IN:       false,
-		SUBSTR:   false,
-		WITGROUP: false,
+		EQ:            false,
+		NE:            false,
+		NOT:           false,
+		IN:            false,
+		SUBSTR:        false,
+		WITGROUP:      false,
+		TypeGroupName: false,
 	}
 	for k, v := range testData {
 		t.Run(k, func(t *testing.T) {
@@ -241,173 +242,175 @@ func TestIsOperator(t *testing.T) {
 }
 
 func TestHandleWitGroup(t *testing.T) {
-	type testData struct {
-		Name                string
-		Value               string
-		Negate              bool
-		ExpectError         bool
-		ExpectedExrpessions []criteria.Expression
-	}
-	td := []testData{
-		{"foo", "bar", false, false, []criteria.Expression{}},
-		{WITGROUP, "unknown", false, true, []criteria.Expression{}},
-		{WITGROUP, "Scenarios", false, false, []criteria.Expression{
-			criteria.Or(
-				criteria.Or(
-					criteria.Equals(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemScenario.String()),
-					),
-					criteria.Equals(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemFundamental.String()),
-					),
-				),
-				criteria.Equals(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemPapercuts.String()),
-				),
-			)},
-		},
-		{WITGROUP, "Experiences", false, false, []criteria.Expression{
-			criteria.Or(
-				criteria.Equals(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemExperience.String()),
-				),
-				criteria.Equals(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemValueProposition.String()),
-				),
-			)},
-		},
-		{WITGROUP, "Requirements", false, false, []criteria.Expression{
-			criteria.Or(
-				criteria.Equals(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemFeature.String()),
-				),
-				criteria.Equals(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemBug.String()),
-				),
-			)},
-		},
-		{WITGROUP, "Execution", false, false, []criteria.Expression{
-			criteria.Or(
-				criteria.Or(
-					criteria.Equals(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemTask.String()),
-					),
-					criteria.Equals(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemBug.String()),
-					),
-				),
-				criteria.Equals(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemFeature.String()),
-				),
-			),
-		}},
-		// // same with negation
-		{"foo", "bar", true, false, []criteria.Expression{}},
-		{WITGROUP, "unknown", true, true, []criteria.Expression{}},
-		{WITGROUP, "Scenarios", true, false, []criteria.Expression{
-			criteria.And(
-				criteria.And(
-					criteria.Not(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemScenario.String()),
-					),
-					criteria.Not(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemFundamental.String()),
-					),
-				),
-				criteria.Not(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemPapercuts.String()),
-				),
-			)},
-		},
-		{WITGROUP, "Experiences", true, false, []criteria.Expression{
-			criteria.And(
-				criteria.Not(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemExperience.String()),
-				),
-				criteria.Not(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemValueProposition.String()),
-				),
-			)},
-		},
-		{WITGROUP, "Requirements", true, false, []criteria.Expression{
-			criteria.And(
-				criteria.Not(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemFeature.String()),
-				),
-				criteria.Not(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemBug.String()),
-				),
-			)},
-		},
-		{WITGROUP, "Execution", true, false, []criteria.Expression{
-			criteria.And(
-				criteria.And(
-					criteria.Not(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemTask.String()),
-					),
-					criteria.Not(
-						criteria.Field("Type"),
-						criteria.Literal(workitem.SystemBug.String()),
-					),
-				),
-				criteria.Not(
-					criteria.Field("Type"),
-					criteria.Literal(workitem.SystemFeature.String()),
-				),
-			),
-		}},
-	}
-	for _, d := range td {
-		format := "%s = %s"
-		if d.Negate {
-			format = "%s != %s"
+	for _, paramName := range []string{WITGROUP, TypeGroupName} {
+		type testData struct {
+			Name                string
+			Value               string
+			Negate              bool
+			ExpectError         bool
+			ExpectedExrpessions []criteria.Expression
 		}
-		t.Run(fmt.Sprintf(format, d.Name, d.Value), func(t *testing.T) {
-			exp := []criteria.Expression{}
-			err := handleWitGroup(Query{Name: d.Name, Value: &d.Value, Negate: d.Negate}, &exp)
-			if d.ExpectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+		td := []testData{
+			{"foo", "bar", false, false, []criteria.Expression{}},
+			{paramName, "unknown", false, true, []criteria.Expression{}},
+			{paramName, "Scenarios", false, false, []criteria.Expression{
+				criteria.Or(
+					criteria.Or(
+						criteria.Equals(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemScenario.String()),
+						),
+						criteria.Equals(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemFundamental.String()),
+						),
+					),
+					criteria.Equals(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemPapercuts.String()),
+					),
+				)},
+			},
+			{paramName, "Experiences", false, false, []criteria.Expression{
+				criteria.Or(
+					criteria.Equals(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemExperience.String()),
+					),
+					criteria.Equals(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemValueProposition.String()),
+					),
+				)},
+			},
+			{paramName, "Requirements", false, false, []criteria.Expression{
+				criteria.Or(
+					criteria.Equals(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemFeature.String()),
+					),
+					criteria.Equals(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemBug.String()),
+					),
+				)},
+			},
+			{paramName, "Execution", false, false, []criteria.Expression{
+				criteria.Or(
+					criteria.Or(
+						criteria.Equals(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemTask.String()),
+						),
+						criteria.Equals(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemBug.String()),
+						),
+					),
+					criteria.Equals(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemFeature.String()),
+					),
+				),
+			}},
+			// // same with negation
+			{"foo", "bar", true, false, []criteria.Expression{}},
+			{paramName, "unknown", true, true, []criteria.Expression{}},
+			{paramName, "Scenarios", true, false, []criteria.Expression{
+				criteria.And(
+					criteria.And(
+						criteria.Not(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemScenario.String()),
+						),
+						criteria.Not(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemFundamental.String()),
+						),
+					),
+					criteria.Not(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemPapercuts.String()),
+					),
+				)},
+			},
+			{paramName, "Experiences", true, false, []criteria.Expression{
+				criteria.And(
+					criteria.Not(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemExperience.String()),
+					),
+					criteria.Not(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemValueProposition.String()),
+					),
+				)},
+			},
+			{paramName, "Requirements", true, false, []criteria.Expression{
+				criteria.And(
+					criteria.Not(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemFeature.String()),
+					),
+					criteria.Not(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemBug.String()),
+					),
+				)},
+			},
+			{paramName, "Execution", true, false, []criteria.Expression{
+				criteria.And(
+					criteria.And(
+						criteria.Not(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemTask.String()),
+						),
+						criteria.Not(
+							criteria.Field("Type"),
+							criteria.Literal(workitem.SystemBug.String()),
+						),
+					),
+					criteria.Not(
+						criteria.Field("Type"),
+						criteria.Literal(workitem.SystemFeature.String()),
+					),
+				),
+			}},
+		}
+		for _, d := range td {
+			format := "%s = %s"
+			if d.Negate {
+				format = "%s != %s"
 			}
-			require.Equal(t, exp, d.ExpectedExrpessions)
+			t.Run(fmt.Sprintf(format, d.Name, d.Value), func(t *testing.T) {
+				exp := []criteria.Expression{}
+				err := handleWitGroup(Query{Name: d.Name, Value: &d.Value, Negate: d.Negate}, &exp)
+				if d.ExpectError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				require.Equal(t, exp, d.ExpectedExrpessions)
+			})
+		}
+
+		t.Run("value is nil", func(t *testing.T) {
+			// given
+			var v *string
+			exp := []criteria.Expression{}
+			// when
+			err := handleWitGroup(Query{Name: paramName, Value: v}, &exp)
+			// then
+			require.Error(t, err)
+		})
+		t.Run("expression array is nil", func(t *testing.T) {
+			// given
+			v := "Scenarios"
+			var exp *[]criteria.Expression
+			// when
+			err := handleWitGroup(Query{Name: paramName, Value: &v}, exp)
+			// then
+			require.Error(t, err)
 		})
 	}
-
-	t.Run("value is nil", func(t *testing.T) {
-		// given
-		var v *string
-		exp := []criteria.Expression{}
-		// when
-		err := handleWitGroup(Query{Name: WITGROUP, Value: v}, &exp)
-		// then
-		require.Error(t, err)
-	})
-	t.Run("expression array is nil", func(t *testing.T) {
-		// given
-		v := "Scenarios"
-		var exp *[]criteria.Expression
-		// when
-		err := handleWitGroup(Query{Name: WITGROUP, Value: &v}, exp)
-		// then
-		require.Error(t, err)
-	})
 }


### PR DESCRIPTION
This addresses the backward compatibility problems I introduced with #1929 (was reverted meanwhile).

`typegroup.name` instead of `$WITGROUP` will be the new field to query for typegroups and the special handling for wit groups in the `search_repository.go` will go away soon.

In #1929 I removed support for `$WITGROUP` but here I kept it an only added support for an additional `typegroup.name`. I've modified all tests that deal with `$WITGROUP` to now test for `typegroup.name` as well.