### PR TITLE
WIP: test update fields of different kinds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DESIGNS := $(shell find $(SOURCE_DIR)/$(DESIGN_DIR) -path $(SOURCE_DIR)/vendor -
 # Find all required tools:
 GIT_BIN := $(shell command -v $(GIT_BIN_NAME) 2> /dev/null)
 DEP_BIN_NAME := dep
-DEP_BIN_DIR := ./tmp/bin
+DEP_BIN_DIR := $(TMP_PATH)/bin
 DEP_BIN := $(DEP_BIN_DIR)/$(DEP_BIN_NAME)
 DEP_VERSION=v0.4.1
 GO_BIN := $(shell command -v $(GO_BIN_NAME) 2> /dev/null)

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -809,7 +809,7 @@ func (s *searchControllerTestSuite) TestSearchQueryScenarioDriven() {
 				]}`,
 			spaceIDStr, workitem.SystemStateOpen, fakeIterationID)
 		_, result := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
-		assert.Empty(t, result.Data) // all items are other than open state & in other thatn fake itr
+		assert.Empty(t, result.Data)
 	})
 
 	s.T().Run("space=ID AND (state!=open AND iteration!=fake-iterationID) using NE", func(t *testing.T) {

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -36,6 +37,7 @@ import (
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	"github.com/fabric8-services/fabric8-wit/test/token"
 	"github.com/fabric8-services/fabric8-wit/workitem"
+	errs "github.com/pkg/errors"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
@@ -262,11 +264,7 @@ func (s *WorkItemSuite) TestCreateWI() {
 
 	s.T().Run("field types", func(t *testing.T) {
 		vals := workitem.GetFieldTypeTestData(t)
-		// Get keys from the map above
-		kinds := []workitem.Kind{}
-		for k := range vals {
-			kinds = append(kinds, k)
-		}
+		kinds := vals.GetKinds()
 		fieldName := "fieldundertest"
 		// Create a work item type for each kind
 		fxt := tf.NewTestFixture(t, s.DB,
@@ -769,13 +767,17 @@ func getMinimumRequiredUpdatePayload(wi *app.WorkItem) *app.UpdateWorkitemPayloa
 }
 
 func minimumRequiredUpdatePayload() app.UpdateWorkitemPayload {
-	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(space.SystemSpace.String()))
+	return minimumRequiredUpdatePayloadWithSpace(space.SystemSpace)
+}
+
+func minimumRequiredUpdatePayloadWithSpace(spaceID uuid.UUID) app.UpdateWorkitemPayload {
+	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
 	return app.UpdateWorkitemPayload{
 		Data: &app.WorkItem{
 			Type:       APIStringTypeWorkItem,
 			Attributes: map[string]interface{}{},
 			Relationships: &app.WorkItemRelationships{
-				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(spaceID, spaceSelfURL),
 			},
 		},
 	}
@@ -870,6 +872,7 @@ type WorkItem2Suite struct {
 	gormtestsupport.DBTestSuite
 	workitemCtrl   app.WorkitemController
 	workitemsCtrl  app.WorkitemsController
+	witCtrl        app.WorkitemtypeController
 	linkCtrl       app.WorkItemLinkController
 	linkCatCtrl    app.WorkItemLinkCategoryController
 	linkTypeCtrl   app.WorkItemLinkTypeController
@@ -878,6 +881,7 @@ type WorkItem2Suite struct {
 	wi             *app.WorkItem
 	minimumPayload *app.UpdateWorkitemPayload
 	notification   notificationsupport.FakeNotificationChannel
+	testDir        string
 }
 
 func (s *WorkItem2Suite) SetupTest() {
@@ -889,6 +893,7 @@ func (s *WorkItem2Suite) SetupTest() {
 	s.svc = testsupport.ServiceAsUser("TestUpdateWI2-Service", *testIdentity)
 	s.workitemCtrl = NewNotifyingWorkitemController(s.svc, gormapplication.NewGormDB(s.DB), &s.notification, s.Configuration)
 	s.workitemsCtrl = NewNotifyingWorkitemsController(s.svc, gormapplication.NewGormDB(s.DB), &s.notification, s.Configuration)
+	s.witCtrl = NewWorkitemtypeController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	s.linkCatCtrl = NewWorkItemLinkCategoryController(s.svc, gormapplication.NewGormDB(s.DB))
 	s.linkTypeCtrl = NewWorkItemLinkTypeController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	s.linkCtrl = NewWorkItemLinkController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
@@ -901,6 +906,7 @@ func (s *WorkItem2Suite) SetupTest() {
 	s.wi = wi.Data
 	s.minimumPayload = getMinimumRequiredUpdatePayload(s.wi)
 	//s.minimumReorderPayload = getMinimumRequiredReorderPayload(s.wi)
+	s.testDir = filepath.Join("test-files", "work_item")
 }
 
 // ========== Actual Test functions ==========
@@ -951,6 +957,110 @@ func (s *WorkItem2Suite) TestWI2UpdateSetReadOnlyFields() {
 	})
 	s.T().Run("ensure number was not updated", func(t *testing.T) {
 		require.Equal(t, fxt.WorkItems[0].Number, updatedWI.Data.Attributes[workitem.SystemNumber])
+	})
+}
+
+func (s *WorkItem2Suite) TestWI2UpdateFieldOfDifferentTypes() {
+	s.T().Run("field types", func(t *testing.T) {
+		vals := workitem.GetFieldTypeTestData(t)
+		kinds := vals.GetKinds()
+		numKinds := len(kinds)
+		// Create a work item type and a work item for each kind and initialize
+		// it with the first valid value.
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.CreateWorkItemEnvironment(),
+			// we need these many spaces because they the WI numbers are tigt to
+			// the space.
+			tf.WorkItemTypes(numKinds, func(fxt *tf.TestFixture, idx int) error {
+				kind := kinds[idx]
+				fxt.WorkItemTypes[idx].Name = kind.String() + "_wit"
+				// Add one field that is used for testing
+				fxt.WorkItemTypes[idx].Fields[kind.String()+"_field"] = workitem.FieldDefinition{
+					Required:    true,
+					Label:       kind.String(),
+					Description: fmt.Sprintf("This field is used for testing values for the field kind '%s'", kind),
+					Type: workitem.SimpleType{
+						Kind: kind,
+					},
+				}
+				return nil
+			}),
+			tf.WorkItems(numKinds, func(fxt *tf.TestFixture, idx int) error {
+				kind := kinds[idx]
+				if len(vals[kind].Valid) < 2 {
+					return errs.Errorf("test map for kind %s needs to have more than one value, one for creation and one for updating", kind)
+				}
+				fxt.WorkItems[idx].Fields[workitem.SystemTitle] = kind.String() + "_wi"
+				fxt.WorkItems[idx].Fields[kind.String()+"_field"] = vals[kind].Valid[0]
+				fxt.WorkItems[idx].Type = fxt.WorkItemTypes[idx].ID
+				fxt.WorkItems[idx].Number = idx
+				return nil
+			}),
+		)
+
+		// when
+		for kind, iv := range vals {
+			t.Run(kind.String(), func(t *testing.T) {
+				kindSpace := fxt.Spaces[0]
+				require.NotNil(t, kindSpace)
+
+				// dump the wit as a golden file for reference
+				wit := fxt.WorkItemTypeByName(kind.String()+"_wit", kindSpace.ID)
+				require.NotNil(t, wit)
+				_, witApp := test.ShowWorkitemtypeOK(t, s.svc.Context, s.svc, s.witCtrl, wit.ID, nil, nil)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "update", kind.String(), kind.String()+"_wit.res.payload.golden.json"), witApp)
+
+				wi := fxt.WorkItemByTitle(kind.String()+"_wi", kindSpace.ID)
+				require.NotNil(t, wi)
+				version := wi.Version
+
+				// Handle cases where the conversion is supposed to work
+				for i := 1; i < len(iv.Valid); i++ {
+					newValue := iv.Valid[i]
+					t.Run(fmt.Sprintf("legal sample %d", i), func(t *testing.T) {
+						// construct an update request
+						u := minimumRequiredUpdatePayloadWithSpace(kindSpace.ID)
+						u.Data.Attributes["version"] = version
+						u.Data.Attributes[kind.String()+"_field"] = newValue
+						u.Data.ID = &wi.ID
+						// when
+						compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "update", kind.String(), fmt.Sprintf("valid_sample_%d", i)+".req.payload.golden.json"), u)
+						// Update the work item
+						res, updatedWI := test.UpdateWorkitemOK(t, s.svc.Context, s.svc, s.workitemCtrl, wi.ID, &u)
+						// Check for updated value
+						compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "update", kind.String(), fmt.Sprintf("valid_sample_%d", i)+".res.payload.golden.json"), updatedWI)
+						compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "update", kind.String(), fmt.Sprintf("valid_sample_%d", i)+".res.headers.golden.json"), res.Header())
+						_, loadedWi := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workitemCtrl, *updatedWI.Data.ID, nil, nil)
+						require.NotNil(t, loadedWi)
+						// compensate for errors when interpreting ambigous actual values
+						actual := loadedWi.Data.Attributes[kind.String()+"_field"]
+						if iv.Compensate != nil {
+							actual = iv.Compensate(actual)
+						}
+						require.Equal(t, newValue, actual, "expected no error when loading and comparing the workitem with a '%s' kind: %#v", kind, spew.Sdump(newValue))
+
+						var ok bool
+						version, ok = loadedWi.Data.Attributes[workitem.SystemVersion].(int)
+						require.True(t, ok, "failed to get updated version")
+					})
+				}
+				// Handle cases where the conversion is supposed to NOT work
+				for i := 0; i < len(iv.Invalid); i++ {
+					newValue := iv.Invalid[i]
+					t.Run(fmt.Sprintf("illegal sample %d", i), func(t *testing.T) {
+						// construct an update request
+						u := minimumRequiredUpdatePayloadWithSpace(kindSpace.ID)
+						u.Data.Attributes["version"] = version
+						u.Data.Attributes[kind.String()+"_field"] = newValue
+						u.Data.ID = &wi.ID
+						// when
+						_, jerrs := test.UpdateWorkitemBadRequest(t, s.svc.Context, s.svc, s.workitemCtrl, wi.ID, &u)
+						// then
+						require.NotNil(t, jerrs, "expected an error when assigning this value to a '%s' field during work item update: %#v", kind, spew.Sdump(newValue))
+					})
+				}
+			})
+		}
 	})
 }
 
@@ -2691,19 +2801,6 @@ func (s *WorkItem2Suite) TestNotificationSendOnUpdate() {
 func minimumRequiredCreatePayloadWithSpace(spaceID uuid.UUID) app.CreateWorkitemsPayload {
 	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
 	return app.CreateWorkitemsPayload{
-		Data: &app.WorkItem{
-			Type:       APIStringTypeWorkItem,
-			Attributes: map[string]interface{}{},
-			Relationships: &app.WorkItemRelationships{
-				Space: app.NewSpaceRelation(spaceID, spaceSelfURL),
-			},
-		},
-	}
-}
-
-func minimumRequiredUpdatePayloadWithSpace(spaceID uuid.UUID) app.UpdateWorkitemPayload {
-	spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(spaceID.String()))
-	return app.UpdateWorkitemPayload{
 		Data: &app.WorkItem{
 			Type:       APIStringTypeWorkItem,
 			Attributes: map[string]interface{}{},

--- a/test/testfixture/query_functions.go
+++ b/test/testfixture/query_functions.go
@@ -5,6 +5,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/label"
 	"github.com/fabric8-services/fabric8-wit/query"
+	"github.com/fabric8-services/fabric8-wit/space"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/fabric8-services/fabric8-wit/workitem/link"
 	errs "github.com/pkg/errors"
@@ -53,6 +54,16 @@ func (fxt *TestFixture) WorkItemTypeByName(name string, spaceID ...uuid.UUID) *w
 	return nil
 }
 
+// SpaceByName returns the first space type that has the given name (if any).
+func (fxt *TestFixture) SpaceByName(name string) *space.Space {
+	for _, s := range fxt.Spaces {
+		if s.Name == name {
+			return s
+		}
+	}
+	return nil
+}
+
 // WorkItemTypeByID returns the work item type that has the given ID (if any).
 func (fxt *TestFixture) WorkItemTypeByID(id uuid.UUID) *workitem.WorkItemType {
 	for _, wit := range fxt.WorkItemTypes {
@@ -81,7 +92,7 @@ func (fxt *TestFixture) WorkItemByTitle(title string, spaceID ...uuid.UUID) *wor
 	for _, wi := range fxt.WorkItems {
 		v, ok := wi.Fields[workitem.SystemTitle]
 		if !ok {
-			panic(errs.Errorf("failed to find work item with title '%s'", title))
+			panic(errs.Errorf("failed to find work item with title '%s' (field '%s' does not exist in work item title)", title, workitem.SystemTitle))
 		}
 		if v == title && len(spaceID) > 0 && wi.SpaceID == spaceID[0] {
 			return wi

--- a/workitem/field_test_data.go
+++ b/workitem/field_test_data.go
@@ -3,6 +3,7 @@ package workitem
 import (
 	"fmt"
 	"math"
+	"sort"
 	"testing"
 	"time"
 
@@ -14,18 +15,38 @@ import (
 // ValidInvalid given a bunch of tests with expected error results for each work
 // item type field kind, a work item type for each kind...
 type ValidInvalid struct {
+	// Valid should contain more than one valid examples so a test function can
+	// properly handle work item creation and updating
 	Valid   []interface{}
 	Invalid []interface{}
-	// When the actual value is a zero (0), it will be interpreted as a
-	// float64 rather than an int. To compensate for that ambiguity, a
-	// kind can opt-in to provide an construction function that returns
-	// the correct value.
+	// When the actual value is a zero (0), it will be interpreted as a float64
+	// rather than an int. To compensate for that ambiguity, a kind can opt-in
+	// to provide a construction function that returns the correct value.
 	Compensate func(interface{}) interface{}
+}
+
+// FieldTypeTestDataMap defines a map with additional functionality on it.
+type FieldTypeTestDataMap map[Kind]ValidInvalid
+
+// GetKinds returns the keys of the test data map in sorted order.
+func (s FieldTypeTestDataMap) GetKinds() []Kind {
+	strArr := make([]string, len(s))
+	kinds := make([]Kind, len(s))
+	i := 0
+	for k := range s {
+		strArr[i] = k.String()
+		i++
+	}
+	sort.Strings(strArr)
+	for i := 0; i < len(strArr); i++ {
+		kinds[i] = Kind(strArr[i])
+	}
+	return kinds
 }
 
 // GetFieldTypeTestData returns a list of legal and illegal values to be used
 // with a given field type (here: the map key).
-func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
+func GetFieldTypeTestData(t *testing.T) FieldTypeTestDataMap {
 	// helper function to convert a string into a duration and handling the
 	// error
 	validDuration := func(s string) time.Duration {
@@ -36,10 +57,11 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 		return d
 	}
 
-	return map[Kind]ValidInvalid{
+	res := FieldTypeTestDataMap{
 		KindString: {
 			Valid: []interface{}{
 				"foo",
+				"bar",
 			},
 			Invalid: []interface{}{
 				"", // NOTE: an empty string is not allowed in a required field.
@@ -52,7 +74,8 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 		KindUser: {
 			Valid: []interface{}{
 				"jane doe", // TODO(kwk): do we really allow usernames with spaces?
-				"",         // TODO(kwk): do we really allow empty usernames?
+				"john doe",
+				"", // TODO(kwk): do we really allow empty usernames?
 			},
 			Invalid: []interface{}{
 				nil,
@@ -64,6 +87,7 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 		KindIteration: {
 			Valid: []interface{}{
 				"some iteration name",
+				"some other iteration name",
 				"", // TODO(kwk): do we really allow empty iteration names?
 			},
 			Invalid: []interface{}{
@@ -75,7 +99,8 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 		},
 		KindArea: {
 			Valid: []interface{}{
-				"some are name",
+				"some area name",
+				"some other area name",
 				"", // TODO(kwk): do we really allow empty area names?
 			},
 			Invalid: []interface{}{
@@ -88,6 +113,7 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 		KindLabel: {
 			Valid: []interface{}{
 				"some label name",
+				"some label name2",
 				"", // TODO(kwk): do we really allow empty label names?
 			},
 			Invalid: []interface{}{
@@ -201,6 +227,11 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 					require.NoError(t, err)
 					return v.UTC()
 				}(),
+				func() interface{} {
+					v, err := time.Parse("02 Jan 06 15:04 -0700", "03 Jan 06 15:04 -0700")
+					require.NoError(t, err)
+					return v.UTC()
+				}(),
 				// time.Now().UTC(), // TODO(kwk): Somehow this fails due to different nsec
 			},
 			Invalid: []interface{}{
@@ -243,6 +274,13 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 					LineNumber: 10,
 					CodebaseID: "dunno",
 				},
+				codebase.Content{
+					Repository: "git://github.com/pkg/error.git",
+					Branch:     "master",
+					FileName:   "main.go",
+					LineNumber: 15,
+					CodebaseID: "dunno",
+				},
 			},
 			Invalid: []interface{}{
 				// empty repository (see codebase.Content.IsValid())
@@ -276,4 +314,14 @@ func GetFieldTypeTestData(t *testing.T) map[Kind]ValidInvalid {
 		//KindEnum:  {}, // TODO(kwk): Add test for KindEnum
 		//KindList:  {}, // TODO(kwk): Add test for KindList
 	}
+
+	for k, iv := range res {
+		if len(iv.Valid) < 2 {
+			t.Fatalf("at least two valid examples required for kind %s but only %d given", k, len(iv.Valid))
+		}
+		if len(iv.Invalid) < 1 {
+			t.Fatalf("at least one invalid example is required for kind %s but only %d given", k, len(iv.Invalid))
+		}
+	}
+	return res
 }

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -259,11 +259,7 @@ func (s *workItemRepoBlackBoxTest) TestCreate() {
 
 	s.T().Run("field types", func(t *testing.T) {
 		vals := workitem.GetFieldTypeTestData(t)
-		// Get keys from the map above
-		kinds := []workitem.Kind{}
-		for k := range vals {
-			kinds = append(kinds, k)
-		}
+		kinds := vals.GetKinds()
 		fieldName := "fieldundertest"
 		// Create a work item type for each kind
 		fxt := tf.NewTestFixture(t, s.DB,


### PR DESCRIPTION
@sanbornsen mentioned last week that we cannot update a work item field of type `integer` and `instant`. This change adds golden files and a test for all except list and enum type fields.

## TODOs

- [ ] have float values in test data with anything other than `.0` suffix so they are written as a float instead of an integer to the JSON golden file.
- [ ] update test name to from `TestWI2UpdateFieldOfDifferentTypes` to `TestWI2UpdateFieldOfDifferentSimpleTypes`
