### PR TITLE
fix pcp pmdaprometheus configuration line

### DIFF
--- a/wit+pmcd.sh
+++ b/wit+pmcd.sh
@@ -18,7 +18,7 @@ echo "# Name  ID  IPC  IPC Params  File/Cmd" >> $PCP_PMCDCONF_PATH;
 echo "pmcd     2  dso  pmcd_init   $PCP_PMDAS_DIR/pmcd/pmda_pmcd.so"   >> $PCP_PMCDCONF_PATH;
 echo "proc     3  dso  proc_init   $PCP_PMDAS_DIR/proc/pmda_proc.so"   >> $PCP_PMCDCONF_PATH;
 echo "linux   60  dso  linux_init  $PCP_PMDAS_DIR/linux/pmda_linux.so" >> $PCP_PMCDCONF_PATH;
-echo "prometheus 144 pipe binary python $PCP_PMDAS_DIR/prometheus/pmdaprometheus.python" >> $PCP_PMCDCONF_PATH;
+echo "prometheus 144 pipe binary notready python $PCP_PMDAS_DIR/prometheus/pmdaprometheus.python" >> $PCP_PMCDCONF_PATH;
 rm -f $PCP_VAR_DIR/pmns/root_xfs $PCP_VAR_DIR/pmns/root_jbd2 $PCP_VAR_DIR/pmns/root_root $PCP_VAR_DIR/pmns/root
 echo 'prometheus	144:*:*' > $PCP_VAR_DIR/pmns/prometheus
 touch $PCP_VAR_DIR/pmns/.NeedRebuild


### PR DESCRIPTION
Adapt to https://sourceware.org/git/?p=pcpfans.git;a=commitdiff;h=1f0a1f90bc8e01b5b28810ecd6a8cf505969f243, which changed the way pmdaprometheus is to be connected to from pmcd.