### PR TITLE
Add timeout parameter to Kubernetes/OpenShift clients 

### DIFF
--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -259,11 +259,15 @@ func (g *defaultClientGetter) GetKubeClient(ctx context.Context) (kubernetes.Kub
 		return nil, errs.Wrap(err, "could not retrieve namespace name")
 	}
 
+	// TODO replace with configurable timeout
+	const timeout time.Duration = 30 * time.Second
+
 	// create the cluster API client
 	kubeConfig := &kubernetes.KubeClientConfig{
 		ClusterURL:    kubeURL,
 		BearerToken:   kubeToken,
 		UserNamespace: *kubeNamespaceName,
+		Timeout:       timeout,
 	}
 	kc, err := kubernetes.NewKubeClient(kubeConfig)
 	if err != nil {

--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -259,6 +259,9 @@ func (g *defaultClientGetter) GetKubeClient(ctx context.Context) (kubernetes.Kub
 		return nil, errs.Wrap(err, "could not retrieve namespace name")
 	}
 
+	/* Timeout used per HTTP request to Kubernetes/OpenShift API servers.
+	 * Communication with Hawkular currently uses a hard-coded 30 second
+	 * timeout per request, and does not use this parameter. */
 	// TODO replace with configurable timeout
 	const timeout time.Duration = 30 * time.Second
 

--- a/kubernetes/deployments_metrics.go
+++ b/kubernetes/deployments_metrics.go
@@ -100,6 +100,8 @@ func NewMetricsClient(config *MetricsClientConfig) (Metrics, error) {
 }
 
 func (*defaultGetter) GetHawkularRESTAPI(config *MetricsClientConfig) (HawkularRESTAPI, error) {
+	// Hawkular client uses a hard-coded timeout of 30s. See:
+	// https://github.com/hawkular/hawkular-client-go/blob/3ec6f27f0d339f9aee02ee4ad545581e52b40e19/metrics/client.go#L43
 	params := hawkular.Parameters{
 		Url:   config.MetricsURL,
 		Token: config.BearerToken,


### PR DESCRIPTION
Currently, we communicate with Kubernetes and OpenShift with the default timeout, which is no timeout at all. To avoid having perpetually open connections in the face of network/server issues, this PR adds a timeout to these requests. The timeout can be set using the new "Timeout" field added to KubeClientConfig, which is propagated to the Kubernetes and OpenShift clients by NewKubeClient. I also had to refactor things a bit to be able to test that the timeouts were passed to these clients.

This PR fixes https://github.com/openshiftio/openshift.io/issues/2462.
