### PR TITLE
Forward X-Request-ID header to Notification call

### DIFF
--- a/notification/notification.go
+++ b/notification/notification.go
@@ -117,7 +117,7 @@ func (s *Service) Send(ctx context.Context, msg Message) {
 		msgID := goauuid.UUID(msg.MessageID)
 
 		resp, err := cl.SendNotify(
-			ctx,
+			goasupport.ForwardContextRequestID(ctx),
 			client.SendNotifyPath(),
 			&client.SendNotifyPayload{
 				Data: &client.Notification{


### PR DESCRIPTION
Helps trace the original call that caused the notification service invocation
