### PR TITLE
Set resource limits on Container level

### DIFF
--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -14,9 +14,6 @@ objects:
     selector:
       service: core
     strategy:
-      resources:
-        limits:
-          memory: 1.5Gi
       rollingParams:
         intervalSeconds: 1
         maxSurge: 25%
@@ -158,6 +155,9 @@ objects:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 1.5Gi
           terminationMessagePath: /dev/termination-log
         dnsPolicy: ClusterFirst
         restartPolicy: Always


### PR DESCRIPTION
Restrict how much memory the container can consume.

Limit to avoid it overtaking the cluster if the process were to go rogue.

Related to openshiftio/openshift.io#2685
