### PR TITLE
Cleanup controller helper functions

### DIFF
--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -68,7 +68,7 @@ func (c *CodebaseController) Show(ctx *app.ShowCodebaseContext) error {
 	})
 }
 
-// Deprecated: ListWorkspaces action should be used instead.
+// Edit Deprecated: ListWorkspaces action should be used instead.
 func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
 	listWorkspacesContext := app.ListWorkspacesCodebaseContext{ctx.Context, ctx.ResponseData, ctx.RequestData, ctx.CodebaseID}
 	return c.ListWorkspaces(&listWorkspacesContext)

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -43,28 +43,6 @@ type TestIterationREST struct {
 	policy  *auth.KeycloakPolicy
 }
 
-// following helper function creates a space , root area, root iteration for that space.
-// Also creates a new iteration and new area in the same space
-func createSpaceAndRootAreaAndIterations(t *testing.T, db *gorm.DB) *tf.TestFixture {
-	return tf.NewTestFixture(t, db,
-		tf.CreateWorkItemEnvironment(),
-		tf.Iterations(2, func(fxt *tf.TestFixture, idx int) error {
-			switch idx {
-			case 1:
-				start, err := time.Parse(time.RFC822, "02 Jan 06 15:04 MST")
-				if err != nil {
-					return err
-				}
-				end := start.Add(time.Hour * 24 * 365 * 100)
-				fxt.Iterations[idx].StartAt = &start
-				fxt.Iterations[idx].EndAt = &end
-			}
-			return nil
-		}),
-		tf.Areas(2),
-	)
-}
-
 func TestRunIterationREST(t *testing.T) {
 	// given
 	suite.Run(t, &TestIterationREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})

--- a/controller/test-files/iteration/show/ok.res.iteration.golden.json
+++ b/controller/test-files/iteration/show/ok.res.iteration.golden.json
@@ -3,44 +3,45 @@
     "attributes": {
       "active_status": true,
       "created-at": "0001-01-01T00:00:00Z",
+      "description": "Some description",
       "endAt": "2105-12-09T15:04:00Z",
-      "name": "Sprint #2",
-      "parent_path": "/00000000-0000-0000-0000-000000000001",
-      "resolved_parent_path": "/foo-00000000-0000-0000-0000-000000000002",
+      "name": "iteration 00000000-0000-0000-0000-000000000001",
+      "parent_path": "/00000000-0000-0000-0000-000000000002",
+      "resolved_parent_path": "/space 00000000-0000-0000-0000-000000000003",
       "startAt": "2006-01-02T15:04:00Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false
     },
-    "id": "00000000-0000-0000-0000-000000000003",
+    "id": "00000000-0000-0000-0000-000000000004",
     "links": {
-      "related": "http:///api/iterations/00000000-0000-0000-0000-000000000003",
-      "self": "http:///api/iterations/00000000-0000-0000-0000-000000000003"
+      "related": "http:///api/iterations/00000000-0000-0000-0000-000000000004",
+      "self": "http:///api/iterations/00000000-0000-0000-0000-000000000004"
     },
     "relationships": {
       "parent": {
         "data": {
-          "id": "00000000-0000-0000-0000-000000000001",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "iterations"
         },
         "links": {
-          "related": "http:///api/iterations/00000000-0000-0000-0000-000000000001",
-          "self": "http:///api/iterations/00000000-0000-0000-0000-000000000001"
+          "related": "http:///api/iterations/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/iterations/00000000-0000-0000-0000-000000000002"
         }
       },
       "space": {
         "data": {
-          "id": "00000000-0000-0000-0000-000000000004",
+          "id": "00000000-0000-0000-0000-000000000005",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
-          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000005",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000005"
         }
       },
       "workitems": {
         "links": {
-          "related": "http:///api/workitems/?filter[iteration]=00000000-0000-0000-0000-000000000003"
+          "related": "http:///api/workitems/?filter[iteration]=00000000-0000-0000-0000-000000000004"
         },
         "meta": {
           "closed": 0,

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -833,72 +833,6 @@ func minimumRequiredCreatePayload(spaceIDOptional ...uuid.UUID) app.CreateWorkit
 	}
 }
 
-func createOneRandomUserIdentity(ctx context.Context, db *gorm.DB) *account.Identity {
-	newUserUUID := uuid.NewV4()
-	identityRepo := account.NewIdentityRepository(db)
-	identity := account.Identity{
-		Username: "Test User Integration Random",
-		ID:       newUserUUID,
-	}
-	err := identityRepo.Create(ctx, &identity)
-	if err != nil {
-		fmt.Println("should not happen off.")
-		return nil
-	}
-	return &identity
-}
-
-func createOneRandomIteration(ctx context.Context, db *gorm.DB) *iteration.Iteration {
-	iterationRepo := iteration.NewIterationRepository(db)
-	spaceRepo := space.NewRepository(db)
-
-	// added timestmap to the space in order to make this function usable for more than one test
-	// else it fails with - (pq: duplicate key value violates unique constraint "spaces_name_idx")
-	newSpace := space.Space{
-		Name: "Space iteration " + time.Now().String(),
-	}
-	space, err := spaceRepo.Create(ctx, &newSpace)
-	if err != nil {
-		fmt.Println("Failed to create space for iteration.")
-		return nil
-	}
-
-	itr := iteration.Iteration{
-		Name:    "Sprint 101",
-		SpaceID: space.ID,
-	}
-	err = iterationRepo.Create(ctx, &itr)
-	if err != nil {
-		fmt.Println("Failed to create iteration.")
-		return nil
-	}
-	return &itr
-}
-
-func createOneRandomArea(ctx context.Context, db *gorm.DB) *area.Area {
-	areaRepo := area.NewAreaRepository(db)
-	spaceRepo := space.NewRepository(db)
-
-	newSpace := space.Space{
-		Name: fmt.Sprintf("Space area %v", uuid.NewV4()),
-	}
-	space, err := spaceRepo.Create(ctx, &newSpace)
-	if err != nil {
-		fmt.Println("Failed to create space for area.")
-		return nil
-	}
-	ar := area.Area{
-		Name:    "Area 51",
-		SpaceID: space.ID,
-	}
-	err = areaRepo.Create(ctx, &ar)
-	if err != nil {
-		fmt.Println("Failed to create area.")
-		return nil
-	}
-	return &ar
-}
-
 func newChildIteration(ctx context.Context, db *gorm.DB, parentIteration *iteration.Iteration) *iteration.Iteration {
 	iterationRepo := iteration.NewIterationRepository(db)
 
@@ -1100,7 +1034,8 @@ func (s *WorkItem2Suite) TestWI2UpdateMultipleScenarios() {
 	s.minimumPayload.Data.Attributes["version"] = updatedWI.Data.Attributes["version"]
 
 	// update assignee relationship and verify
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Identities(1))
+	newUser := fxt.Identities[0]
 	require.NotNil(s.T(), newUser)
 
 	newUserUUID := newUser.ID.String()
@@ -1315,7 +1250,8 @@ func (s *WorkItem2Suite) TestWI2FailCreateWithEmptyTitle() {
 func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 	// given
 	userType := APIStringTypeUser
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Identities(1))
+	newUser := fxt.Identities[0]
 	newUserID := newUser.ID.String()
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
@@ -1341,9 +1277,10 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 
 func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 	// given
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
-	newUser2 := createOneRandomUserIdentity(s.svc.Context, s.DB)
-	newUser3 := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Identities(3))
+	newUser := fxt.Identities[0]
+	newUser2 := fxt.Identities[1]
+	newUser3 := fxt.Identities[2]
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -1385,7 +1322,8 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 
 func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 	// given
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Identities(1))
+	newUser := fxt.Identities[0]
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -1414,7 +1352,8 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 func (s *WorkItem2Suite) TestWI2ListByNoAssigneeFilter() {
 	// given
 	userType := APIStringTypeUser
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Identities(1))
+	newUser := fxt.Identities[0]
 	newUserID := newUser.ID.String()
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
@@ -1584,7 +1523,8 @@ func (s *WorkItem2Suite) TestWI2ListByStateFilterOKModifiedUsingIfNoneMatchIfMod
 }
 
 func (s *WorkItem2Suite) setupAreaWorkItem(createWorkItem bool) (uuid.UUID, string, *app.WorkItemSingle) {
-	tempArea := createOneRandomArea(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Areas(1))
+	tempArea := fxt.Areas[0]
 	require.NotNil(s.T(), tempArea)
 	areaID := tempArea.ID.String()
 	c := minimumRequiredCreatePayload()
@@ -1687,7 +1627,8 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilterNotModifiedUsingIfNoneMatchHeade
 }
 
 func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
-	tempIteration := createOneRandomIteration(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1))
+	tempIteration := fxt.Iterations[0]
 	require.NotNil(s.T(), tempIteration)
 	iterationID := tempIteration.ID.String()
 	c := minimumRequiredCreatePayload()
@@ -1729,7 +1670,8 @@ func (s *WorkItem2Suite) TestWI2FailCreateInvalidAssignees() {
 }
 
 func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Identities(1))
+	newUser := fxt.Identities[0]
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -1756,8 +1698,9 @@ func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
 }
 
 func (s *WorkItem2Suite) TestWI2SuccessUpdateWithAssigneesRelation() {
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
-	newUser2 := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Identities(2))
+	newUser := fxt.Identities[0]
+	newUser2 := fxt.Identities[1]
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -2106,7 +2049,8 @@ func (s *WorkItem2Suite) TestWI2CreateUnknownArea() {
 
 func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 	// given
-	_, _, _, _, iterationInstance := createSpaceAndRootAreaAndIterations(s.T(), gormapplication.NewGormDB(s.DB))
+	fxt := createSpaceAndRootAreaAndIterations(s.T(), s.DB)
+	iterationInstance := *fxt.Iterations[1]
 	iterationID := iterationInstance.ID.String()
 	itType := iteration.APIStringTypeIteration
 	// when
@@ -2132,7 +2076,8 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 
 func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 	// given
-	_, _, _, _, iterationInstance := createSpaceAndRootAreaAndIterations(s.T(), gormapplication.NewGormDB(s.DB))
+	fxt := createSpaceAndRootAreaAndIterations(s.T(), s.DB)
+	iterationInstance := *fxt.Iterations[1]
 	iterationID := iterationInstance.ID.String()
 	itType := iteration.APIStringTypeIteration
 	c := minimumRequiredCreatePayload()
@@ -2169,7 +2114,10 @@ func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 
 func (s *WorkItem2Suite) TestWI2UpdateWithRootIterationIfMissing() {
 	// given
-	testSpace, _, rootIteration, _, otherIteration := createSpaceAndRootAreaAndIterations(s.T(), gormapplication.NewGormDB(s.DB))
+	fxt := createSpaceAndRootAreaAndIterations(s.T(), s.DB)
+	otherIteration := *fxt.Iterations[1]
+	rootIteration := *fxt.Iterations[0]
+	testSpace := *fxt.Spaces[0]
 	iterationID := otherIteration.ID.String()
 	iterationType := iteration.APIStringTypeIteration
 	payload := app.CreateWorkitemsPayload{
@@ -2225,7 +2173,8 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootIterationIfMissing() {
 func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 	s.T().Skip("iteration.data can't be sent as nil from client libs since it's optionall and is removed during json encoding")
 	// given
-	_, _, _, _, iterationInstance := createSpaceAndRootAreaAndIterations(s.T(), gormapplication.NewGormDB(s.DB))
+	fxt := createSpaceAndRootAreaAndIterations(s.T(), s.DB)
+	iterationInstance := *fxt.Iterations[1]
 	iterationID := iterationInstance.ID.String()
 	itType := iteration.APIStringTypeIteration
 	// when
@@ -2574,7 +2523,13 @@ func (s *WorkItem2Suite) TestDefaultSpaceAndIterationRelations() {
 // Following test verifies that UPDATE on WI by setting AREA & Iteration
 // works as expected and do not alter previously set values
 func (s *WorkItem2Suite) TestWI2UpdateWithAreaIterationSuccessively() {
-	sp, rootArea, rootIteration, areaInstance, iterationInstance := createSpaceAndRootAreaAndIterations(s.T(), gormapplication.NewGormDB(s.DB))
+	fxt := createSpaceAndRootAreaAndIterations(s.T(), s.DB)
+	iterationInstance := *fxt.Iterations[1]
+	rootIteration := *fxt.Iterations[0]
+	areaInstance := *fxt.Areas[1]
+	rootArea := *fxt.Areas[0]
+	sp := *fxt.Spaces[0]
+
 	iterationID := iterationInstance.ID.String()
 	areaID := areaInstance.ID.String()
 	itType := iteration.APIStringTypeIteration
@@ -2670,8 +2625,8 @@ func (s *WorkItem2Suite) xTestWI2IfModifiedSince() {
 }
 
 func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
-	grandParentIteration := createOneRandomIteration(s.svc.Context, s.DB)
-	require.NotNil(s.T(), grandParentIteration)
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.Iterations(1))
+	grandParentIteration := fxt.Iterations[0]
 
 	parentIteration := newChildIteration(s.svc.Context, s.DB, grandParentIteration)
 	require.NotNil(s.T(), parentIteration)

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -534,7 +534,12 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, spaceID uuid.UUID, up
 	wiStorage.Version = wiStorage.Version + 1
 	wiStorage.Type = updatedWorkItem.Type
 	wiStorage.Fields = Fields{}
-	wiStorage.ExecutionOrder = updatedWorkItem.Fields[SystemOrder].(float64)
+
+	var convOk bool
+	wiStorage.ExecutionOrder, convOk = updatedWorkItem.Fields[SystemOrder].(float64)
+	if !convOk {
+		return nil, errors.NewConversionError(fmt.Sprintf("failed to convert field %s to float: %+v", SystemOrder, updatedWorkItem))
+	}
 	for fieldName, fieldDef := range wiType.Fields {
 		if fieldName == SystemCreatedAt || fieldName == SystemUpdatedAt || fieldName == SystemOrder {
 			continue


### PR DESCRIPTION
* Refactored `controller.createSpaceAndRootAreaAndIterations()` to use test fixture
* Replaced `controller.createOneRandomUserIdentity()/createOneRandomIteration()/createOneRandomArea()` with test fixture
* Added conversion check for `workitem.Fields[SystemOrder].(float64)` on work item repo's `Save()` method 