### PR TITLE
Expose option to remove a user from the provisioned cluster

### DIFF
--- a/account/init_tenant.go
+++ b/account/init_tenant.go
@@ -34,9 +34,9 @@ func NewUpdateTenant(config tenantConfig) func(context.Context) error {
 }
 
 // NewCleanTenant creates a new tenant service in oso
-func NewCleanTenant(config tenantConfig) func(context.Context) error {
-	return func(ctx context.Context) error {
-		return CleanTenant(ctx, config)
+func NewCleanTenant(config tenantConfig) func(context.Context, bool) error {
+	return func(ctx context.Context, remove bool) error {
+		return CleanTenant(ctx, config, remove)
 	}
 }
 
@@ -81,14 +81,14 @@ func UpdateTenant(ctx context.Context, config tenantConfig) error {
 }
 
 // CleanTenant cleans out a tenant in oso.
-func CleanTenant(ctx context.Context, config tenantConfig) error {
+func CleanTenant(ctx context.Context, config tenantConfig, remove bool) error {
 
 	c, err := createClient(ctx, config)
 	if err != nil {
 		return err
 	}
 
-	res, err := c.CleanTenant(goasupport.ForwardContextRequestID(ctx), tenant.CleanTenantPath())
+	res, err := c.CleanTenant(goasupport.ForwardContextRequestID(ctx), tenant.CleanTenantPath(), &remove)
 	if err != nil {
 		return err
 	}

--- a/controller/user_service.go
+++ b/controller/user_service.go
@@ -14,7 +14,7 @@ import (
 type UserServiceController struct {
 	*goa.Controller
 	UpdateTenant func(context.Context) error
-	CleanTenant  func(context.Context) error
+	CleanTenant  func(context.Context, bool) error
 	ShowTenant   func(context.Context) (*tenant.TenantSingle, error)
 }
 
@@ -31,7 +31,7 @@ func (c *UserServiceController) Update(ctx *app.UpdateUserServiceContext) error 
 
 // Clean runs the clean action.
 func (c *UserServiceController) Clean(ctx *app.CleanUserServiceContext) error {
-	err := c.CleanTenant(ctx)
+	err := c.CleanTenant(ctx, ctx.Remove)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}

--- a/design/user_service.go
+++ b/design/user_service.go
@@ -96,7 +96,7 @@ var _ = a.Resource("UserService", func() {
 			a.DELETE(""),
 		)
 		a.Params(func() {
-			a.Param("remove", d.Boolean, "Remove user services from provisioned cluster", func() {
+			a.Param("remove", d.Boolean, "Remove user services from provisioned cluster. Restricted to internal users.", func() {
 				a.Default(false)
 			})
 		})

--- a/design/user_service.go
+++ b/design/user_service.go
@@ -95,6 +95,12 @@ var _ = a.Resource("UserService", func() {
 		a.Routing(
 			a.DELETE(""),
 		)
+		a.Params(func() {
+			a.Param("remove", d.Boolean, "Remove user services from provisioned cluster", func() {
+				a.Default(false)
+			})
+		})
+
 		a.Description("Clean the authenticated user tenant services")
 		a.Response(d.OK)
 		a.Response(d.BadRequest, JSONAPIErrors)

--- a/glide.lock
+++ b/glide.lock
@@ -64,7 +64,7 @@ imports:
   subpackages:
   - design
 - name: github.com/fabric8-services/fabric8-tenant
-  version: be8f39326808024c29ef6946151273359ae3e472
+  version: e86c6ee8a68ea79062061eb9a8ed216f773aed34
   subpackages:
   - design
 - name: github.com/fatih/structs

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ homepage: https://github.com/fabric8-services/fabric8-wit
 license: Apache-2.0
 import:
 - package: github.com/fabric8-services/fabric8-tenant
-  version: be8f39326808024c29ef6946151273359ae3e472
+  version: e86c6ee8a68ea79062061eb9a8ed216f773aed34
   subpackages:
   - design
 - package: github.com/fabric8-services/fabric8-notification


### PR DESCRIPTION
DELETE /api/user/services?remove=true

The User will be auto reprovisioned later when needed. Used by e2e
tests to test init flow and during user abuse.

Related to openshiftio/openshift.io#2393