### PR TITLE
goroutine leak in WIT around SQL package (OSIO#2478)

### DIFF
--- a/space/space.go
+++ b/space/space.go
@@ -151,6 +151,7 @@ func (r *GormRepository) LoadMany(ctx context.Context, IDs []uuid.UUID) ([]Space
 		}, "unable to load multiple spaces by their IDs")
 		return nil, errors.NewInternalError(ctx, err)
 	}
+	defer rows.Close()
 	// scan the results
 	for rows.Next() {
 		s := Space{}

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -486,10 +486,10 @@ func (r *GormWorkItemLinkRepository) ListWorkItemChildren(ctx context.Context, p
 		// total
 		db := db.Select("count(*)")
 		rows2, err := db.Rows()
-		defer rows2.Close()
 		if err != nil {
 			return nil, 0, errs.WithStack(err)
 		}
+		defer rows2.Close()
 		rows2.Next() // count(*) will always return a row
 		rows2.Scan(&count)
 	}


### PR DESCRIPTION
add missing `defer rows.close()` (and move another one
after the error checking)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>