### PR TITLE
time agnostic golden files for RFC7232 (section 2.2) and RFC3339

### DIFF
--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -110,8 +110,6 @@ func MockShowTenant() func(context.Context) (*tenant.TenantSingle, error) {
 }
 
 func (s *CodebaseControllerTestSuite) TestShowCodebase() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("success without stackId", func(t *testing.T) {
 		// given
@@ -121,7 +119,7 @@ func (s *CodebaseControllerTestSuite) TestShowCodebase() {
 		_, result := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
 		// then
 		require.NotNil(t, result)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_without_stackId.golden.json"), result)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_without_stackId.golden.json"), result)
 	})
 
 	s.T().Run("success with stackId", func(t *testing.T) {
@@ -135,13 +133,11 @@ func (s *CodebaseControllerTestSuite) TestShowCodebase() {
 		_, result := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
 		// then
 		require.NotNil(t, result)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_with_stackId.golden.json"), result)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_with_stackId.golden.json"), result)
 	})
 }
 
 func (s *CodebaseControllerTestSuite) TestDeleteCodebase() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("OK", func(t *testing.T) {
 		// given

--- a/controller/filters_blackbox_test.go
+++ b/controller/filters_blackbox_test.go
@@ -30,8 +30,6 @@ func TestRunFiltersREST(t *testing.T) {
 }
 
 func (rest *TestFiltersREST) TestListFiltersOK() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	// given
 	svc := goa.New("filterService")

--- a/controller/filters_blackbox_test.go
+++ b/controller/filters_blackbox_test.go
@@ -37,6 +37,6 @@ func (rest *TestFiltersREST) TestListFiltersOK() {
 	// when
 	res, filters := test.ListFilterOK(rest.T(), svc.Context, svc, ctrl)
 	// then
-	compareWithGolden(rest.T(), filepath.Join("test-files", "filter", "list", "list_available_filters.golden.json"), filters)
+	compareWithGoldenAgnostic(rest.T(), filepath.Join("test-files", "filter", "list", "list_available_filters.golden.json"), filters)
 	assertResponseHeaders(rest.T(), res)
 }

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -34,7 +35,7 @@ func compareWithGolden(t *testing.T, goldenFile string, actualObj interface{}) {
 	}
 }
 
-// compareWithGoldenUUIDAgnostic does the same as compareWithGolden but after
+// compareWithGoldenAgnostic does the same as compareWithGolden but after
 // marshalling the given objects to a JSON string it replaces UUIDs in both
 // strings (the golden file as well as in the actual object) before comparing
 // the two strings. This should make the comparison UUID agnostic without
@@ -42,14 +43,17 @@ func compareWithGolden(t *testing.T, goldenFile string, actualObj interface{}) {
 // UUID with a more generic "00000000-0000-0000-0000-000000000001",
 // "00000000-0000-0000-0000-000000000002", ...,
 // "00000000-0000-0000-0000-00000000000N" value.
-func compareWithGoldenUUIDAgnostic(t *testing.T, goldenFile string, actualObj interface{}) {
+//
+// In addition to UUID replacement, we also replace all RFC3339 time strings
+// with "0001-01-01T00:00:00Z".
+func compareWithGoldenAgnostic(t *testing.T, goldenFile string, actualObj interface{}) {
 	err := testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, true)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 }
 
-func testableCompareWithGolden(update bool, goldenFile string, actualObj interface{}, uuidAgnostic bool) error {
+func testableCompareWithGolden(update bool, goldenFile string, actualObj interface{}, agnostic bool) error {
 	absPath, err := filepath.Abs(goldenFile)
 	if err != nil {
 		return errs.WithStack(err)
@@ -68,10 +72,14 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 		tmp := string(actual)
 		// Eliminate concrete UUIDs if requested. This makes adding changes to
 		// golden files much more easy in git.
-		if uuidAgnostic {
+		if agnostic {
 			tmp, err = replaceUUIDs(tmp)
 			if err != nil {
-				return errs.Wrapf(err, "failed to replace UUIDs with more generic ones")
+				return errs.Wrap(err, "failed to replace UUIDs with more generic ones")
+			}
+			tmp, err = replaceTimes(tmp)
+			if err != nil {
+				return errs.Wrap(err, "failed to replace RFC3339 times with default time")
 			}
 		}
 		err = ioutil.WriteFile(absPath, []byte(tmp), os.ModePerm)
@@ -86,14 +94,22 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 
 	expectedStr := string(expected)
 	actualStr := string(actual)
-	if uuidAgnostic {
+	if agnostic {
 		expectedStr, err = replaceUUIDs(expectedStr)
 		if err != nil {
 			return errs.Wrapf(err, "failed to replace UUIDs with more generic ones")
 		}
+		expectedStr, err = replaceTimes(expectedStr)
+		if err != nil {
+			return errs.Wrap(err, "failed to replace RFC3339 times with default time")
+		}
 		actualStr, err = replaceUUIDs(actualStr)
 		if err != nil {
 			return errs.Wrapf(err, "failed to replace UUIDs with more generic ones")
+		}
+		actualStr, err = replaceTimes(actualStr)
+		if err != nil {
+			return errs.Wrap(err, "failed to replace RFC3339 times with default time")
 		}
 	}
 	if expectedStr != actualStr {
@@ -114,7 +130,7 @@ func findUUIDs(str string) ([]uuid.UUID, error) {
 	pattern := "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
 	uuidRegexp, err := regexp.Compile(pattern)
 	if err != nil {
-		return nil, errs.Wrapf(err, "failed to compile UUID regex pattern %s", pattern)
+		return nil, errs.Wrapf(err, "failed to compile UUID regex pattern: %s", pattern)
 	}
 	uniqIDs := map[uuid.UUID]struct{}{}
 	var res []uuid.UUID
@@ -150,7 +166,117 @@ func replaceUUIDs(str string) (string, error) {
 	return newStr, nil
 }
 
+// replaceTimes finds all RFC3339 times in the given string and replaces them
+// with "0001-01-01T00:00:00Z".
+func replaceTimes(str string) (string, error) {
+	year := "([0-9]+)"
+	month := "(0[1-9]|1[012])"
+	day := "(0[1-9]|[12][0-9]|3[01])"
+	datePattern := year + "-" + month + "-" + day
+
+	hour := "([01][0-9]|2[0-3])"
+	minute := "([0-5][0-9])"
+	second := "([0-5][0-9]|60)"
+	subSecond := "(\\.[0-9]+)?"
+	timePattern := hour + ":" + minute + ":" + second + subSecond
+
+	timeZoneOffset := "(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))"
+
+	pattern := datePattern + "[Tt]" + timePattern + timeZoneOffset
+
+	rfc3339Pattern, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", errs.Wrapf(err, "failed to compile RFC3339 regex pattern: %s", pattern)
+	}
+	return rfc3339Pattern.ReplaceAllString(str, `0001-01-01T00:00:00Z`), nil
+}
+
 const testInputStr = `
+{
+	"data": {
+		"attributes": {
+		"createdAt": "2017-04-21T04:38:26.777609Z",
+		"last_used_workspace": "my-last-used-workspace",
+		"type": "git",
+		"url": "https://github.com/fabric8-services/fabric8-wit.git"
+		},
+		"id": "d7a282f6-1c10-459e-bb44-55a1a6d48bdd",
+		"links": {
+		"edit": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd/edit",
+		"related": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd",
+		"self": "http:///api/codebases/d7a282f6-1c10-459e-bb44-55a1a6d48bdd"
+		},
+		"relationships": {
+		"space": {
+			"data": {
+			"id": "a8bee527-12d2-4aff-9823-3511c1c8e6b9",
+			"type": "spaces"
+			},
+			"links": {
+			"related": "http:///api/spaces/a8bee527-12d2-4aff-9823-3511c1c8e6b9",
+			"self": "http:///api/spaces/a8bee527-12d2-4aff-9823-3511c1c8e6b9"
+			}
+		}
+		},
+		"type": "codebases"
+	}
+}`
+
+const testUUIDOutputStr = `
+{
+	"data": {
+		"attributes": {
+		"createdAt": "2017-04-21T04:38:26.777609Z",
+		"last_used_workspace": "my-last-used-workspace",
+		"type": "git",
+		"url": "https://github.com/fabric8-services/fabric8-wit.git"
+		},
+		"id": "00000000-0000-0000-0000-000000000001",
+		"links": {
+		"edit": "http:///api/codebases/00000000-0000-0000-0000-000000000001/edit",
+		"related": "http:///api/codebases/00000000-0000-0000-0000-000000000001",
+		"self": "http:///api/codebases/00000000-0000-0000-0000-000000000001"
+		},
+		"relationships": {
+		"space": {
+			"data": {
+			"id": "00000000-0000-0000-0000-000000000002",
+			"type": "spaces"
+			},
+			"links": {
+			"related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+			"self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+			}
+		}
+		},
+		"type": "codebases"
+	}
+}`
+
+func TestGoldenFindUUIDs(t *testing.T) {
+	t.Parallel()
+	t.Run("find UUIDs", func(t *testing.T) {
+		t.Parallel()
+		ids, err := findUUIDs(testInputStr)
+		require.NoError(t, err)
+		require.Equal(t, []uuid.UUID{
+			uuid.FromStringOrNil("d7a282f6-1c10-459e-bb44-55a1a6d48bdd"),
+			uuid.FromStringOrNil("a8bee527-12d2-4aff-9823-3511c1c8e6b9"),
+		}, ids)
+	})
+}
+
+func TestGoldenReplaceUUIDs(t *testing.T) {
+	t.Parallel()
+	t.Run("replace UUIDs", func(t *testing.T) {
+		t.Parallel()
+		newStr, err := replaceUUIDs(testInputStr)
+		require.NoError(t, err)
+		require.Equal(t, testUUIDOutputStr, newStr)
+	})
+}
+
+const testTimesOutputStr = `
 {
 	"data": {
 		"attributes": {
@@ -181,86 +307,43 @@ const testInputStr = `
 	}
 }`
 
-const testOutputStr = `
-{
-	"data": {
-		"attributes": {
-		"createdAt": "0001-01-01T00:00:00Z",
-		"last_used_workspace": "my-last-used-workspace",
-		"type": "git",
-		"url": "https://github.com/fabric8-services/fabric8-wit.git"
-		},
-		"id": "00000000-0000-0000-0000-000000000001",
-		"links": {
-		"edit": "http:///api/codebases/00000000-0000-0000-0000-000000000001/edit",
-		"related": "http:///api/codebases/00000000-0000-0000-0000-000000000001",
-		"self": "http:///api/codebases/00000000-0000-0000-0000-000000000001"
-		},
-		"relationships": {
-		"space": {
-			"data": {
-			"id": "00000000-0000-0000-0000-000000000002",
-			"type": "spaces"
-			},
-			"links": {
-			"related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
-			"self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
-			}
-		}
-		},
-		"type": "codebases"
-	}
-}`
-
-func TestFindUUIDs(t *testing.T) {
+func TestGoldenReplaceTimes(t *testing.T) {
 	t.Parallel()
-	t.Run("find UUIDs", func(t *testing.T) {
+	t.Run("replace Times", func(t *testing.T) {
 		t.Parallel()
-		ids, err := findUUIDs(testInputStr)
+		newStr, err := replaceTimes(testInputStr)
 		require.NoError(t, err)
-		require.Equal(t, []uuid.UUID{
-			uuid.FromStringOrNil("d7a282f6-1c10-459e-bb44-55a1a6d48bdd"),
-			uuid.FromStringOrNil("a8bee527-12d2-4aff-9823-3511c1c8e6b9"),
-		}, ids)
+		require.Equal(t, testTimesOutputStr, newStr)
 	})
 }
 
-func TestReplaceUUIDs(t *testing.T) {
-	t.Parallel()
-	t.Run("replace UUIDs", func(t *testing.T) {
-		t.Parallel()
-		newStr, err := replaceUUIDs(testInputStr)
-		require.NoError(t, err)
-		require.Equal(t, testOutputStr, newStr)
-	})
-}
-
-func TestCompareWithGolden(t *testing.T) {
+func TestGoldenCompareWithGolden(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 	type Foo struct {
-		ID  uuid.UUID
-		Bar string
+		ID        uuid.UUID
+		Bar       string
+		CreatedAt time.Time
 	}
 	dummy := Foo{Bar: "hello world", ID: uuid.NewV4()}
 
-	uuidAgnosticVals := []bool{false, true}
-	for _, uuidAgnostic := range uuidAgnosticVals {
+	agnosticVals := []bool{false, true}
+	for _, agnostic := range agnosticVals {
 		t.Run("file not found", func(t *testing.T) {
 			// given
 			f := "not_existing_file.golden.json"
 			// when
-			err := testableCompareWithGolden(false, f, dummy, uuidAgnostic)
+			err := testableCompareWithGolden(false, f, dummy, agnostic)
 			// then
 			require.Error(t, err)
 			_, isPathError := errs.Cause(err).(*os.PathError)
-			require.True(t, isPathError)
+			require.False(t, isPathError)
 		})
 		t.Run("update golden file in a folder that does not yet exist", func(t *testing.T) {
 			// given
 			f := "not/existing/folder/file.golden.json"
 			// when
-			err := testableCompareWithGolden(true, f, dummy, uuidAgnostic)
+			err := testableCompareWithGolden(true, f, dummy, agnostic)
 			// then
 			// then double check that file exists and no error occurred
 			require.NoError(t, err)
@@ -272,11 +355,12 @@ func TestCompareWithGolden(t *testing.T) {
 			// given
 			f := "test-files/codebase/show/ok_without_auth.golden.json"
 			// when
-			err := testableCompareWithGolden(false, f, dummy, uuidAgnostic)
+			err := testableCompareWithGolden(false, f, dummy, agnostic)
 			// then
 			require.Error(t, err)
 			_, isPathError := errs.Cause(err).(*os.PathError)
 			require.False(t, isPathError)
+
 		})
 	}
 
@@ -293,13 +377,13 @@ func TestCompareWithGolden(t *testing.T) {
 		}()
 
 		t.Run("comparing with the same object", func(t *testing.T) {
-			t.Run("not UUID agnostic", func(t *testing.T) {
+			t.Run("not agnostic", func(t *testing.T) {
 				// when
 				err = testableCompareWithGolden(false, f, dummy, false)
 				// then
 				require.NoError(t, err)
 			})
-			t.Run("UUID agnostic", func(t *testing.T) {
+			t.Run("agnostic", func(t *testing.T) {
 				// when
 				err = testableCompareWithGolden(false, f, dummy, true)
 				// then
@@ -308,13 +392,28 @@ func TestCompareWithGolden(t *testing.T) {
 		})
 		t.Run("comparing with the same object but modified its UUID", func(t *testing.T) {
 			dummy.ID = uuid.NewV4()
-			t.Run("not UUID agnostic", func(t *testing.T) {
+			t.Run("not agnostic", func(t *testing.T) {
 				// when
 				err = testableCompareWithGolden(false, f, dummy, false)
 				// then
 				require.Error(t, err)
 			})
-			t.Run("UUID agnostic", func(t *testing.T) {
+			t.Run("agnostic", func(t *testing.T) {
+				// when
+				err = testableCompareWithGolden(false, f, dummy, true)
+				// then
+				require.NoError(t, err)
+			})
+		})
+		t.Run("comparing with the same object but modified its time", func(t *testing.T) {
+			dummy.CreatedAt = time.Now()
+			t.Run("not agnostic", func(t *testing.T) {
+				// when
+				err = testableCompareWithGolden(false, f, dummy, false)
+				// then
+				require.Error(t, err)
+			})
+			t.Run("agnostic", func(t *testing.T) {
 				// when
 				err = testableCompareWithGolden(false, f, dummy, true)
 				// then

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -337,7 +337,7 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 			// then
 			require.Error(t, err)
 			_, isPathError := errs.Cause(err).(*os.PathError)
-			require.False(t, isPathError)
+			require.True(t, isPathError)
 		})
 		t.Run("update golden file in a folder that does not yet exist", func(t *testing.T) {
 			// given

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -93,8 +93,6 @@ func (s *DummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
 }
 
 func (rest *TestIterationREST) TestCreateChildIteration() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("Ok", func(t *testing.T) {
 		t.Run("as space owner", func(t *testing.T) {
@@ -115,9 +113,9 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			resp, created := test.CreateChildIterationCreated(t, svc.Context, svc, ctrl, childItr.ID.String(), ci)
 			// then
 			require.NotNil(t, created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.res.iteration.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.req.payload.golden.json"), ci)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.res.iteration.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.req.payload.golden.json"), ci)
 		})
 		t.Run("as collaborator", func(t *testing.T) {
 			fxt := tf.NewTestFixture(t, rest.DB,
@@ -154,9 +152,9 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			resp, created := test.CreateChildIterationCreated(t, svc.Context, svc, ctrl, childItr.ID.String(), ci)
 			// then
 			require.NotNil(t, created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.res.iteration.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_ID_paylod.req.payload.golden.json"), ci)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.res.iteration.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_ID_paylod.req.payload.golden.json"), ci)
 			require.Equal(t, *ci.Data.ID, *created.Data.ID)
 		})
 	})
@@ -172,8 +170,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			// overwrite service with Dummy Auth to treat user as non-collaborator
 			svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", *notSpaceOwner, &DummySpaceAuthzService{rest})
 			_, jerrs := test.CreateChildIterationUnauthorized(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.req.payload.golden.json"), ci)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.req.payload.golden.json"), ci)
 		})
 		t.Run("for non-collaborator", func(t *testing.T) {
 			fxt := tf.NewTestFixture(t, rest.DB,
@@ -185,7 +183,7 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			// overwrite service with Dummy Auth to treat user as non-collaborator
 			svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", *nonCollaborator, &DummySpaceAuthzService{rest})
 			_, jerrs := test.CreateChildIterationUnauthorized(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
 		})
 	})
 
@@ -201,8 +199,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		svc, ctrl := rest.SecuredControllerWithIdentity(fxt.Identities[0])
 		_, jerrs := test.CreateChildIterationConflict(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
 
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.req.payload.golden.json"), ci)
 	})
 
 	rest.T().Run("fail - create child iteration missing name", func(t *testing.T) {
@@ -212,8 +210,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		svc, ctrl := rest.SecuredControllerWithIdentity(fxt.Identities[0])
 		_, jerrs := test.CreateChildIterationBadRequest(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
 
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.req.payload.golden.json"), ci)
 	})
 
 	rest.T().Run("fail - create child missing parent", func(t *testing.T) {
@@ -223,8 +221,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		_, jerrs := test.CreateChildIterationNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
 		jerrs.Errors[0].ID = ptr.String("IGNORE_ME")
 
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.req.payload.golden.json"), ci)
 	})
 
 	rest.T().Run("unauthorized - create child iteration with unauthorized user", func(t *testing.T) {
@@ -233,8 +231,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		svc, ctrl := rest.UnSecuredController()
 		_, jerrs := test.CreateChildIterationUnauthorized(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
 		jerrs.Errors[0].ID = ptr.String("IGNORE_ME")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.req.payload.golden.json"), ci)
 	})
 }
 
@@ -267,8 +265,7 @@ func (rest *TestIterationREST) TestFailValidationIterationNameStartWith() {
 }
 
 func (rest *TestIterationREST) TestShowIterationOK() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
+
 	// given
 	fxt := createSpaceAndRootAreaAndIterations(rest.T(), rest.DB)
 	itr := *fxt.Iterations[1]
@@ -280,7 +277,7 @@ func (rest *TestIterationREST) TestShowIterationOK() {
 	require.NotNil(rest.T(), created.Data.Relationships.Workitems.Meta)
 	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta[KeyTotalWorkItems])
 	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta[KeyClosedWorkItems])
-	compareWithGoldenUUIDAgnostic(rest.T(), filepath.Join(rest.testDir, "show", "ok.res.iteration.golden.json"), created)
+	compareWithGoldenAgnostic(rest.T(), filepath.Join(rest.testDir, "show", "ok.res.iteration.golden.json"), created)
 }
 
 func (rest *TestIterationREST) TestShowIterationOKUsingExpiredIfModifiedSinceHeader() {
@@ -1147,8 +1144,7 @@ func (rest *TestIterationREST) TestIterationDelete() {
 }
 
 func (rest *TestIterationREST) TestUpdateIteration() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
+
 	rest.T().Run("update success - iteration parent", func(t *testing.T) {
 		// build following structure
 		// 	root 0
@@ -1198,8 +1194,8 @@ func (rest *TestIterationREST) TestUpdateIteration() {
 		// when
 		resp, updatedItr := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr3.ID.String(), &payload)
 		require.NotNil(t, updatedItr)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.res.iteration.golden.json"), updatedItr)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.headers.golden.json"), resp.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.res.iteration.golden.json"), updatedItr)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.headers.golden.json"), resp.Header())
 		// then
 		require.NotNil(t, updatedItr.Data.Relationships.Parent)
 		assert.Equal(t, newParentIDStr, *updatedItr.Data.Relationships.Parent.Data.ID)

--- a/controller/label_blackbox_test.go
+++ b/controller/label_blackbox_test.go
@@ -94,8 +94,6 @@ func (rest *TestLabelREST) TestCreateLabelWithWhiteSpace() {
 }
 
 func (rest *TestLabelREST) TestUpdate() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	testFxt := tf.NewTestFixture(rest.T(), rest.DB, tf.Labels(1))
 	svc := testsupport.ServiceAsUser("Label-Service", *testFxt.Identities[0])
@@ -121,8 +119,8 @@ func (rest *TestLabelREST) TestUpdate() {
 		}
 		resp, updated := test.UpdateLabelOK(t, svc.Context, svc, ctrl, testFxt.Spaces[0].ID, testFxt.Labels[0].ID, &payload)
 		assert.Equal(t, newName, *updated.Data.Attributes.Name)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok.label.golden.json"), updated)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok.headers.golden.json"), resp)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok.label.golden.json"), updated)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok.headers.golden.json"), resp)
 
 		_, labels2 := test.ShowLabelOK(t, svc.Context, svc, ctrl, testFxt.Spaces[0].ID, testFxt.Labels[0].ID, nil, nil)
 		assertLabelLinking(t, labels2.Data)
@@ -148,7 +146,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "version conflict")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "conflict.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "conflict.errors.golden.json"), jerrs)
 	})
 
 	rest.T().Run("update label with bad parameter", func(t *testing.T) {
@@ -165,7 +163,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "Bad value for parameter 'data.attributes.version'")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_version.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_version.errors.golden.json"), jerrs)
 	})
 
 	rest.T().Run("update label with bad parameter - name", func(t *testing.T) {
@@ -188,7 +186,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "Bad value for parameter 'label name cannot be empty string'")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_name.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_name.errors.golden.json"), jerrs)
 	})
 
 	rest.T().Run("update label with unauthorized", func(t *testing.T) {
@@ -210,7 +208,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "Missing token manager")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "unauthorized.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "unauthorized.errors.golden.json"), jerrs)
 	})
 	rest.T().Run("update label not found", func(t *testing.T) {
 		newName := "Label New 1002"

--- a/controller/query_blackbox_test.go
+++ b/controller/query_blackbox_test.go
@@ -77,8 +77,6 @@ func getQueryCreatePayload(title string, qs *string) *app.CreateQueryPayload {
 }
 
 func (rest *TestQueryREST) TestCreate() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
@@ -91,9 +89,9 @@ func (rest *TestQueryREST) TestCreate() {
 			// then
 			require.NotNil(t, created)
 			require.Equal(t, fxt.Identities[0].ID.String(), *created.Data.Relationships.Creator.Data.ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
 		})
 		t.Run("same title with different spaceID", func(t *testing.T) {
 			fxt := tf.NewTestFixture(t, rest.DB,
@@ -106,9 +104,9 @@ func (rest *TestQueryREST) TestCreate() {
 			// then
 			require.NotNil(t, created)
 			require.Equal(t, fxt.Identities[0].ID.String(), *created.Data.Relationships.Creator.Data.ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
 		})
 		t.Run("same object after delete", func(t *testing.T) {
 			queryTitle := "query 1"
@@ -128,9 +126,9 @@ func (rest *TestQueryREST) TestCreate() {
 			// then
 			require.NotNil(t, created)
 			require.Equal(t, fxt.Identities[0].ID.String(), *created.Data.Relationships.Creator.Data.ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
 		})
 	})
 
@@ -173,8 +171,6 @@ func (rest *TestQueryREST) TestCreate() {
 }
 
 func (rest *TestQueryREST) TestList() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
@@ -239,8 +235,6 @@ func (rest *TestQueryREST) TestList() {
 }
 
 func (rest *TestQueryREST) TestShow() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok with identity", func(t *testing.T) {
@@ -253,8 +247,8 @@ func (rest *TestQueryREST) TestShow() {
 			resp, queryObj := test.ShowQueryOK(t, svc.Context, svc, ctrl, fxt.Spaces[0].ID, q.ID, nil, nil)
 			// then
 			require.NotNil(t, queryObj)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.res.query.golden.json"), queryObj)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.res.query.golden.json"), queryObj)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.headers.golden.json"), resp.Header())
 		})
 	})
 
@@ -301,8 +295,6 @@ func (rest *TestQueryREST) TestShow() {
 }
 
 func (rest *TestQueryREST) TestDelete() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok with identity", func(t *testing.T) {

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -1072,8 +1072,6 @@ func (s *searchControllerTestSuite) TestSearchByJoinedData() {
 
 // TestIncludedParents verifies the Included list of parents
 func (s *searchControllerTestSuite) TestIncludedParents() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	fxt := tf.NewTestFixture(s.T(), s.DB,
 		tf.WorkItems(5, tf.SetWorkItemTitles("A", "B", "C", "D", "E")),
@@ -1140,7 +1138,7 @@ func (s *searchControllerTestSuite) TestIncludedParents() {
 				// then
 				require.NotEmpty(t, result.Data)
 				assert.Len(t, result.Data, len(searchForTitles))
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", strings.Replace("in topology A-B-C and A-D search for", " ", "_", -1), strings.Replace(testName+".res.golden.json", " ", "_", -1)), result)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", strings.Replace("in topology A-B-C and A-D search for", " ", "_", -1), strings.Replace(testName+".res.golden.json", " ", "_", -1)), result)
 
 				// test what's included in the "data" portion of the response
 				for _, wi := range result.Data {
@@ -1233,8 +1231,6 @@ func (s *searchControllerTestSuite) TestIncludedParents() {
 }
 
 func (s *searchControllerTestSuite) TestIncludedChildren() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	// Suppose we have this topology:
 	//
@@ -1324,7 +1320,7 @@ func (s *searchControllerTestSuite) TestIncludedChildren() {
 			require.Empty(t, toBeFound, "failed to find these work items: %s", toBeFound.ToString(", ", func(ID uuid.UUID) string {
 				return fxt.WorkItemByID(ID).Fields[workitem.SystemTitle].(string)
 			}))
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "include_children.res.payload.golden.json"), result)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "include_children.res.payload.golden.json"), result)
 		})
 
 		t.Run("B,C with tree-view = false", func(t *testing.T) {
@@ -1348,14 +1344,12 @@ func (s *searchControllerTestSuite) TestIncludedChildren() {
 				return fxt.WorkItemByID(ID).Fields[workitem.SystemTitle].(string)
 			}))
 			// check "included" section
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "do_not_include_children.res.payload.golden.json"), result)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "do_not_include_children.res.payload.golden.json"), result)
 		})
 	})
 }
 
 func (s *searchControllerTestSuite) TestUpdateWorkItem() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("assignees", func(t *testing.T) {
 		// given
@@ -1386,10 +1380,10 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 				wi.Attributes[workitem.SystemTitle] = "Updated Test WI"
 				payload2 := app.UpdateWorkitemPayload{Data: wi}
 				_, updated := test.UpdateWorkitemOK(t, s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_update_work_item.golden.json"), updated)
 
 				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_show_after_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_show_after_update_work_item.golden.json"), updated)
 				assert.Nil(s.T(), result.Data[0].Attributes[workitem.SystemAssignees])
 
 			})
@@ -1424,10 +1418,10 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 				wi.Attributes[workitem.SystemTitle] = "Updated Test WI"
 				payload2 := app.UpdateWorkitemPayload{Data: wi}
 				_, updated := test.UpdateWorkitemOK(t, s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_update_work_item.golden.json"), updated)
 
 				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_show_after_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_show_after_update_work_item.golden.json"), updated)
 				assert.Nil(s.T(), result.Data[0].Attributes[workitem.SystemLabels])
 			})
 		})
@@ -1435,8 +1429,6 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 }
 
 func (s *searchControllerTestSuite) TestSearchCodebases() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("Single match", func(t *testing.T) {
 		// given
@@ -1452,7 +1444,7 @@ func (s *searchControllerTestSuite) TestSearchCodebases() {
 		require.NotNil(t, codebaseList)
 		require.NotNil(t, codebaseList.Data)
 		require.Len(t, codebaseList.Data, 1)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_single_match.json"), codebaseList)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_single_match.json"), codebaseList)
 	})
 
 	s.T().Run("Multi-match", func(t *testing.T) {
@@ -1478,7 +1470,7 @@ func (s *searchControllerTestSuite) TestSearchCodebases() {
 		sort.Sort(SortableCodebasesByID(codebaseList.Data))
 		// for included spaces, we must sort the spaces by their ID
 		sort.Sort(SortableIncludedSpacesByID(codebaseList.Included))
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_multi_match.json"), codebaseList)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_multi_match.json"), codebaseList)
 	})
 }
 

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -424,8 +424,6 @@ func (s *SpaceControllerTestSuite) TestUpdateSpace() {
 func (s *SpaceControllerTestSuite) TestShowSpace() {
 
 	// needed to valid comparison with golden files
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("ok", func(t *testing.T) {
 		// given
@@ -440,7 +438,7 @@ func (s *SpaceControllerTestSuite) TestShowSpace() {
 		eTag, lastModified, _ := assertResponseHeaders(t, res)
 		assert.Equal(t, app.ToHTTPTime(getSpaceUpdatedAt(*created)), lastModified)
 		assert.Equal(t, generateSpaceTag(*created), eTag)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show_space_ok.golden.json"), fetched)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show_space_ok.golden.json"), fetched)
 	})
 
 	s.T().Run("conditional request", func(t *testing.T) {

--- a/controller/test-files/iteration/create/bad_request_missing_name.req.payload.golden.json
+++ b/controller/test-files/iteration/create/bad_request_missing_name.req.payload.golden.json
@@ -2,8 +2,8 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
-      "startAt": "2006-01-02T15:04:00Z"
+      "endAt": "0001-01-01T00:00:00Z",
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/create/bad_request_unknown_parent.req.payload.golden.json
+++ b/controller/test-files/iteration/create/bad_request_unknown_parent.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2006-01-02T15:04:00Z"
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/create/conflict_for_same_name.req.payload.golden.json
+++ b/controller/test-files/iteration/create/conflict_for_same_name.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "iteration 00000000-0000-0000-0000-000000000001",
-      "startAt": "2006-01-02T15:04:00Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "user_active": false
     },
     "type": "iterations"

--- a/controller/test-files/iteration/create/ok_create_child.req.payload.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "user_active": false
     },
     "type": "iterations"

--- a/controller/test-files/iteration/create/ok_create_child.res.iteration.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child.res.iteration.golden.json
@@ -4,11 +4,11 @@
       "active_status": false,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
       "parent_path": "/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/root/child",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false

--- a/controller/test-files/iteration/create/ok_create_child_ID_paylod.req.payload.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_ID_paylod.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "user_active": false
     },
     "id": "00000000-0000-0000-0000-000000000001",

--- a/controller/test-files/iteration/create/ok_create_child_with_ID_paylod.res.iteration.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_with_ID_paylod.res.iteration.golden.json
@@ -4,11 +4,11 @@
       "active_status": false,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
       "parent_path": "/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/root/child",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false

--- a/controller/test-files/iteration/create/unauthorized.req.payload.golden.json
+++ b/controller/test-files/iteration/create/unauthorized.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2006-01-02T15:04:00Z"
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/create/unauthorized_other_user.req.payload.golden.json
+++ b/controller/test-files/iteration/create/unauthorized_other_user.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2006-01-02T15:04:00Z"
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/show/ok.res.iteration.golden.json
+++ b/controller/test-files/iteration/show/ok.res.iteration.golden.json
@@ -4,11 +4,11 @@
       "active_status": true,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "iteration 00000000-0000-0000-0000-000000000001",
       "parent_path": "/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/space 00000000-0000-0000-0000-000000000003",
-      "startAt": "2006-01-02T15:04:00Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false

--- a/controller/test-files/work_item_type/create/animal.headers.golden.json
+++ b/controller/test-files/work_item_type/create/animal.headers.golden.json
@@ -3,6 +3,6 @@
     "application/vnd.api+json"
   ],
   "Location": [
-    "/api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2/workitemtypes/729431f2-bca4-4062-9087-c751807b569f"
+    "/api/spaces/00000000-0000-0000-0000-000000000001/workitemtypes/00000000-0000-0000-0000-000000000002"
   ]
 }

--- a/controller/test-files/work_item_type/create/animal.wit.golden.json
+++ b/controller/test-files/work_item_type/create/animal.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/create/person.golden.json
+++ b/controller/test-files/work_item_type/create/person.golden.json
@@ -18,16 +18,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "22a1e4f1-7e9d-4ce8-ac87-fe7c79356b16",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/create/person.headers.golden.json
+++ b/controller/test-files/work_item_type/create/person.headers.golden.json
@@ -3,6 +3,6 @@
     "application/vnd.api+json"
   ],
   "Location": [
-    "/api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2/workitemtypes/22a1e4f1-7e9d-4ce8-ac87-fe7c79356b16"
+    "/api/spaces/00000000-0000-0000-0000-000000000001/workitemtypes/00000000-0000-0000-0000-000000000002"
   ]
 }

--- a/controller/test-files/work_item_type/show/ok.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/show/ok_using_expired_etag_header.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_etag_header.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -143,14 +143,13 @@ func (s *workItemLinkSuite) SecuredController(identity account.Identity) (*goa.S
 }
 
 func (s *workItemLinkSuite) TestCreate() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
+
 	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
 		// helper function used in all ok-cases
 		createOK := func(t *testing.T, fxt *tf.TestFixture, svc *goa.Service, ctrl *WorkItemLinkController) {
 			// when
 			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, fxt.WorkItems[1].ID, fxt.WorkItemLinkTypes[0].ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.req.payload.golden.json"), createPayload)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.req.payload.golden.json"), createPayload)
 			res, workItemLink := test.CreateWorkItemLinkCreated(t, svc.Context, svc, ctrl, createPayload)
 			// then
 			require.NotNil(t, workItemLink)
@@ -184,9 +183,9 @@ func (s *workItemLinkSuite) TestCreate() {
 			}
 			require.Empty(t, 0, expectedIDs, "these elements where missing from the included objects: %+v", expectedIDs)
 
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.payload.golden.json"), workItemLink)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.payload.golden.json"), workItemLink)
 			res.Header().Set("Etag", "0icd7ov5CqwDXN6Fx9z18g==") // overwrite Etag to always match
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.headers.golden.json"), res)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.headers.golden.json"), res)
 		}
 
 		t.Run("as space owner", func(t *testing.T) {
@@ -319,8 +318,6 @@ func (s *workItemLinkSuite) TestDelete() {
 func (s *workItemLinkSuite) TestShow() {
 	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
 		t.Run("normal", func(t *testing.T) {
-			resetFn := s.DisableGormCallbacks()
-			defer resetFn()
 
 			// given
 			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
@@ -334,9 +331,9 @@ func (s *workItemLinkSuite) TestShow() {
 			require.Equal(t, fxt.WorkItemLinks[0].SourceID, actual.SourceID)
 			require.Equal(t, fxt.WorkItemLinks[0].TargetID, actual.TargetID)
 			require.Equal(t, fxt.WorkItemLinks[0].LinkTypeID, actual.LinkTypeID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.payload.golden.json"), l)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.payload.golden.json"), l)
 			res.Header().Set("Etag", "0icd7ov5CqwDXN6Fx9z18g==") // overwrite Etag to always match
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.headers.golden.json"), res)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.headers.golden.json"), res)
 		})
 		t.Run("using expired IfModifiedSince header", func(t *testing.T) {
 			// given
@@ -400,14 +397,13 @@ func (s *workItemLinkSuite) TestShow() {
 			_, jerrs := test.ShowWorkItemLinkNotFound(t, svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
 			ignoreMe := "IGNOREME"
 			jerrs.Errors[0].ID = &ignoreMe
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.res.errors.golden.json"), jerrs)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.res.errors.golden.json"), jerrs)
 		})
 	})
 }
 
 func (s *workItemLinkSuite) TestList() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
+
 	// given
 	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
 	svc, _ := s.SecuredController(*fxt.Identities[0])
@@ -425,7 +421,7 @@ func (s *workItemLinkSuite) TestList() {
 				}
 			}
 			// then
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.paylpad.golden.json"), links)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.paylpad.golden.json"), links)
 		})
 	})
 	s.T().Run(http.StatusText(http.StatusNotFound), func(t *testing.T) {

--- a/controller/work_item_type_group_blackbox_test.go
+++ b/controller/work_item_type_group_blackbox_test.go
@@ -48,8 +48,8 @@ func (s *workItemTypeGroupSuite) TestList() {
 		// when
 		res, groups := test.ListWorkItemTypeGroupsOK(t, nil, s.svc, s.typeGroupsCtrl, sapcetemplateID)
 		// then
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.witg.golden.json"), groups)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.witg.golden.json"), groups)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.headers.golden.json"), res.Header())
 	})
 	s.T().Run("not found", func(t *testing.T) {
 		// given
@@ -59,8 +59,8 @@ func (s *workItemTypeGroupSuite) TestList() {
 		// then
 		ignoreMe := "IGNOREME"
 		jerrs.Errors[0].ID = &ignoreMe
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "not_found.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "not_found.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "not_found.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "not_found.headers.golden.json"), res.Header())
 	})
 }
 
@@ -71,8 +71,8 @@ func (s *workItemTypeGroupSuite) TestShow() {
 		// when
 		res, group := test.ShowWorkItemTypeGroupOK(t, nil, s.svc, s.typeGroupCtrl, typeGroupID)
 		// then
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.witg.golden.json"), group)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.witg.golden.json"), group)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
 	})
 	s.T().Run("not found", func(t *testing.T) {
 		// given
@@ -82,7 +82,7 @@ func (s *workItemTypeGroupSuite) TestShow() {
 		// then
 		ignoreMe := "IGNOREME"
 		jerrs.Errors[0].ID = &ignoreMe
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.headers.golden.json"), res.Header())
 	})
 }

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -246,11 +246,11 @@ func (s *workItemTypeSuite) TestCreate() {
 
 	s.T().Run("ok", func(t *testing.T) {
 		res, animal := s.createWorkItemTypeAnimal()
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "animal.wit.golden.json"), animal)
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "animal.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "animal.wit.golden.json"), animal)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "animal.headers.golden.json"), res.Header())
 		res, person := s.createWorkItemTypePerson()
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "person.golden.json"), person)
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "person.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "person.golden.json"), person)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "person.headers.golden.json"), res.Header())
 	})
 }
 
@@ -322,7 +322,7 @@ func (s *workItemTypeSuite) TestValidate() {
 		gerr, ok := err.(*goa.ErrorResponse)
 		require.True(t, ok)
 		gerr.ID = "IGNORE_ME"
-		compareWithGolden(t, filepath.Join(s.testDir, "validate", "invalid_oversized_name.golden.json"), gerr)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "validate", "invalid_oversized_name.golden.json"), gerr)
 	})
 
 	s.T().Run("invalid - name starts with underscore", func(t *testing.T) {
@@ -336,7 +336,7 @@ func (s *workItemTypeSuite) TestValidate() {
 		gerr, ok := err.(*goa.ErrorResponse)
 		require.True(t, ok)
 		gerr.ID = "IGNORE_ME"
-		compareWithGolden(t, filepath.Join(s.testDir, "validate", "invalid_name_starts_with_underscore.golden.json"), gerr)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "validate", "invalid_name_starts_with_underscore.golden.json"), gerr)
 	})
 }
 
@@ -353,8 +353,8 @@ func (s *workItemTypeSuite) TestShow() {
 		res, actual := test.ShowWorkitemtypeOK(t, nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, nil)
 		// then
 		require.NotNil(t, actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok.wit.golden.json"), actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.wit.golden.json"), actual)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("ok - using expired IfModifiedSince header", func(t *testing.T) {
@@ -363,8 +363,8 @@ func (s *workItemTypeSuite) TestShow() {
 		res, actual := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, *wit.Data.ID, &lastModified, nil)
 		// then
 		require.NotNil(t, actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.wit.golden.json"), actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.wit.golden.json"), actual)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("ok - using IfNoneMatch header", func(t *testing.T) {
@@ -373,8 +373,8 @@ func (s *workItemTypeSuite) TestShow() {
 		res, actual := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, &ifNoneMatch)
 		// then
 		require.NotNil(t, actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.wit.golden.json"), actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.wit.golden.json"), actual)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("not modified - using IfModifiedSince header", func(t *testing.T) {
@@ -382,7 +382,7 @@ func (s *workItemTypeSuite) TestShow() {
 		lastModified := app.ToHTTPTime(time.Now().Add(119 * time.Second))
 		res := test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, &lastModified, nil)
 		// then
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "not_modified_using_if_modified_since_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_if_modified_since_header.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("not modified - using IfNoneMatch header", func(t *testing.T) {
@@ -390,7 +390,7 @@ func (s *workItemTypeSuite) TestShow() {
 		etag := generateWorkItemTypeTag(*wit)
 		res := test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, &etag)
 		// then
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
 	})
 }
 

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -243,8 +243,6 @@ func lookupWorkItemTypes(witCollection app.WorkItemTypeList, workItemTypes ...ap
 //-----------------------------------------------------------------------------
 
 func (s *workItemTypeSuite) TestCreate() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("ok", func(t *testing.T) {
 		res, animal := s.createWorkItemTypeAnimal()
@@ -257,8 +255,6 @@ func (s *workItemTypeSuite) TestCreate() {
 }
 
 func (s *workItemTypeSuite) TestCreateByNotOwnerForbidden() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("forbidden", func(t *testing.T) {
 		idn := &account.Identity{
@@ -345,8 +341,6 @@ func (s *workItemTypeSuite) TestValidate() {
 }
 
 func (s *workItemTypeSuite) TestShow() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	// given
 	_, wit := s.createWorkItemTypeAnimal()

--- a/gormtestsupport/db_test_suite.go
+++ b/gormtestsupport/db_test_suite.go
@@ -89,24 +89,3 @@ func (s *DBTestSuite) populateDBTestSuite(ctx context.Context) {
 func (s *DBTestSuite) TearDownSuite() {
 	s.DB.Close()
 }
-
-// DisableGormCallbacks will turn off gorm's automatic setting of `created_at`
-// and `updated_at` columns. Call this function and make sure to `defer` the
-// returned function.
-//
-//    resetFn := DisableGormCallbacks()
-//    defer resetFn()
-func (s *DBTestSuite) DisableGormCallbacks() func() {
-	gormCallbackName := "gorm:update_time_stamp"
-	// remember old callbacks
-	oldCreateCallback := s.DB.Callback().Create().Get(gormCallbackName)
-	oldUpdateCallback := s.DB.Callback().Update().Get(gormCallbackName)
-	// remove current callbacks
-	s.DB.Callback().Create().Remove(gormCallbackName)
-	s.DB.Callback().Update().Remove(gormCallbackName)
-	// return a function to restore old callbacks
-	return func() {
-		s.DB.Callback().Create().Register(gormCallbackName, oldCreateCallback)
-		s.DB.Callback().Update().Register(gormCallbackName, oldUpdateCallback)
-	}
-}

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -827,9 +827,6 @@ func (s *linkRepoBlackBoxTest) TestAncestorList() {
 }
 
 func (s *linkRepoBlackBoxTest) TestListChildLinks() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("ok", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB,


### PR DESCRIPTION
The function `controller.compareWithGoldenUUIDAgnostic` was renamed to just `controller.compareWithGoldenAgnostic` and will now replace time values conforming to [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) as well.

This essentially means, that you no longer have to write:

```go
resetFn := s.DisableGormCallbacks()
defer resetFn()
```

in your test before you compare/create a golden file with dates in it. Dates in golden files will be set to a default, namely `"0001-01-01T00:00:00Z"`, when running in agnostic mode.

In addition to RFC3339 we also support time replacements for [RFC7232 Sec 2.2](https://tools.ietf.org/html/rfc7232#section-2.2) now. So times like the `Last-Modified` header values in golden files will be replaced with `"Mon, 01 Jan 0001 00:00:00 GMT"` as of now.

The `gormtestsupport.DBTestSuite.DisableGormCallbacks` function was removed with this PR as well.
