### PR TITLE
Close Hawkular client if error occurs before returning from NewKubeClient

### DIFF
--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -132,7 +132,8 @@ var _ KubeClientInterface = (*kubeClient)(nil)
 // Receiver for default implementation of KubeRESTAPIGetter and MetricsGetter
 type defaultGetter struct{}
 
-// NewKubeClient creates a KubeClientInterface given a configuration
+// NewKubeClient creates a KubeClientInterface given a configuration. The returned
+// KubeClientInterface must be closed using the Close method, when no longer needed.
 func NewKubeClient(config *KubeClientConfig) (KubeClientInterface, error) {
 	// Use default implementation if no KubernetesGetter is specified
 	if config.KubeRESTAPIGetter == nil {
@@ -174,6 +175,8 @@ func NewKubeClient(config *KubeClientConfig) (KubeClientInterface, error) {
 	// Get environments from config map
 	envMap, err := getEnvironmentsFromConfigMap(kubeAPI, config.UserNamespace)
 	if err != nil {
+		// Close metrics client opened above
+		metrics.Close()
 		return nil, errs.WithStack(err)
 	}
 

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -714,7 +714,7 @@ func TestConfigMapEnvironments(t *testing.T) {
 			_, err := kubernetes.NewKubeClient(config)
 			if testCase.shouldFail {
 				require.Error(t, err, "Expected an error")
-				require.True(t, fixture.metrics.closed, "Metrics not closed after error")
+				require.True(t, fixture.metrics.closed, "Metrics must be closed after error")
 			} else {
 				require.NoError(t, err)
 				configMapHolder := fixture.kube.configMapHolder

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -714,6 +714,7 @@ func TestConfigMapEnvironments(t *testing.T) {
 			_, err := kubernetes.NewKubeClient(config)
 			if testCase.shouldFail {
 				require.Error(t, err, "Expected an error")
+				require.True(t, fixture.metrics.closed, "Metrics not closed after error")
 			} else {
 				require.NoError(t, err)
 				configMapHolder := fixture.kube.configMapHolder


### PR DESCRIPTION
We are leaking goroutines from the Hawkular client again. I believe the cause is due to not closing the Hawkular client if we fail to read the fabric8-environments config map from the user's OpenShift namespace. I don't see any other code paths that could result in a non-closed Hawkular client.

Fixes: https://github.com/openshiftio/openshift.io/issues/2087