### PR TITLE
Temporarily work around missing space label

### DIFF
--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -840,11 +840,22 @@ func (kc *kubeClient) getDeploymentConfig(namespace string, appName string, spac
 	if !ok {
 		return nil, errs.Errorf("labels missing from deployment config for application %s: %+v", appName, metadata)
 	}
-	spaceLabel, ok := labels["space"].(string)
-	if !ok || len(spaceLabel) == 0 {
-		return nil, errs.Errorf("space label missing from deployment config for application %s: %+v", appName, metadata)
+	/* FIXME Not all projects will have the space label defined due to the requirement that
+	 * fabric8-maven-plugin is called from the project's POM and not that of its parent.
+	 * This requirement is not always satisfied. For now, we work around the issue by logging
+	 * a warning and waiving the space label check, if missing.
+	 */
+	spaceLabel, err := getOptionalStringValue(labels, "space")
+	if err != nil {
+		return nil, err
 	}
-	if spaceLabel != space {
+	if len(spaceLabel) == 0 {
+		log.Warn(nil, map[string]interface{}{
+			"namespace": namespace,
+			"app_name":  appName,
+			"space":     space,
+		}, "space label missing from deployment config")
+	} else if spaceLabel != space {
 		return nil, errs.Errorf("deployment config %s is part of space %s, expected space %s", appName, spaceLabel, space)
 	}
 	// Get UID from deployment config

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -1241,6 +1241,58 @@ func TestGetDeployment(t *testing.T) {
 				routeInput: defaultRouteInput,
 			},
 		},
+		{
+			// Tests handling of a deployment config with missing space label
+			// FIXME When our workaround is no longer needed, we should expect
+			// an error
+			testName:      "No Space Label",
+			spaceName:     "mySpace",
+			appName:       "myApp",
+			envName:       "run",
+			envNS:         "my-run",
+			expectVersion: "1.0.2",
+			expectPodStatus: [][]string{
+				{"Running", "2"},
+			},
+			expectPodsTotal:         2,
+			expectPodsQuotaCpucores: 0.976,
+			expectPodsQuotaMemory:   524288000,
+			expectConsoleURL:        "http://console.myCluster/console/project/my-run",
+			expectLogURL:            "http://console.myCluster/console/project/my-run/browse/rc/myApp-1?tab=logs",
+			expectAppURL:            "http://myApp-my-run.example.com",
+			deploymentInput: deploymentInput{
+				dcInput: deploymentConfigInput{
+					"myApp": {
+						"my-run": "deploymentconfig-nospace.json",
+					},
+				},
+				rcInput:    defaultReplicationControllerInput,
+				podInput:   defaultPodInput,
+				svcInput:   defaultServiceInput,
+				routeInput: defaultRouteInput,
+			},
+		},
+		{
+			// Tests that we don't accept deployment configs with a space
+			// label different from the argument passed to GetDeployment
+			testName:  "Wrong Space Label",
+			spaceName: "mySpace",
+			appName:   "myApp",
+			envName:   "run",
+			envNS:     "my-run",
+			deploymentInput: deploymentInput{
+				dcInput: deploymentConfigInput{
+					"myApp": {
+						"my-run": "deploymentconfig-wrongspace.json",
+					},
+				},
+				rcInput:    defaultReplicationControllerInput,
+				podInput:   defaultPodInput,
+				svcInput:   defaultServiceInput,
+				routeInput: defaultRouteInput,
+			},
+			shouldFail: true,
+		},
 	}
 
 	fixture := &testFixture{}

--- a/test/kubernetes/deploymentconfig-nospace.json
+++ b/test/kubernetes/deploymentconfig-nospace.json
@@ -1,0 +1,203 @@
+{
+    "apiVersion": "v1",
+    "kind": "DeploymentConfig",
+    "metadata": {
+        "annotations": {
+            "fabric8.io/git-branch": "myUser/myApp/master-1.0.2",
+            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+            "fabric8.io/iconUrl": "img/icon.svg",
+            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myApp\u0026var-version=1.0.2",
+            "fabric8.io/scm-con-url": "scm:git:https://example.com/myApp",
+            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myApp",
+            "fabric8.io/scm-tag": "myTag",
+            "fabric8.io/scm-url": "https://example.com/myApp"
+        },
+        "creationTimestamp": "2018-01-25T16:33:02Z",
+        "generation": 3,
+        "labels": {
+            "app": "myApp",
+            "group": "myGroup",
+            "provider": "fabric8",
+            "version": "1.0.2"
+        },
+        "name": "myApp",
+        "namespace": "my-run",
+        "resourceVersion": "838024578",
+        "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myApp",
+        "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+    },
+    "spec": {
+        "replicas": 2,
+        "revisionHistoryLimit": 2,
+        "selector": {
+            "app": "myApp",
+            "group": "myGroup",
+            "provider": "fabric8"
+        },
+        "strategy": {
+            "activeDeadlineSeconds": 21600,
+            "resources": {},
+            "rollingParams": {
+                "intervalSeconds": 1,
+                "maxSurge": "25%",
+                "maxUnavailable": "25%",
+                "timeoutSeconds": 3600,
+                "updatePeriodSeconds": 1
+            },
+            "type": "Rolling"
+        },
+        "template": {
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myApp/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myApp\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myApp",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myApp",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myApp"
+                },
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "myApp",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "KUBERNETES_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 180,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "name": "myApp",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "http",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9779,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 8778,
+                                "name": "jolokia",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 10,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "memory": "250Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "privileged": false
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        },
+        "test": false,
+        "triggers": [
+            {
+                "type": "ConfigChange"
+            },
+            {
+                "imageChangeParams": {
+                    "automatic": true,
+                    "containerNames": [
+                        "myApp"
+                    ],
+                    "from": {
+                        "kind": "ImageStreamTag",
+                        "name": "myApp:1.0.2",
+                        "namespace": "my-run"
+                    },
+                    "lastTriggeredImage": "127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                },
+                "type": "ImageChange"
+            }
+        ]
+    },
+    "status": {
+        "availableReplicas": 2,
+        "conditions": [
+            {
+                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                "lastUpdateTime": "2018-01-25T16:33:27Z",
+                "message": "replication controller \"myApp-1\" successfully rolled out",
+                "reason": "NewReplicationControllerAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2018-01-25T20:40:25Z",
+                "lastUpdateTime": "2018-01-25T20:40:25Z",
+                "message": "Deployment config has minimum availability.",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "details": {
+            "causes": [
+                {
+                    "type": "ConfigChange"
+                }
+            ],
+            "message": "config change"
+        },
+        "latestVersion": 1,
+        "observedGeneration": 3,
+        "readyReplicas": 2,
+        "replicas": 2,
+        "unavailableReplicas": 0,
+        "updatedReplicas": 2
+    }
+}

--- a/test/kubernetes/deploymentconfig-wrongspace.json
+++ b/test/kubernetes/deploymentconfig-wrongspace.json
@@ -1,0 +1,204 @@
+{
+    "apiVersion": "v1",
+    "kind": "DeploymentConfig",
+    "metadata": {
+        "annotations": {
+            "fabric8.io/git-branch": "myUser/myApp/master-1.0.2",
+            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+            "fabric8.io/iconUrl": "img/icon.svg",
+            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myApp\u0026var-version=1.0.2",
+            "fabric8.io/scm-con-url": "scm:git:https://example.com/myApp",
+            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myApp",
+            "fabric8.io/scm-tag": "myTag",
+            "fabric8.io/scm-url": "https://example.com/myApp"
+        },
+        "creationTimestamp": "2018-01-25T16:33:02Z",
+        "generation": 3,
+        "labels": {
+            "app": "myApp",
+            "group": "myGroup",
+            "provider": "fabric8",
+            "space": "myOtherSpace",
+            "version": "1.0.2"
+        },
+        "name": "myApp",
+        "namespace": "my-run",
+        "resourceVersion": "838024578",
+        "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myApp",
+        "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+    },
+    "spec": {
+        "replicas": 2,
+        "revisionHistoryLimit": 2,
+        "selector": {
+            "app": "myApp",
+            "group": "myGroup",
+            "provider": "fabric8"
+        },
+        "strategy": {
+            "activeDeadlineSeconds": 21600,
+            "resources": {},
+            "rollingParams": {
+                "intervalSeconds": 1,
+                "maxSurge": "25%",
+                "maxUnavailable": "25%",
+                "timeoutSeconds": 3600,
+                "updatePeriodSeconds": 1
+            },
+            "type": "Rolling"
+        },
+        "template": {
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myApp/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myApp\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myApp",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myApp",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myApp"
+                },
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "myApp",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "KUBERNETES_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 180,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "name": "myApp",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "http",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9779,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 8778,
+                                "name": "jolokia",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 10,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "memory": "250Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "privileged": false
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        },
+        "test": false,
+        "triggers": [
+            {
+                "type": "ConfigChange"
+            },
+            {
+                "imageChangeParams": {
+                    "automatic": true,
+                    "containerNames": [
+                        "myApp"
+                    ],
+                    "from": {
+                        "kind": "ImageStreamTag",
+                        "name": "myApp:1.0.2",
+                        "namespace": "my-run"
+                    },
+                    "lastTriggeredImage": "127.0.0.1:5000/my-run/myApp@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                },
+                "type": "ImageChange"
+            }
+        ]
+    },
+    "status": {
+        "availableReplicas": 2,
+        "conditions": [
+            {
+                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                "lastUpdateTime": "2018-01-25T16:33:27Z",
+                "message": "replication controller \"myApp-1\" successfully rolled out",
+                "reason": "NewReplicationControllerAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2018-01-25T20:40:25Z",
+                "lastUpdateTime": "2018-01-25T20:40:25Z",
+                "message": "Deployment config has minimum availability.",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "details": {
+            "causes": [
+                {
+                    "type": "ConfigChange"
+                }
+            ],
+            "message": "config change"
+        },
+        "latestVersion": 1,
+        "observedGeneration": 3,
+        "readyReplicas": 2,
+        "replicas": 2,
+        "unavailableReplicas": 0,
+        "updatedReplicas": 2
+    }
+}


### PR DESCRIPTION
Currently all Spring Boot boosters do not work in the Deployments page, due to a change causing their space labels to not be applied at build-time (https://github.com/openshiftio/openshift.io/issues/2360). A proper fix for this involves changing the way fabric8 determines which space a project belongs to, and how the labels are applied.

In the meantime, we can work around this problem by not returning an error if the space label is missing from a Deployment Config. We instead rely on Deployment Configs having the same name as their corresponding Build Config. If the label is present and indicates the config belongs to a different space, we still return an error. If the label is missing, we proceed and log a warning. I have included tests for both of these cases.
