### PR TITLE
Fix scrum icons

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -812,6 +812,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "843238741f4e88d78a8acaa703af920f93880a14b119627c75831c56a6e20393"
+  inputs-digest = "284ad58436782380c1524b9794fbca2cc798fbdeab89818fdd22a063398d9e19"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/controller/test-files/work_item_type/list/ok_base.res.headers.golden.json
+++ b/controller/test-files/work_item_type/list/ok_base.res.headers.golden.json
@@ -1,0 +1,14 @@
+{
+  "Cache-Control": [
+    "max-age=2"
+  ],
+  "Content-Type": [
+    "application/vnd.api+json"
+  ],
+  "Etag": [
+    "0icd7ov5CqwDXN6Fx9z18g=="
+  ],
+  "Last-Modified": [
+    "Mon, 01 Jan 0001 00:00:00 GMT"
+  ]
+}

--- a/controller/test-files/work_item_type/list/ok_base.res.payload.golden.json
+++ b/controller/test-files/work_item_type/list/ok_base.res.payload.golden.json
@@ -1,0 +1,163 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "can-construct": false,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "Description for Planner Item",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-bookmark",
+        "name": "Planner Item",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    }
+  ]
+}

--- a/controller/test-files/work_item_type/list/ok_legacy.res.headers.golden.json
+++ b/controller/test-files/work_item_type/list/ok_legacy.res.headers.golden.json
@@ -1,0 +1,14 @@
+{
+  "Cache-Control": [
+    "max-age=2"
+  ],
+  "Content-Type": [
+    "application/vnd.api+json"
+  ],
+  "Etag": [
+    "0icd7ov5CqwDXN6Fx9z18g=="
+  ],
+  "Last-Modified": [
+    "Mon, 01 Jan 0001 00:00:00 GMT"
+  ]
+}

--- a/controller/test-files/work_item_type/list/ok_legacy.res.payload.golden.json
+++ b/controller/test-files/work_item_type/list/ok_legacy.res.payload.golden.json
@@ -1,0 +1,1356 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-tasks",
+        "name": "Task",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-bug",
+        "name": "Bug",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-puzzle-piece",
+        "name": "Feature",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000005",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000004",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "pficon pficon-infrastructure",
+        "name": "Experience",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000005",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000004",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-diamond",
+        "name": "Value Proposition",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000007",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000005",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000004",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-bullseye",
+        "name": "Scenario",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000008",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000006",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000007",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-university",
+        "name": "Fundamental",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000009",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000006",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000007",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-scissors",
+        "name": "Papercuts",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000010",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000006",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000007",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    }
+  ]
+}

--- a/controller/test-files/work_item_type/list/ok_scrum.res.headers.golden.json
+++ b/controller/test-files/work_item_type/list/ok_scrum.res.headers.golden.json
@@ -1,0 +1,14 @@
+{
+  "Cache-Control": [
+    "max-age=2"
+  ],
+  "Content-Type": [
+    "application/vnd.api+json"
+  ],
+  "Etag": [
+    "0icd7ov5CqwDXN6Fx9z18g=="
+  ],
+  "Last-Modified": [
+    "Mon, 01 Jan 0001 00:00:00 GMT"
+  ]
+}

--- a/controller/test-files/work_item_type/list/ok_scrum.res.payload.golden.json
+++ b/controller/test-files/work_item_type/list/ok_scrum.res.payload.golden.json
@@ -1,0 +1,1496 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "can-construct": false,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "This is the work item type that defines the common fields that are shared among all for all work item types of the scrum template. It extends the planner item type and thereby already provides a great deal of common fields.\n",
+        "fields": {
+          "resolution": {
+            "description": "The reason why this work item's state was last changed.\n",
+            "label": "Resolution",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Done",
+                "Rejected",
+                "Duplicate",
+                "Incomplete Description",
+                "Cannot Reproduce",
+                "Partially Completed",
+                "Deferred",
+                "Won't Fix",
+                "Won't Do",
+                "Out of Date",
+                "Explained",
+                "Verified"
+              ]
+            }
+          },
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the work item",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "new",
+                "open",
+                "in progress",
+                "resolved",
+                "closed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-question",
+        "name": "Scrum Common Type",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "Note that this is never part of a backlog. It is simply associated with other work items to indicate impediments blocking that work item.\n",
+        "fields": {
+          "resolution": {
+            "description": "The reason why this work item's state was last changed.\n",
+            "label": "Resolution",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Done",
+                "Rejected",
+                "Duplicate",
+                "Incomplete Description",
+                "Cannot Reproduce",
+                "Partially Completed",
+                "Deferred",
+                "Won't Fix",
+                "Won't Do",
+                "Out of Date",
+                "Explained",
+                "Verified"
+              ]
+            }
+          },
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the impediment.",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Open",
+                "Closed",
+                "Removed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-stumbleupon",
+        "name": "Impediment",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "remaining_work": {
+            "description": "TBD",
+            "label": "Remaining work",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "resolution": {
+            "description": "The reason why this work item's state was last changed.\n",
+            "label": "Resolution",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Done",
+                "Rejected",
+                "Duplicate",
+                "Incomplete Description",
+                "Cannot Reproduce",
+                "Partially Completed",
+                "Deferred",
+                "Won't Fix",
+                "Won't Do",
+                "Out of Date",
+                "Explained",
+                "Verified"
+              ]
+            }
+          },
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the Task.",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "To Do",
+                "In Progress",
+                "Done",
+                "Removed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "fa fa-tasks",
+        "name": "Task",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000005",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000005",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "acceptance_criteria": {
+            "description": "TBD",
+            "label": "Acceptance criteria",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "effort": {
+            "description": "TBD",
+            "label": "Effort",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "found_in": {
+            "description": "Good place for both users and automated tools to indicate where they found the bug (e.g. perhaps a build number).\n",
+            "label": "Found in",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "remaining_work": {
+            "description": "TBD",
+            "label": "Remaining work",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "repro_steps": {
+            "description": "TBD",
+            "label": "Steps to reproduce",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "resolution": {
+            "description": "The reason why this work item's state was last changed.\n",
+            "label": "Resolution",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Done",
+                "Rejected",
+                "Duplicate",
+                "Incomplete Description",
+                "Cannot Reproduce",
+                "Partially Completed",
+                "Deferred",
+                "Won't Fix",
+                "Won't Do",
+                "Out of Date",
+                "Explained",
+                "Verified"
+              ]
+            }
+          },
+          "severity": {
+            "description": "TBD",
+            "label": "Severity",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Critical",
+                "High",
+                "Medium",
+                "Low"
+              ]
+            }
+          },
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the Bug.",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "New",
+                "Approved",
+                "Committed",
+                "Done",
+                "Removed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system_info": {
+            "description": "TBD",
+            "label": "System Info",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          }
+        },
+        "icon": "fa fa-bug",
+        "name": "Bug",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000005",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "acceptance_criteria": {
+            "description": "TBD",
+            "label": "Acceptance criteria",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "business_value": {
+            "description": "TBD",
+            "label": "Business value",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "effort": {
+            "description": "TBD",
+            "label": "Effort",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "resolution": {
+            "description": "The reason why this work item's state was last changed.\n",
+            "label": "Resolution",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Done",
+                "Rejected",
+                "Duplicate",
+                "Incomplete Description",
+                "Cannot Reproduce",
+                "Partially Completed",
+                "Deferred",
+                "Won't Fix",
+                "Won't Do",
+                "Out of Date",
+                "Explained",
+                "Verified"
+              ]
+            }
+          },
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the product backlog item.",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "New",
+                "Approved",
+                "Committed",
+                "Done",
+                "Removed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          }
+        },
+        "icon": "pficon pficon-image",
+        "name": "Product Backlog Item",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000007",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000005",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000007",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "acceptance_criteria": {
+            "description": "TBD",
+            "label": "Acceptance criteria",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "business_value": {
+            "description": "TBD",
+            "label": "Business value",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "effort": {
+            "description": "TBD",
+            "label": "Effort",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "resolution": {
+            "description": "The reason why this work item's state was last changed.\n",
+            "label": "Resolution",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Done",
+                "Rejected",
+                "Duplicate",
+                "Incomplete Description",
+                "Cannot Reproduce",
+                "Partially Completed",
+                "Deferred",
+                "Won't Fix",
+                "Won't Do",
+                "Out of Date",
+                "Explained",
+                "Verified"
+              ]
+            }
+          },
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the feature.",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "New",
+                "In Progress",
+                "Done",
+                "Removed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "target_date": {
+            "description": "TBD",
+            "label": "Target date",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "time_criticality": {
+            "description": "Time Criticality captures how the business value decreases over time for a Feature or Epic. Higher values indicate that the item is inherently more time critical than those items with lower values.\n",
+            "label": "Time criticality",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          }
+        },
+        "icon": "fa fa-puzzle-piece",
+        "name": "Feature",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000008",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000006",
+              "type": "workitemtypes"
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000007",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    },
+    {
+      "attributes": {
+        "can-construct": true,
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "TBD",
+        "fields": {
+          "acceptance_criteria": {
+            "description": "TBD",
+            "label": "Acceptance criteria",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "business_value": {
+            "description": "TBD",
+            "label": "Business value",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "effort": {
+            "description": "TBD",
+            "label": "Effort",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "resolution": {
+            "description": "The reason why this work item's state was last changed.\n",
+            "label": "Resolution",
+            "required": false,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "Done",
+                "Rejected",
+                "Duplicate",
+                "Incomplete Description",
+                "Cannot Reproduce",
+                "Partially Completed",
+                "Deferred",
+                "Won't Fix",
+                "Won't Do",
+                "Out of Date",
+                "Explained",
+                "Verified"
+              ]
+            }
+          },
+          "system.area": {
+            "description": "The area to which the work item belongs",
+            "label": "Area",
+            "required": false,
+            "type": {
+              "kind": "area"
+            }
+          },
+          "system.assignees": {
+            "description": "The users that are assigned to the work item",
+            "label": "Assignees",
+            "required": false,
+            "type": {
+              "componentType": "user",
+              "kind": "list"
+            }
+          },
+          "system.codebase": {
+            "description": "Contains codebase attributes to which this WI belongs to",
+            "label": "Codebase",
+            "required": false,
+            "type": {
+              "kind": "codebase"
+            }
+          },
+          "system.created_at": {
+            "description": "The date and time when the work item was created",
+            "label": "Created at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "system.creator": {
+            "description": "The user that created the work item",
+            "label": "Creator",
+            "required": true,
+            "type": {
+              "kind": "user"
+            }
+          },
+          "system.description": {
+            "description": "A descriptive text of the work item",
+            "label": "Description",
+            "required": false,
+            "type": {
+              "kind": "markup"
+            }
+          },
+          "system.iteration": {
+            "description": "The iteration to which the work item belongs",
+            "label": "Iteration",
+            "required": false,
+            "type": {
+              "kind": "iteration"
+            }
+          },
+          "system.labels": {
+            "description": "List of labels attached to the work item",
+            "label": "Labels",
+            "required": false,
+            "type": {
+              "componentType": "label",
+              "kind": "list"
+            }
+          },
+          "system.number": {
+            "description": "The unique number that was given to this workitem within its space.",
+            "label": "Number",
+            "required": false,
+            "type": {
+              "kind": "integer"
+            }
+          },
+          "system.order": {
+            "description": "Execution Order of the workitem",
+            "label": "Execution Order",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          },
+          "system.remote_item_id": {
+            "description": "The ID of the remote work item",
+            "label": "Remote item",
+            "required": false,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.state": {
+            "description": "The state of the Epic.",
+            "label": "State",
+            "required": true,
+            "type": {
+              "baseType": "string",
+              "kind": "enum",
+              "values": [
+                "New",
+                "In Progress",
+                "Done",
+                "Removed"
+              ]
+            }
+          },
+          "system.title": {
+            "description": "The title text of the work item",
+            "label": "Title",
+            "required": true,
+            "type": {
+              "kind": "string"
+            }
+          },
+          "system.updated_at": {
+            "description": "The date and time when the work item was last updated",
+            "label": "Updated at",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "target_date": {
+            "description": "TBD",
+            "label": "Target date",
+            "required": false,
+            "type": {
+              "kind": "instant"
+            }
+          },
+          "time_criticality": {
+            "description": "Time Criticality captures how the business value decreases over time for a Feature or Epic. Higher values indicate that the item is inherently more time critical than those items with lower values.\n",
+            "label": "Time criticality",
+            "required": false,
+            "type": {
+              "kind": "float"
+            }
+          }
+        },
+        "icon": "fa fa-bullseye",
+        "name": "Epic",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000009",
+      "relationships": {
+        "guidedChildTypes": {
+          "data": [
+            {
+              "id": "00000000-0000-0000-0000-000000000008",
+              "type": "workitemtypes"
+            }
+          ]
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "workitemtypes"
+    }
+  ]
+}

--- a/controller/test-files/work_item_type_group/list/ok_scrum_template.payload.golden.json
+++ b/controller/test-files/work_item_type_group/list/ok_scrum_template.payload.golden.json
@@ -4,7 +4,7 @@
       "attributes": {
         "bucket": "portfolio",
         "created-at": "0001-01-01T00:00:00Z",
-        "icon": "fa fa-bolt",
+        "icon": "fa fa-bullseye",
         "name": "Epics",
         "show-in-sidebar": true,
         "updated-at": "0001-01-01T00:00:00Z"
@@ -66,7 +66,7 @@
       "attributes": {
         "bucket": "requirement",
         "created-at": "0001-01-01T00:00:00Z",
-        "icon": "fa fa-question",
+        "icon": "pficon pficon-image",
         "name": "Backlog items",
         "show-in-sidebar": true,
         "updated-at": "0001-01-01T00:00:00Z"
@@ -101,7 +101,7 @@
       "attributes": {
         "bucket": "iteration",
         "created-at": "0001-01-01T00:00:00Z",
-        "icon": "fa fa-tasks",
+        "icon": "fa fa-repeat",
         "name": "Execution",
         "show-in-sidebar": false,
         "updated-at": "0001-01-01T00:00:00Z"

--- a/controller/workitemtypes_blackbox_test.go
+++ b/controller/workitemtypes_blackbox_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -79,31 +80,51 @@ func (s *workItemTypesSuite) TestList() {
 	})
 
 	s.T().Run("ok", func(t *testing.T) {
-		// when
-		res, witCollection := test.ListWorkitemtypesOK(t, nil, nil, s.typeCtrl, fxt.SpaceTemplates[0].ID, nil, nil)
-		// then
-		require.NotNil(t, witCollection)
-		require.Nil(t, witCollection.Validate())
+		t.Run("generated", func(t *testing.T) {
+			// when
+			res, witCollection := test.ListWorkitemtypesOK(t, nil, nil, s.typeCtrl, fxt.SpaceTemplates[0].ID, nil, nil)
+			// then
+			require.NotNil(t, witCollection)
+			require.Nil(t, witCollection.Validate())
 
-		toBeFound := id.Slice{fxt.WorkItemTypes[0].ID, fxt.WorkItemTypes[1].ID}.ToMap()
-		for _, wit := range witCollection.Data {
-			_, ok := toBeFound[*wit.ID]
-			assert.True(t, ok, "failed to find work item type %s in expected list", *wit.ID)
-			delete(toBeFound, *wit.ID)
+			toBeFound := id.Slice{fxt.WorkItemTypes[0].ID, fxt.WorkItemTypes[1].ID}.ToMap()
+			for _, wit := range witCollection.Data {
+				_, ok := toBeFound[*wit.ID]
+				assert.True(t, ok, "failed to find work item type %s in expected list", *wit.ID)
+				delete(toBeFound, *wit.ID)
+			}
+			require.Empty(t, toBeFound, "failed to find these expected work item types: %v", toBeFound)
+
+			require.NotNil(t, res.Header()[app.LastModified])
+			assert.Equal(t, app.ToHTTPTime(fxt.WorkItemTypes[1].UpdatedAt), res.Header()[app.LastModified][0])
+			require.NotNil(t, res.Header()[app.CacheControl])
+			assert.NotNil(t, res.Header()[app.CacheControl][0])
+			require.NotNil(t, res.Header()[app.ETag])
+			assert.Equal(t, generateWorkItemTypesTag(*witCollection), res.Header()[app.ETag][0])
+
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.payload.golden.json"), witCollection)
+			safeOverriteHeader(t, res, "Etag", "0icd7ov5CqwDXN6Fx9z18g==")
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.headers.golden.json"), res.Header())
+			assertResponseHeaders(t, res)
+		})
+		// Test pre-defined work item types
+		spaceTemplates := map[string]uuid.UUID{
+			"base":   spacetemplate.SystemBaseTemplateID,
+			"scrum":  spacetemplate.SystemScrumTemplateID,
+			"legacy": spacetemplate.SystemLegacyTemplateID,
 		}
-		require.Empty(t, toBeFound, "failed to find these expected work item types: %v", toBeFound)
-
-		require.NotNil(t, res.Header()[app.LastModified])
-		assert.Equal(t, app.ToHTTPTime(fxt.WorkItemTypes[1].UpdatedAt), res.Header()[app.LastModified][0])
-		require.NotNil(t, res.Header()[app.CacheControl])
-		assert.NotNil(t, res.Header()[app.CacheControl][0])
-		require.NotNil(t, res.Header()[app.ETag])
-		assert.Equal(t, generateWorkItemTypesTag(*witCollection), res.Header()[app.ETag][0])
-
-		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.payload.golden.json"), witCollection)
-		safeOverriteHeader(t, res, "Etag", "0icd7ov5CqwDXN6Fx9z18g==")
-		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.headers.golden.json"), res.Header())
-		assertResponseHeaders(t, res)
+		for name, ID := range spaceTemplates {
+			t.Run(name, func(t *testing.T) {
+				// when
+				res, witCollection := test.ListWorkitemtypesOK(t, nil, nil, s.typeCtrl, ID, nil, nil)
+				// then
+				require.NotNil(t, witCollection)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", fmt.Sprintf("ok_%s.res.payload.golden.json", name)), witCollection)
+				safeOverriteHeader(t, res, "Etag", "0icd7ov5CqwDXN6Fx9z18g==")
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", fmt.Sprintf("ok_%s.res.headers.golden.json", name)), res.Header())
+				assertResponseHeaders(t, res)
+			})
+		}
 	})
 
 	s.T().Run("ok - using expired IfModifiedSince header", func(t *testing.T) {

--- a/spacetemplate/assets/scrum.yaml
+++ b/spacetemplate/assets/scrum.yaml
@@ -194,7 +194,7 @@ work_item_types:
   name: Product Backlog Item
   can_construct: yes
   description: TBD
-  icon: fa fa-question
+  icon: pficon pficon-image
   fields:
     "system.state":
       label: State
@@ -370,7 +370,7 @@ work_item_type_groups:
   - *productBacklogItemID
   - *bugID
   bucket: requirement
-  icon: fa fa-question
+  icon: pficon pficon-image
 
 - name: Execution
   id: "4d187330-0efb-4077-8745-8a61384a6540"

--- a/spacetemplate/assets/scrum.yaml
+++ b/spacetemplate/assets/scrum.yaml
@@ -66,7 +66,7 @@ work_item_types:
   description: >
     Note that this is never part of a backlog. It is simply associated with
     other work items to indicate impediments blocking that work item.
-  icon: fa fa-question
+  icon: fa fa-stumbleupon
   fields:
     "system.state":
       label: State
@@ -296,7 +296,7 @@ work_item_types:
   name: Epic
   can_construct: yes
   description: TBD
-  icon: fa fa-bolt
+  icon: fa fa-bullseye
   fields:
     "system.state":
       label: State
@@ -355,7 +355,7 @@ work_item_type_groups:
   type_list:
   - *epicID
   bucket: portfolio
-  icon: fa fa-bolt
+  icon: fa fa-bullseye
 
 - name: Features
   id: "9e41be6f-9e16-4e39-bb46-bd130855f2e5"
@@ -379,4 +379,4 @@ work_item_type_groups:
   - *productBacklogItemID
   - *bugID
   bucket: iteration
-  icon: fa fa-tasks
+  icon: fa fa-repeat


### PR DESCRIPTION
Change icons of work item types and side panel entries according to these designs: https://redhat.invisionapp.com/share/WJGSJ17SMHN#/screens/290540724.

**NOTE**: Most of the changed files are new golden files. We didn't have golden files for listing work item types of the pre-known space templates before and that is what bloats this PR. The important change is this: https://github.com/fabric8-services/fabric8-wit/pull/2067/files#diff-f71e2910b3317a6a57a3a93edc987a7b.

**Impediment** (WIT):

Changed from `fa fa-question` to `fa fa-stumbleupon`  ![bildschirmfoto von 2018-04-30 13-04-52](https://user-images.githubusercontent.com/193408/39424456-1a76daa0-4c77-11e8-876b-3e977f7a1274.png)

**Product Backlog Item** (WIT) / **Backlog Items** (Sidepanel entry): 

Change from `fa fa-question` to `pficon pficon-image` ![bildschirmfoto von 2018-04-30 13-06-31](https://user-images.githubusercontent.com/193408/39424502-54bbd36e-4c77-11e8-93be-b6bd69d61880.png)

**Epic** (WIT) / **Epics** (Sidepanel entry):

Change from `fa fa-bolt` to `fa fa-bullseye` ![bildschirmfoto von 2018-04-30 13-09-15](https://user-images.githubusercontent.com/193408/39424597-b93835ee-4c77-11e8-9113-dbc086a33d02.png)



