### PR TITLE
WIP: Added read-only number to the planner item type.

### DIFF
--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -116,13 +116,16 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError("user is not authorized to access the space"))
 	}
 	result := application.Transactional(c.db, func(appl application.Application) error {
-		// Type changes of WI are not allowed which is why we overwrite it the
-		// type with the old one after the WI has been converted.
+		// The Number and Type of a work item are not allowed to be changed
+		// which is why we overwrite it the those values with their old value
+		// after the work item was converted.
+		oldNumber := wi.Number
 		oldType := wi.Type
 		err = ConvertJSONAPIToWorkItem(ctx, ctx.Method, appl, *ctx.Payload.Data, wi, wi.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
+		wi.Number = oldNumber
 		wi.Type = oldType
 		wi, err = appl.WorkItems().Save(ctx, wi.SpaceID, *wi, *currentUserIdentityID)
 		if err != nil {

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -117,8 +117,8 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	}
 	result := application.Transactional(c.db, func(appl application.Application) error {
 		// The Number and Type of a work item are not allowed to be changed
-		// which is why we overwrite it the those values with their old value
-		// after the work item was converted.
+		// which is why we overwrite those values with their old value after the
+		// work item was converted.
 		oldNumber := wi.Number
 		oldType := wi.Type
 		err = ConvertJSONAPIToWorkItem(ctx, ctx.Method, appl, *ctx.Payload.Data, wi, wi.SpaceID)

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -932,7 +932,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithNonExistentID() {
 
 func (s *WorkItem2Suite) TestWI2UpdateSetReadOnlyFields() {
 	// given
-	fxt := tf.NewTestFixture(s.T(), s.DB, tf.WorkItems(1), tf.WorkItemTypes(2))
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1), tf.WorkItemTypes(2))
 
 	u := minimumRequiredUpdatePayload()
 	u.Data.Attributes[workitem.SystemTitle] = "Test title"
@@ -944,10 +944,10 @@ func (s *WorkItem2Suite) TestWI2UpdateSetReadOnlyFields() {
 	}
 
 	// when
-	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.workitemCtrl, *s.wi.ID, &u)
+	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.workitemCtrl, fxt.WorkItems[0].ID, &u)
 
 	s.T().Run("ensure type was not updated", func(t *testing.T) {
-		require.Equal(t, workitem.SystemBug, updatedWI.Data.Relationships.BaseType.Data.ID)
+		require.Equal(t, fxt.WorkItemTypes[0].ID, updatedWI.Data.Relationships.BaseType.Data.ID)
 	})
 	s.T().Run("ensure number was not updated", func(t *testing.T) {
 		require.Equal(t, fxt.WorkItems[0].Number, updatedWI.Data.Attributes[workitem.SystemNumber])

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -770,7 +770,7 @@ func createOrUpdateSystemPlannerItemType(ctx context.Context, witr *workitem.Gor
 		workitem.SystemCreatedAt:    {Type: workitem.SimpleType{Kind: "instant"}, Required: false, Label: "Created at", Description: "The date and time when the work item was created"},
 		workitem.SystemUpdatedAt:    {Type: workitem.SimpleType{Kind: "instant"}, Required: false, Label: "Updated at", Description: "The date and time when the work item was last updated"},
 		workitem.SystemOrder:        {Type: workitem.SimpleType{Kind: "float"}, Required: false, Label: "Execution Order", Description: "Execution Order of the workitem."},
-		workitem.SystemNumber:       {Type: workitem.SimpleType{Kind: "integer"}, Required: true, Label: "Number", Description: "The unique number that was given to this workitem within its space."},
+		workitem.SystemNumber:       {Type: workitem.SimpleType{Kind: "integer"}, Required: false, Label: "Number", Description: "The unique number that was given to this workitem within its space."},
 		workitem.SystemIteration:    {Type: workitem.SimpleType{Kind: "iteration"}, Required: false, Label: "Iteration", Description: "The iteration to which the work item belongs"},
 		workitem.SystemArea:         {Type: workitem.SimpleType{Kind: "area"}, Required: false, Label: "Area", Description: "The area to which the work item belongs"},
 		workitem.SystemCodebase:     {Type: workitem.SimpleType{Kind: "codebase"}, Required: false, Label: "Codebase", Description: "Contains codebase attributes to which this WI belongs to"},

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -770,6 +770,7 @@ func createOrUpdateSystemPlannerItemType(ctx context.Context, witr *workitem.Gor
 		workitem.SystemCreatedAt:    {Type: workitem.SimpleType{Kind: "instant"}, Required: false, Label: "Created at", Description: "The date and time when the work item was created"},
 		workitem.SystemUpdatedAt:    {Type: workitem.SimpleType{Kind: "instant"}, Required: false, Label: "Updated at", Description: "The date and time when the work item was last updated"},
 		workitem.SystemOrder:        {Type: workitem.SimpleType{Kind: "float"}, Required: false, Label: "Execution Order", Description: "Execution Order of the workitem."},
+		workitem.SystemNumber:       {Type: workitem.SimpleType{Kind: "integer"}, Required: true, Label: "Number", Description: "The unique number that was given to this workitem within its space."},
 		workitem.SystemIteration:    {Type: workitem.SimpleType{Kind: "iteration"}, Required: false, Label: "Iteration", Description: "The iteration to which the work item belongs"},
 		workitem.SystemArea:         {Type: workitem.SimpleType{Kind: "area"}, Required: false, Label: "Area", Description: "The area to which the work item belongs"},
 		workitem.SystemCodebase:     {Type: workitem.SimpleType{Kind: "codebase"}, Required: false, Label: "Codebase", Description: "Contains codebase attributes to which this WI belongs to"},

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -670,6 +670,9 @@ func ConvertWorkItemStorageToModel(wiType *WorkItemType, wi *WorkItemStorage) (*
 	if _, ok := wiType.Fields[SystemOrder]; ok {
 		result.Fields[SystemOrder] = wi.ExecutionOrder
 	}
+	if _, ok := wiType.Fields[SystemNumber]; ok {
+		result.Fields[SystemNumber] = wi.Number
+	}
 	return result, nil
 
 }


### PR DESCRIPTION
I was looking at [this code](https://github.com/fabric8-services/fabric8-wit/blob/master/migration/migration.go#L765). The fields defined there are essentially our "planner item type". There's no `system.number` field in there but we return it for every work item. I wondered if the planner item type only knows about fields that could be **set by the user**? But that cannot be entirely true because the `system.created_at` and `system.updated_at` are fields of planner item type as well. And they are system defined and **read-only**. 

This change makes the `system.number` part of the planner item as well but treats it as read-only.