### PR TITLE
Show help text for dev-wit-openshift and dev-wit-openshift-clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,9 @@ AUTH_IMAGE_TAG ?= latest
 AUTH_IMAGE_URL=$(AUTH_IMAGE_DEFAULT):$(AUTH_IMAGE_TAG)
 
 .PHONY: dev-wit-openshift
+## Starts minishift and creates or uses a project named wit-openshift
+## Deploys DB, DB-AUTH, AUTH services from minishift/kedge/
+## Runs WIT service on local machine
 dev-wit-openshift: prebuild-check deps generate $(FRESH_BIN)
 	minishift start
 	./check_hosts.sh
@@ -320,6 +323,7 @@ dev-wit-openshift: prebuild-check deps generate $(FRESH_BIN)
 	$(FRESH_BIN)
 
 .PHONY: dev-wit-openshift-clean
+## Removes the project created by `make dev-wit-openshift`
 dev-wit-openshift-clean:
 	-eval `minishift oc-env` &&  oc login -u developer -p developer && oc delete project wit-openshift --force
 

--- a/Makefile
+++ b/Makefile
@@ -305,8 +305,8 @@ AUTH_IMAGE_TAG ?= latest
 AUTH_IMAGE_URL=$(AUTH_IMAGE_DEFAULT):$(AUTH_IMAGE_TAG)
 
 .PHONY: dev-wit-openshift
-## Starts minishift and creates or uses a project named wit-openshift
-## Deploys DB, DB-AUTH, AUTH services from minishift/kedge/
+## Starts minishift and creates/uses a project named wit-openshift
+## Deploys DB, DB-AUTH, AUTH services from minishift/kedge/*.yml
 ## Runs WIT service on local machine
 dev-wit-openshift: prebuild-check deps generate $(FRESH_BIN)
 	minishift start


### PR DESCRIPTION
```
$$ make help
dev-wit-openshift                   - Starts minishift and creates/uses a project named wit-openshift
                                      Deploys DB, DB-AUTH, AUTH services from minishift/kedge/*.yml
                                      Runs WIT service on local machine
dev-wit-openshift-clean             - Removes the project created by `make dev-wit-openshift`
```