### PR TITLE
Don't use IDs as part of log message Keys (#1971)

### DIFF
--- a/controller/space_iterations.go
+++ b/controller/space_iterations.go
@@ -139,9 +139,8 @@ func (c *SpaceIterationsController) List(ctx *app.ListSpaceIterationsContext) er
 			}
 			// fetch extra information(counts of WI in each iteration of the space) to be added in response
 			wiCounts, err := appl.WorkItems().GetCountsPerIteration(ctx, ctx.SpaceID)
-			log.Info(ctx, map[string]interface{}{
+			log.Debug(ctx, map[string]interface{}{
 				"space_id": ctx.SpaceID.String(),
-				"wiCounts": wiCounts,
 			}, "Retrieving wicounts for spaceID %s -> %v", ctx.SpaceID.String(), wiCounts)
 
 			if err != nil {


### PR DESCRIPTION
Downgrade to log.Debug and remove the `wiCount` map from the
message fields.

Fixes #1971

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>