### PR TITLE
WIP: Fix old ALM naming in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,7 +126,7 @@ $ make generate
 
 ===== Build [[build]]
 
-If you want to just build the ALM server and client, run `make build`.
+If you want to just build the server and the client, run `make build`.
 
 ----
 $ cd $GOPATH/src/github.com/fabric8-services/fabric8-wit


### PR DESCRIPTION
This is to test the integration of https://golangci.com/
