### PR TITLE
Revert "Removes sort by name/ID of workitems in result.Data in search API. (#1924)"

### DIFF
--- a/controller/search.go
+++ b/controller/search.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/fabric8-services/fabric8-wit/id"
 	"github.com/fabric8-services/fabric8-wit/workitem/link"
@@ -38,6 +39,96 @@ type SearchController struct {
 func NewSearchController(service *goa.Service, db application.DB, configuration searchConfiguration) *SearchController {
 	return &SearchController{Controller: service.NewController("SearchController"), db: db, configuration: configuration}
 }
+
+// WorkItemPtrSlice exists in order to allow sorting results in a search
+// response.
+type WorkItemPtrSlice []*app.WorkItem
+
+// Len is the number of elements in the collection.
+func (a WorkItemPtrSlice) Len() int {
+	return len(a)
+}
+
+// Less reports whether the element with
+// index i should sort before the element with index j.
+func (a WorkItemPtrSlice) Less(i, j int) bool {
+	title1, foundTitle1 := a[i].Attributes[workitem.SystemTitle]
+	title2, foundTitle2 := a[j].Attributes[workitem.SystemTitle]
+	if foundTitle1 && foundTitle2 {
+		t1, cast1Ok := title1.(string)
+		t2, cast2Ok := title2.(string)
+		if cast1Ok && cast2Ok {
+			return t1 < t2
+		}
+	}
+	return a[i].ID.String() < a[j].ID.String()
+}
+
+// Swap swaps the elements with indexes i and j.
+func (a WorkItemPtrSlice) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+// Ensure WorkItemPtrSlice implements the sort.Interface
+var _ sort.Interface = WorkItemPtrSlice{}
+var _ sort.Interface = (*WorkItemPtrSlice)(nil)
+
+// WorkItemInterfaceSlice exists in order to allow sorting results in a search
+// response.
+type WorkItemInterfaceSlice []interface{}
+
+// Len is the number of elements in the collection.
+func (a WorkItemInterfaceSlice) Len() int {
+	return len(a)
+}
+
+// Less reports whether the element with index i should sort before the element
+// with index j.
+//
+// NOTE: For now we assume that included elements in the search response are
+// only work items. We can handle work items as pointers or objects. Both
+// options are possible.
+func (a WorkItemInterfaceSlice) Less(i, j int) bool {
+	var x, y *app.WorkItem
+
+	switch v := a[i].(type) {
+	case app.WorkItem:
+		x = &v
+	case *app.WorkItem:
+		x = v
+	}
+
+	switch v := a[j].(type) {
+	case app.WorkItem:
+		y = &v
+	case *app.WorkItem:
+		y = v
+	}
+
+	if x == nil || y == nil {
+		return false
+	}
+
+	title1, foundTitle1 := x.Attributes[workitem.SystemTitle]
+	title2, foundTitle2 := y.Attributes[workitem.SystemTitle]
+	if foundTitle1 && foundTitle2 {
+		t1, cast1Ok := title1.(string)
+		t2, cast2Ok := title2.(string)
+		if cast1Ok && cast2Ok {
+			return t1 < t2
+		}
+	}
+	return x.ID.String() < y.ID.String()
+}
+
+// Swap swaps the elements with indexes i and j.
+func (a WorkItemInterfaceSlice) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+// Ensure WorkItemInterfaceSlice implements the sort.Interface
+var _ sort.Interface = WorkItemInterfaceSlice{}
+var _ sort.Interface = (*WorkItemInterfaceSlice)(nil)
 
 // Show runs the show action.
 func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
@@ -94,6 +185,16 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 			}
 			c.enrichWorkItemList(ctx, ancestors, matchingWorkItemIDs, childLinks, &response, hasChildren) // append parentWI and ancestors (if not empty) in response
 			setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(result), offset, limit, count, "filter[expression]="+*ctx.FilterExpression)
+
+			// Sort "data" by name or ID if no title given
+			var data WorkItemPtrSlice = response.Data
+			sort.Sort(data)
+			response.Data = data
+
+			// Sort work items in the "included" array by ID or title
+			var included WorkItemInterfaceSlice = response.Included
+			sort.Sort(included)
+			response.Included = included
 
 			// build up list of sorted ancestor IDs from already sorted work items
 			ancestorIDs := ancestors.GetDistinctAncestorIDs().ToMap()

--- a/controller/test-files/search/show/in_topology_A-B-C-D_and_B-E_search_for_B_and_C/do_not_include_children.res.payload.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C-D_and_B-E_search_for_B_and_C/do_not_include_children.res.payload.golden.json
@@ -3,11 +3,11 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 3,
-        "system.order": 3000,
+        "system.number": 2,
+        "system.order": 2000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "C",
+        "system.title": "B",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -80,11 +80,11 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 2,
-        "system.order": 2000,
+        "system.number": 3,
+        "system.order": 3000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "B",
+        "system.title": "C",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },

--- a/controller/test-files/search/show/in_topology_A-B-C-D_and_B-E_search_for_B_and_C/include_children.res.payload.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C-D_and_B-E_search_for_B_and_C/include_children.res.payload.golden.json
@@ -3,11 +3,11 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 3,
-        "system.order": 3000,
+        "system.number": 2,
+        "system.order": 2000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "C",
+        "system.title": "B",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -85,95 +85,11 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 2,
-        "system.order": 2000,
+        "system.number": 3,
+        "system.order": 3000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "B",
-        "system.updated_at": "0001-01-01T00:00:00Z",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000005",
-      "links": {
-        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005",
-        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
-      },
-      "relationships": {
-        "area": {},
-        "assignees": {},
-        "baseType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
-          }
-        },
-        "children": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/children"
-          },
-          "meta": {
-            "hasChildren": true
-          }
-        },
-        "comments": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/comments",
-            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005/relationships/comments"
-          }
-        },
-        "creator": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
-            "links": {
-              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
-              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
-            },
-            "type": "users"
-          }
-        },
-        "iteration": {},
-        "labels": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/labels"
-          }
-        },
-        "parent": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000006",
-            "type": "workitems"
-          }
-        },
-        "space": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
-            "type": "spaces"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
-          }
-        },
-        "workItemLinks": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/links"
-          }
-        }
-      },
-      "type": "workitems"
-    }
-  ],
-  "included": [
-    {
-      "attributes": {
-        "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 1,
-        "system.order": 1000,
-        "system.remote_item_id": null,
-        "system.state": "new",
-        "system.title": "A",
+        "system.title": "C",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -224,7 +140,12 @@
             "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/labels"
           }
         },
-        "parent": {},
+        "parent": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "type": "workitems"
+          }
+        },
         "space": {
           "data": {
             "id": "00000000-0000-0000-0000-000000000003",
@@ -238,6 +159,85 @@
         "workItemLinks": {
           "links": {
             "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/links"
+          }
+        }
+      },
+      "type": "workitems"
+    }
+  ],
+  "included": [
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 1,
+        "system.order": 1000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "A",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000005",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/children"
+          },
+          "meta": {
+            "hasChildren": true
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000005/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/labels"
+          }
+        },
+        "parent": {},
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/links"
           }
         }
       },
@@ -303,7 +303,7 @@
         },
         "parent": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000005",
+            "id": "00000000-0000-0000-0000-000000000001",
             "type": "workitems"
           }
         },
@@ -332,8 +332,8 @@
   },
   "meta": {
     "ancestorIDs": [
-      "00000000-0000-0000-0000-000000000005",
-      "00000000-0000-0000-0000-000000000006"
+      "00000000-0000-0000-0000-000000000001",
+      "00000000-0000-0000-0000-000000000005"
     ],
     "totalCount": 2
   }

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B,C_with_tree-view=false.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B,C_with_tree-view=false.res.golden.json
@@ -3,11 +3,11 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 3,
-        "system.order": 3000,
+        "system.number": 2,
+        "system.order": 2000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "C",
+        "system.title": "B",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -33,7 +33,7 @@
             "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/children"
           },
           "meta": {
-            "hasChildren": false
+            "hasChildren": true
           }
         },
         "comments": {
@@ -80,11 +80,11 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 2,
-        "system.order": 2000,
+        "system.number": 3,
+        "system.order": 3000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "B",
+        "system.title": "C",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -110,7 +110,7 @@
             "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/children"
           },
           "meta": {
-            "hasChildren": true
+            "hasChildren": false
           }
         },
         "comments": {

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B,C_with_tree-view=true.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/B,C_with_tree-view=true.res.golden.json
@@ -3,11 +3,11 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 3,
-        "system.order": 3000,
+        "system.number": 2,
+        "system.order": 2000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "C",
+        "system.title": "B",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -33,7 +33,7 @@
             "related": "http:///api/workitems/00000000-0000-0000-0000-000000000001/children"
           },
           "meta": {
-            "hasChildren": false
+            "hasChildren": true
           }
         },
         "comments": {
@@ -85,11 +85,95 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 2,
-        "system.order": 2000,
+        "system.number": 3,
+        "system.order": 3000,
         "system.remote_item_id": null,
         "system.state": "new",
-        "system.title": "B",
+        "system.title": "C",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/children"
+          },
+          "meta": {
+            "hasChildren": false
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/labels"
+          }
+        },
+        "parent": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "type": "workitems"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/links"
+          }
+        }
+      },
+      "type": "workitems"
+    }
+  ],
+  "included": [
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 1,
+        "system.order": 1000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "A",
         "system.updated_at": "0001-01-01T00:00:00Z",
         "version": 0
       },
@@ -140,12 +224,7 @@
             "related": "http:///api/workitems/00000000-0000-0000-0000-000000000005/labels"
           }
         },
-        "parent": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000006",
-            "type": "workitems"
-          }
-        },
+        "parent": {},
         "space": {
           "data": {
             "id": "00000000-0000-0000-0000-000000000003",
@@ -165,93 +244,14 @@
       "type": "workitems"
     }
   ],
-  "included": [
-    {
-      "attributes": {
-        "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 1,
-        "system.order": 1000,
-        "system.remote_item_id": null,
-        "system.state": "new",
-        "system.title": "A",
-        "system.updated_at": "0001-01-01T00:00:00Z",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000006",
-      "links": {
-        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006",
-        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006"
-      },
-      "relationships": {
-        "area": {},
-        "assignees": {},
-        "baseType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
-          }
-        },
-        "children": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/children"
-          },
-          "meta": {
-            "hasChildren": true
-          }
-        },
-        "comments": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/comments",
-            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006/relationships/comments"
-          }
-        },
-        "creator": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
-            "links": {
-              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
-              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
-            },
-            "type": "users"
-          }
-        },
-        "iteration": {},
-        "labels": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/labels"
-          }
-        },
-        "parent": {},
-        "space": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
-            "type": "spaces"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
-          }
-        },
-        "workItemLinks": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/links"
-          }
-        }
-      },
-      "type": "workitems"
-    }
-  ],
   "links": {
     "first": "http:///api/search?page[offset]=0\u0026page[limit]=20\u0026filter[expression]={\"$AND\": [{\"$OR\": [{\"title\":\"C\"}, {\"title\":\"B\"}]}, {\"space\": \"00000000-0000-0000-0000-000000000003\"}],\"$OPTS\":{\"tree-view\": true}}",
     "last": "http:///api/search?page[offset]=0\u0026page[limit]=20\u0026filter[expression]={\"$AND\": [{\"$OR\": [{\"title\":\"C\"}, {\"title\":\"B\"}]}, {\"space\": \"00000000-0000-0000-0000-000000000003\"}],\"$OPTS\":{\"tree-view\": true}}"
   },
   "meta": {
     "ancestorIDs": [
-      "00000000-0000-0000-0000-000000000005",
-      "00000000-0000-0000-0000-000000000006"
+      "00000000-0000-0000-0000-000000000001",
+      "00000000-0000-0000-0000-000000000005"
     ],
     "totalCount": 2
   }

--- a/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/C_with_tree-view=true.res.golden.json
+++ b/controller/test-files/search/show/in_topology_A-B-C_and_A-D_search_for/C_with_tree-view=true.res.golden.json
@@ -87,6 +87,83 @@
     {
       "attributes": {
         "system.created_at": "0001-01-01T00:00:00Z",
+        "system.number": 1,
+        "system.order": 1000,
+        "system.remote_item_id": null,
+        "system.state": "new",
+        "system.title": "A",
+        "system.updated_at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "links": {
+        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006",
+        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006"
+      },
+      "relationships": {
+        "area": {},
+        "assignees": {},
+        "baseType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "children": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/children"
+          },
+          "meta": {
+            "hasChildren": true
+          }
+        },
+        "comments": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/comments",
+            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006/relationships/comments"
+          }
+        },
+        "creator": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
+              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
+            },
+            "type": "users"
+          }
+        },
+        "iteration": {},
+        "labels": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/labels"
+          }
+        },
+        "parent": {},
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
+          }
+        },
+        "workItemLinks": {
+          "links": {
+            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/links"
+          }
+        }
+      },
+      "type": "workitems"
+    },
+    {
+      "attributes": {
+        "system.created_at": "0001-01-01T00:00:00Z",
         "system.number": 2,
         "system.order": 2000,
         "system.remote_item_id": null,
@@ -165,83 +242,6 @@
         }
       },
       "type": "workitems"
-    },
-    {
-      "attributes": {
-        "system.created_at": "0001-01-01T00:00:00Z",
-        "system.number": 1,
-        "system.order": 1000,
-        "system.remote_item_id": null,
-        "system.state": "new",
-        "system.title": "A",
-        "system.updated_at": "0001-01-01T00:00:00Z",
-        "version": 0
-      },
-      "id": "00000000-0000-0000-0000-000000000006",
-      "links": {
-        "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006",
-        "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006"
-      },
-      "relationships": {
-        "area": {},
-        "assignees": {},
-        "baseType": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000002",
-            "type": "workitemtypes"
-          },
-          "links": {
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003/workitemtypes/00000000-0000-0000-0000-000000000002"
-          }
-        },
-        "children": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/children"
-          },
-          "meta": {
-            "hasChildren": true
-          }
-        },
-        "comments": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/comments",
-            "self": "http:///api/workitems/00000000-0000-0000-0000-000000000006/relationships/comments"
-          }
-        },
-        "creator": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
-            "links": {
-              "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
-              "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
-            },
-            "type": "users"
-          }
-        },
-        "iteration": {},
-        "labels": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/labels"
-          }
-        },
-        "parent": {},
-        "space": {
-          "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
-            "type": "spaces"
-          },
-          "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
-          }
-        },
-        "workItemLinks": {
-          "links": {
-            "related": "http:///api/workitems/00000000-0000-0000-0000-000000000006/links"
-          }
-        }
-      },
-      "type": "workitems"
     }
   ],
   "links": {
@@ -250,8 +250,8 @@
   },
   "meta": {
     "ancestorIDs": [
-      "00000000-0000-0000-0000-000000000005",
-      "00000000-0000-0000-0000-000000000006"
+      "00000000-0000-0000-0000-000000000006",
+      "00000000-0000-0000-0000-000000000005"
     ],
     "totalCount": 1
   }


### PR DESCRIPTION
This reverts commit bc9240d7e6ed5b3f55deacaf46dd07af906ff006.

Reason for revert:

TestSearchController/TestIncludedParents/in_topology_A-B-C_and_A-D_search_for/C_with_tree-view=true
fails from time to time.
