### PR TITLE
Dynamically set replicas via saasherder

### DIFF
--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -198,3 +198,8 @@ objects:
 parameters:
 - name: IMAGE_TAG
   value: latest
+- description: Number of deployment replicas
+  displayName: Number of deployment replicas
+  required: true
+  name: REPLICAS
+  value: "1"  

--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -202,4 +202,4 @@ parameters:
   displayName: Number of deployment replicas
   required: true
   name: REPLICAS
-  value: "1"  
+  value: 1

--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -10,7 +10,7 @@ objects:
       service: core
     name: core
   spec:
-    replicas: ${REPLICAS}
+    replicas: ${{REPLICAS}}
     selector:
       service: core
     strategy:

--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -10,7 +10,7 @@ objects:
       service: core
     name: core
   spec:
-    replicas: 4
+    replicas: ${{REPLICAS}}
     selector:
       service: core
     strategy:

--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -10,7 +10,7 @@ objects:
       service: core
     name: core
   spec:
-    replicas: ${{REPLICAS}}
+    replicas: ${REPLICAS}
     selector:
       service: core
     strategy:


### PR DESCRIPTION
Fixes openshiftio/openshift.io#2675

Differentiate the number of nodes we run in preview and prod to make preview breath a little lighter.