### PR TITLE
remove route 'core'

### DIFF
--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -191,15 +191,6 @@ objects:
       service: core
     type: ClusterIP
     sessionAffinity: null
-- kind: Route
-  apiVersion: v1
-  metadata:
-    name: core
-  spec:
-    host: ''
-    to:
-      kind: Service
-      name: core
 parameters:
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This points to a cluster-specific url called http://core-dsaas-preview.b6ff.rh-idev.openshiftapps.com/ which makes it difficult for service migrations across clusters.