### PR TITLE
Fix space creation

### DIFF
--- a/auth/resource.go
+++ b/auth/resource.go
@@ -71,8 +71,8 @@ func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *http.Re
 	}
 	defer rest.CloseResponse(res)
 
-	responseBody := rest.ReadBody(res.Body)
 	if res.StatusCode != http.StatusOK {
+		responseBody := rest.ReadBody(res.Body)
 		log.Error(ctx, map[string]interface{}{
 			"space_id":        spaceID,
 			"response_status": res.Status,
@@ -86,12 +86,11 @@ func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *http.Re
 	resource, err := c.DecodeSpaceResource(res)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
-			"err":           err,
-			"space_id":      spaceID,
-			"response_body": rest.ReadBody(res.Body),
+			"err":      err,
+			"space_id": spaceID,
 		}, "unable to decode the create space resource request result")
 
-		return nil, errs.Wrapf(err, "unable to decode the create space resource request result %s ", rest.ReadBody(res.Body))
+		return nil, errs.Wrapf(err, "unable to decode the create space resource request result")
 	}
 
 	log.Debug(ctx, map[string]interface{}{

--- a/auth/resource.go
+++ b/auth/resource.go
@@ -13,12 +13,11 @@ import (
 	goaclient "github.com/goadesign/goa/client"
 	goauuid "github.com/goadesign/goa/uuid"
 	errs "github.com/pkg/errors"
-	"github.com/satori/go.uuid"
 )
 
 // ResourceManager represents a space resource manager
 type ResourceManager interface {
-	CreateSpace(ctx context.Context, request *http.Request, spaceID string) (*authservice.SpaceResource, error)
+	CreateSpace(ctx context.Context, request *http.Request, spaceID string) error
 	DeleteSpace(ctx context.Context, request *http.Request, spaceID string) error
 }
 
@@ -40,26 +39,22 @@ func NewAuthzResourceManager(config ServiceConfiguration) *AuthzResourceManager 
 }
 
 // CreateSpace calls auth service to create a keycloak resource associated with the space
-func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *http.Request, spaceID string) (*authservice.SpaceResource, error) {
+func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *http.Request, spaceID string) error {
 	if !m.configuration.IsAuthorizationEnabled() {
 		// Keycloak authorization is disabled by default in Developer Mode
 		log.Warn(ctx, map[string]interface{}{
 			"space_id": spaceID,
 		}, "Authorization is disabled. Keycloak space resource won't be created")
-		return &authservice.SpaceResource{Data: &authservice.SpaceResourceData{
-			ResourceID:   uuid.NewV4().String(),
-			PermissionID: uuid.NewV4().String(),
-			PolicyID:     uuid.NewV4().String(),
-		}}, nil
+		return nil
 	}
 
 	c, err := CreateClient(ctx, m.configuration)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	sUD, err := goauuid.FromString(spaceID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	res, err := c.CreateSpace(goasupport.ForwardContextRequestID(ctx), authservice.CreateSpacePath(sUD))
 	if err != nil {
@@ -67,7 +62,7 @@ func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *http.Re
 			"space_id": spaceID,
 			"err":      err.Error(),
 		}, "unable to create a space resource via auth service")
-		return nil, errs.Wrap(err, "unable to create a space resource via auth service")
+		return errs.Wrap(err, "unable to create a space resource via auth service")
 	}
 	defer rest.CloseResponse(res)
 
@@ -80,25 +75,10 @@ func (m *AuthzResourceManager) CreateSpace(ctx context.Context, request *http.Re
 		}, "unable to create a space resource via auth service")
 		// Proxy-back back the response as is -
 		// WIT acts as a gateway to Auth, who would send the appropriate response.
-		return nil, proxy.ConvertHTTPErrorCode(res.StatusCode, responseBody)
+		return proxy.ConvertHTTPErrorCode(res.StatusCode, responseBody)
 	}
 
-	resource, err := c.DecodeSpaceResource(res)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"err":      err,
-			"space_id": spaceID,
-		}, "unable to decode the create space resource request result")
-
-		return nil, errs.Wrapf(err, "unable to decode the create space resource request result")
-	}
-
-	log.Debug(ctx, map[string]interface{}{
-		"space_id":    spaceID,
-		"resource_id": resource.Data.ResourceID,
-	}, "Space resource created")
-
-	return resource, nil
+	return nil
 }
 
 // DeleteSpace calls auth service to delete the keycloak resource associated with the space

--- a/controller/space.go
+++ b/controller/space.go
@@ -116,7 +116,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 	}
 
 	// Create keycloak resource for this space
-	_, err = c.resourceManager.CreateSpace(ctx, ctx.Request, spaceID.String())
+	err = c.resourceManager.CreateSpace(ctx, ctx.Request, spaceID.String())
 	if err != nil {
 		// Unable to create a space resource. Can't proceed. Roll back space creation and return an error.
 		c.rollBackSpaceCreation(ctx, spaceID)

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/app/test"
-	"github.com/fabric8-services/fabric8-wit/auth/authservice"
 	"github.com/fabric8-services/fabric8-wit/configuration"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/errors"
@@ -34,17 +33,17 @@ type DummyResourceManager struct {
 	httpResponseCode int
 }
 
-func (m *DummyResourceManager) CreateSpace(ctx context.Context, request *http.Request, spaceID string) (*authservice.SpaceResource, error) {
+func (m *DummyResourceManager) CreateSpace(ctx context.Context, request *http.Request, spaceID string) error {
 	if m.httpResponseCode == 400 {
-		return nil, errors.NewBadParameterErrorFromString("auth returned a 400")
+		return errors.NewBadParameterErrorFromString("auth returned a 400")
 	}
 	if m.httpResponseCode == 401 {
-		return nil, errors.NewUnauthorizedError("auth returned a 401")
+		return errors.NewUnauthorizedError("auth returned a 401")
 	}
 	if m.httpResponseCode == 500 {
-		return nil, errors.NewInternalErrorFromString("auth returned a 500")
+		return errors.NewInternalErrorFromString("auth returned a 500")
 	}
-	return &authservice.SpaceResource{Data: &authservice.SpaceResourceData{ResourceID: uuid.NewV4().String(), PermissionID: uuid.NewV4().String(), PolicyID: uuid.NewV4().String()}}, nil
+	return nil
 }
 
 func (m *DummyResourceManager) DeleteSpace(ctx context.Context, request *http.Request, spaceID string) error {


### PR DESCRIPTION
The issue was introduced by https://github.com/fabric8-services/fabric8-wit/commit/f704d8cbd38e1ef04e923a0127cc176f96e165c6#diff-ebe2c82ed83d49b7c1b2c79e7fd306f1R132

During handling the response from Auth service the response body was read from the stream before decoding it. So, the output stream is already empty by the time we decode the result body and response decoding failed.

Quick fix would be just move the body reading inside an error handling block - https://github.com/fabric8-services/fabric8-wit/pull/2027/commits/aaf315e3bb1f32af6d077a19408d5439d0600b12#diff-ebe2c82ed83d49b7c1b2c79e7fd306f1R75 but we actually don't need the response body of a successful result at all. It's not used anywhere. So, I removed this body decoding completely in this PR.

Fixes https://github.com/openshiftio/openshift.io/issues/3191