### PR TITLE
Only delete comments if any comment found

### DIFF
--- a/comment/comment_repository.go
+++ b/comment/comment_repository.go
@@ -114,13 +114,13 @@ func (m *GormCommentRepository) Delete(ctx context.Context, commentID uuid.UUID,
 	// fetch the id and parent id of the comment to delete, to store them in the new revision.
 	c := Comment{}
 	tx := m.db.Select("id, parent_id").Where("id = ?", commentID).Find(&c)
-	m.db.Delete(c)
 	if tx.RowsAffected == 0 {
 		return errors.NewNotFoundError("comment", commentID.String())
 	}
 	if err := tx.Error; err != nil {
 		return errors.NewInternalError(ctx, err)
 	}
+	m.db.Delete(c)
 	// save a revision of the deleted comment
 	if err := m.revisionRepository.Create(ctx, suppressorID, RevisionTypeDelete, c); err != nil {
 		return errs.Wrapf(err, "error while deleting work item")

--- a/comment/comment_repository.go
+++ b/comment/comment_repository.go
@@ -114,7 +114,7 @@ func (m *GormCommentRepository) Delete(ctx context.Context, commentID uuid.UUID,
 	// fetch the id and parent id of the comment to delete, to store them in the new revision.
 	c := Comment{}
 	tx := m.db.Select("id, parent_id").Where("id = ?", commentID).Find(&c)
-	if tx.RowsAffected == 0 {
+	if tx.RowsAffected != 1 {
 		return errors.NewNotFoundError("comment", commentID.String())
 	}
 	if err := tx.Error; err != nil {


### PR DESCRIPTION
If no comments are found, c would be an empty struct and
cause all comments to be deleted.

Fixes openshiftio/openshift.io#2688