### PR TITLE
Remove unused deployments api

### DIFF
--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -429,32 +428,6 @@ func (c *DeploymentsController) ShowDeploymentStats(ctx *app.ShowDeploymentStats
 	return ctx.OK(res)
 }
 
-// ShowEnvironment runs the showEnvironment action.
-func (c *DeploymentsController) ShowEnvironment(ctx *app.ShowEnvironmentDeploymentsContext) error {
-
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
-	if err != nil {
-		return errors.NewUnauthorizedError("openshift token")
-	}
-
-	env, err := kc.GetEnvironment(ctx.EnvName)
-	if err != nil {
-		return errors.NewInternalError(ctx, errs.Wrapf(err, "could not retrieve environment %s", ctx.EnvName))
-	}
-	if env == nil {
-		return errors.NewNotFoundError("environment", ctx.EnvName)
-	}
-
-	env.ID = *env.Attributes.Name
-
-	res := &app.SimpleEnvironmentSingle{
-		Data: env,
-	}
-
-	return ctx.OK(res)
-}
-
 // ShowSpace runs the showSpace action.
 func (c *DeploymentsController) ShowSpace(ctx *app.ShowSpaceDeploymentsContext) error {
 
@@ -486,90 +459,6 @@ func (c *DeploymentsController) ShowSpace(ctx *app.ShowSpaceDeploymentsContext) 
 	}
 
 	return ctx.OK(res)
-}
-
-// ShowSpaceApp runs the showSpaceApp action.
-func (c *DeploymentsController) ShowSpaceApp(ctx *app.ShowSpaceAppDeploymentsContext) error {
-
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
-	if err != nil {
-		return errors.NewUnauthorizedError("openshift token")
-	}
-
-	kubeSpaceName, err := c.getSpaceNameFromSpaceID(ctx, ctx.SpaceID)
-	if err != nil {
-		return errors.NewNotFoundError("osio space", ctx.SpaceID.String())
-	}
-
-	theapp, err := kc.GetApplication(*kubeSpaceName, ctx.AppName)
-	if err != nil {
-		return errors.NewInternalError(ctx, errs.Wrapf(err, "could not retrieve application %s", ctx.AppName))
-	}
-	if theapp == nil {
-		return errors.NewNotFoundError("application", ctx.AppName)
-	}
-
-	theapp.ID = theapp.Attributes.Name
-
-	res := &app.SimpleApplicationSingle{
-		Data: theapp,
-	}
-
-	return ctx.OK(res)
-}
-
-// ShowSpaceAppDeployment runs the showSpaceAppDeployment action.
-func (c *DeploymentsController) ShowSpaceAppDeployment(ctx *app.ShowSpaceAppDeploymentDeploymentsContext) error {
-
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
-	if err != nil {
-		return errors.NewUnauthorizedError("openshift token")
-	}
-
-	kubeSpaceName, err := c.getSpaceNameFromSpaceID(ctx, ctx.SpaceID)
-	if err != nil {
-		return errors.NewNotFoundError("osio space", ctx.SpaceID.String())
-	}
-
-	deploymentStats, err := kc.GetDeployment(*kubeSpaceName, ctx.AppName, ctx.DeployName)
-	if err != nil {
-		return errors.NewInternalError(ctx, errs.Wrapf(err, "error retrieving deployment %s", ctx.DeployName))
-	}
-	if deploymentStats == nil {
-		return errors.NewNotFoundError("deployment statistics", ctx.DeployName)
-	}
-
-	deploymentStats.ID = deploymentStats.Attributes.Name
-
-	res := &app.SimpleDeploymentSingle{
-		Data: deploymentStats,
-	}
-
-	return ctx.OK(res)
-}
-
-// ShowEnvAppPods runs the showEnvAppPods action.
-func (c *DeploymentsController) ShowEnvAppPods(ctx *app.ShowEnvAppPodsDeploymentsContext) error {
-
-	kc, err := c.GetKubeClient(ctx)
-	defer cleanup(kc)
-	if err != nil {
-		return errors.NewUnauthorizedError("openshift token")
-	}
-
-	pods, err := kc.GetPodsInNamespace(ctx.EnvName, ctx.AppName)
-	if err != nil {
-		return errors.NewInternalError(ctx, errs.Wrapf(err, "error retrieving pods from namespace %s/%s", ctx.EnvName, ctx.AppName))
-	}
-	if pods == nil || len(pods) == 0 {
-		return errors.NewNotFoundError("pods", ctx.AppName)
-	}
-
-	jsonresp := fmt.Sprintf("{\"data\":{\"attributes\":{\"environment\":\"%s\",\"application\":\"%s\",\"pods\":%s}}}", ctx.EnvName, ctx.AppName, tostring(pods))
-
-	return ctx.OK([]byte(jsonresp))
 }
 
 // ShowSpaceEnvironments runs the showSpaceEnvironments action.

--- a/controller/deployments_blackbox_test.go
+++ b/controller/deployments_blackbox_test.go
@@ -111,25 +111,9 @@ func TestAPIMethodsCloseKube(t *testing.T) {
 			ctx := &app.ShowDeploymentStatsDeploymentsContext{}
 			return ctrl.ShowDeploymentStats(ctx)
 		}},
-		{"ShowEnvironment", func(ctrl *controller.DeploymentsController) error {
-			ctx := &app.ShowEnvironmentDeploymentsContext{}
-			return ctrl.ShowEnvironment(ctx)
-		}},
 		{"ShowSpace", func(ctrl *controller.DeploymentsController) error {
 			ctx := &app.ShowSpaceDeploymentsContext{}
 			return ctrl.ShowSpace(ctx)
-		}},
-		{"ShowSpaceApp", func(ctrl *controller.DeploymentsController) error {
-			ctx := &app.ShowSpaceAppDeploymentsContext{}
-			return ctrl.ShowSpaceApp(ctx)
-		}},
-		{"ShowSpaceAppDeployment", func(ctrl *controller.DeploymentsController) error {
-			ctx := &app.ShowSpaceAppDeploymentDeploymentsContext{}
-			return ctrl.ShowSpaceAppDeployment(ctx)
-		}},
-		{"ShowEnvAppPods", func(ctrl *controller.DeploymentsController) error {
-			ctx := &app.ShowEnvAppPodsDeploymentsContext{}
-			return ctrl.ShowEnvAppPods(ctx)
 		}},
 		{"ShowSpaceEnvironments", func(ctrl *controller.DeploymentsController) error {
 			ctx := &app.ShowSpaceEnvironmentsDeploymentsContext{}

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -155,36 +155,10 @@ var simpleSpaceSingle = JSONSingle(
 	simpleSpace,
 	nil)
 
-var simpleAppSingle = JSONSingle(
-	"SimpleApplication", "Holds a single response to a space/application request",
-	simpleApp,
-	nil)
-
-var simpleEnvironmentSingle = JSONSingle(
-	"SimpleEnvironment", "Holds a single response to a space/environment request",
-	simpleEnvironment,
-	nil)
-
 var simpleEnvironmentMultiple = JSONList(
 	"SimpleEnvironment", "Holds a response to a space/environment request",
 	simpleEnvironment,
 	nil,
-	nil)
-
-var simplePod = a.Type("SimplePod", func() {
-	a.Description("wrapper for a kubernetes Pod")
-	a.Attribute("pod", d.Any)
-})
-
-var simplePodMultiple = JSONList(
-	"SimplePod", "Holds a list of pods",
-	simplePod,
-	nil,
-	nil)
-
-var simpleDeploymentSingle = JSONSingle(
-	"SimpleDeployment", "Holds a single response to a space/application/deployment request",
-	simpleDeployment,
 	nil)
 
 var simpleDeploymentStatsSingle = JSONSingle(
@@ -193,13 +167,8 @@ var simpleDeploymentStatsSingle = JSONSingle(
 	nil)
 
 var simpleDeploymentStatSeriesSingle = JSONSingle(
-	"SimpleDeploymentStatSeries", "HOlds a response to a stat series query",
+	"SimpleDeploymentStatSeries", "Holds a response to a stat series query",
 	simpleDeploymentStatSeries,
-	nil)
-
-var simpleEnvironmentStatSingle = JSONSingle(
-	"EnvStats", "Holds a single response to a pipeline/stats request",
-	envStats,
 	nil)
 
 var _ = a.Resource("deployments", func() {
@@ -217,37 +186,6 @@ var _ = a.Resource("deployments", func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 		})
 		a.Response(d.OK, simpleSpaceSingle)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-	})
-
-	a.Action("showSpaceApp", func() {
-		a.Routing(
-			a.GET("/spaces/:spaceID/applications/:appName"),
-		)
-		a.Description("list application")
-		a.Params(func() {
-			a.Param("spaceID", d.UUID, "ID of the space")
-			a.Param("appName", d.String, "Name of the application")
-		})
-		a.Response(d.OK, simpleAppSingle)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-	})
-
-	a.Action("showSpaceAppDeployment", func() {
-		a.Routing(
-			a.GET("/spaces/:spaceID/applications/:appName/deployments/:deployName"),
-		)
-		a.Description("list deployment")
-		a.Params(func() {
-			a.Param("spaceID", d.UUID, "ID of the space")
-			a.Param("appName", d.String, "Name of the application")
-			a.Param("deployName", d.String, "Name of the deployment")
-		})
-		a.Response(d.OK, simpleDeploymentSingle)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -335,36 +273,4 @@ var _ = a.Resource("deployments", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
-
-	a.Action("showEnvironment", func() {
-		a.Routing(
-			a.GET("/environments/:envName"),
-		)
-		a.Description("list environment")
-		a.Params(func() {
-			a.Param("envName", d.String, "Name of the environment")
-		})
-		a.Response(d.OK, simpleEnvironmentSingle)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-	})
-
-	a.Action("showEnvAppPods", func() {
-		a.Routing(
-			a.GET("/environments/:envName/applications/:appName/pods"),
-		)
-		a.Description("list application pods")
-		a.Params(func() {
-			a.Param("envName", d.String, "Name of the environment")
-			a.Param("appName", d.String, "Name of the application")
-		})
-		// TODO - find a way to use predefined structs in goa DSL
-		// until then, hand code JSON response here instead of []v1.Pod
-		a.Response(d.OK, "application/json")
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
-	})
-
 })

--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -72,7 +72,6 @@ type KubeClientInterface interface {
 	DeleteDeployment(spaceName string, appName string, envName string) error
 	GetEnvironments() ([]*app.SimpleEnvironment, error)
 	GetEnvironment(envName string) (*app.SimpleEnvironment, error)
-	GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error)
 	Close()
 }
 
@@ -1103,18 +1102,6 @@ func quantityToFloat64(q resource.Quantity) (float64, error) {
 		result = float64(val64) * math.Pow10(-int(valDec.Scale()))
 	}
 	return result, nil
-}
-
-// GetPodsInNamespace - return all pods in namepsace 'nameSpace' and application 'appName'
-func (kc *kubeClient) GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error) {
-	listOptions := metaV1.ListOptions{
-		LabelSelector: "app=" + appName,
-	}
-	pods, err := kc.Pods(nameSpace).List(listOptions)
-	if err != nil {
-		return nil, errs.WithStack(err)
-	}
-	return pods.Items, nil
 }
 
 func (kc *kubeClient) getPods(namespace string, uid types.UID) ([]*v1.Pod, error) {


### PR DESCRIPTION
This addresses https://github.com/openshiftio/openshift.io/issues/2597

Unused deployments API endpoints are removed.

* removes /spaces/:spaceId/applications/:appName
* removes /environments/:envName
* removes /environments/:envName/applications/:appName/pods