### PR TITLE
Add index to comments.parent_id

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -376,6 +376,9 @@ func GetMigrations() Migrations {
 	// Version 82
 	m = append(m, steps{ExecuteSQLFile("082-iteration-related-changes.sql")})
 
+	// Version 83
+	m = append(m, steps{ExecuteSQLFile("083-index-comments-parent.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/083-index-comments-parent.sql
+++ b/migration/sql-files/083-index-comments-parent.sql
@@ -1,0 +1,3 @@
+-- add index on comments.parent_id
+create index idx_comments_parentid on comments using btree (parent_id);
+


### PR DESCRIPTION
All comments are fetched by the belonging parent object

Fixes openshiftio/openshift.io#2667