### PR TITLE
Generate String() for app.JSONAPIErrors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,11 +249,12 @@ $(VENDOR_DIR): glide.lock glide.yaml
 ## Download build dependencies.
 deps: $(VENDOR_DIR)
 
-app/controllers.go: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR)
+app/controllers.go: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR) goasupport/jsonapi_errors_stringer/generator.go goasupport/conditional_request/generator.go goasupport/helper_function/generator.go
 	$(GOAGEN_BIN) app -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) controller -d ${PACKAGE_NAME}/${DESIGN_DIR} -o controller/ --pkg controller --app-pkg ${PACKAGE_NAME}/app
 	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goasupport/conditional_request --out app
 	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goasupport/helper_function --out app
+	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goasupport/jsonapi_errors_stringer --out app
 	$(GOAGEN_BIN) client -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) swagger -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) client -d github.com/fabric8-services/fabric8-tenant/design --notool --pkg tenant -o account

--- a/goasupport/jsonapi_errors_stringer/generator.go
+++ b/goasupport/jsonapi_errors_stringer/generator.go
@@ -1,0 +1,85 @@
+package helperfunctions
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/goagen/codegen"
+)
+
+// Generate adds method to support conditional queries
+func Generate() ([]string, error) {
+	var (
+		ver    string
+		outDir string
+	)
+	set := flag.NewFlagSet("app", flag.PanicOnError)
+	set.String("design", "", "") // Consume design argument so Parse doesn't complain
+	set.StringVar(&ver, "version", "", "")
+	set.StringVar(&outDir, "out", "", "")
+	set.Parse(os.Args[2:])
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+	return writeFunctions(design.Design, outDir)
+}
+
+// WriteNames creates the names.txt file.
+func writeFunctions(api *design.APIDefinition, outDir string) ([]string, error) {
+	ctxFile := filepath.Join(outDir, "jsonapi_errors_stringer.go")
+	ctxWr, err := codegen.SourceFileFor(ctxFile)
+	if err != nil {
+		panic(err) // bug
+	}
+	title := fmt.Sprintf("%s: String functions for JSONAPI Errors - See goasupport/jsonapi_errors_stringer/generator.go", api.Context())
+	imports := []*codegen.ImportSpec{
+		codegen.SimpleImport("fmt"),
+		codegen.SimpleImport("github.com/davecgh/go-spew/spew"),
+	}
+	ctxWr.WriteHeader(title, "app", imports)
+	if err := ctxWr.ExecuteTemplate("jsonAPIErrorsStringer", jsonAPIErrorsStringer, nil, nil); err != nil {
+		return nil, err
+	}
+	return []string{ctxFile}, nil
+}
+
+const (
+	jsonAPIErrorsStringer = `
+// String implements the Stringer interface for JSONAPIErrors
+func (mt JSONAPIErrors) String() string {
+	if mt.Errors == nil {
+		return ""
+	}
+	res := fmt.Sprintf("%d JSONAPI Error(s):\n", len(mt.Errors))
+	for i, e := range mt.Errors {
+		res += fmt.Sprintf("[ERROR No. %3d]: %s\n", i, e)
+	}
+	return res
+}
+
+// String implements the Stringer interface for a JSONAPIError
+func (ut JSONAPIError) String() string {
+	return fmt.Sprintf(` + "`" + `
+		Code:    %[1]s
+		Detail:  %[2]s
+		ID:      %[3]s
+		Links:   %[4]s
+		Meta:    %[5]s
+		Source:  %[6]s
+		Status:  %[7]s
+		Title:   %[8]s
+	` + "`" + `, spew.Sdump(ut.Code),
+		spew.Sdump(ut.Detail),
+		spew.Sdump(ut.ID),
+		spew.Sdump(ut.Links),
+		spew.Sdump(ut.Meta),
+		spew.Sdump(ut.Source),
+		spew.Sdump(ut.Status),
+		spew.Sdump(ut.Title))
+}
+`
+)


### PR DESCRIPTION
Before the error output looked like this in case of an JSONAPIError:

```
workitem_testing.go:1798: invalid response media: got variable of type *app.JSONAPIErrors, value &{Errors:[0xc420c6e5f0]}, expected instance of app.WorkItemSingle
```

after output looks like this:

```
workitem_testing.go:1798: invalid response media: got variable of type *app.JSONAPIErrors, value 1 JSONAPI Error(s):
    [ERROR No.   0]:
            Code:    (*string)((len=13) "bad_parameter")

            Detail:  (string) (len=100) "Bad value for parameter 'space': 'ab05ffa4-f8e3-45e8-b27a-136c39e8cb95' (expected: 'valid space ID')"

            ID:      (*string)(<nil>)

            Links:   (map[string]*app.JSONAPILink) <nil>

            Meta:    (map[string]interface {}) <nil>

            Source:  (map[string]interface {}) <nil>

            Status:  (*string)((len=3) "400")

            Title:   (*string)((len=19) "Bad parameter error")
```