### PR TITLE
Call WI's conversion from model to to JSONAPI and back using the WI's type

### DIFF
--- a/controller/planner_backlog.go
+++ b/controller/planner_backlog.go
@@ -60,13 +60,9 @@ func (c *PlannerBacklogController) List(ctx *app.ListPlannerBacklogContext) erro
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	// Load all work item types
-	wits := make([]workitem.WorkItemType, len(result))
-	for idx, wi := range result {
-		wit, err := c.db.WorkItemTypes().Load(ctx.Context, wi.Type)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "failed to load the work item type"))
-		}
-		wits[idx] = *wit
+	wits, err := loadWorkItemTypesFromArr(ctx.Context, c.db, result)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	return ctx.ConditionalEntities(result, c.config.GetCacheControlWorkItems, func() error {
 		response := app.WorkItemList{

--- a/controller/planner_backlog.go
+++ b/controller/planner_backlog.go
@@ -55,12 +55,7 @@ func (c *PlannerBacklogController) List(ctx *app.ListPlannerBacklogContext) erro
 	}
 
 	// Get the list of work items for the following criteria
-	result, count, err := getBacklogItems(ctx.Context, c.db, ctx.SpaceID, exp, &offset, &limit)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, err)
-	}
-	// Load all work item types
-	wits, err := loadWorkItemTypesFromArr(ctx.Context, c.db, result)
+	result, wits, count, err := getBacklogItems(ctx.Context, c.db, ctx.SpaceID, exp, &offset, &limit)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -128,13 +123,14 @@ func generateBacklogExpression(ctx context.Context, db application.DB, spaceID u
 	return exp, nil
 }
 
-func getBacklogItems(ctx context.Context, db application.DB, spaceID uuid.UUID, exp criteria.Expression, offset *int, limit *int) ([]workitem.WorkItem, int, error) {
+func getBacklogItems(ctx context.Context, db application.DB, spaceID uuid.UUID, exp criteria.Expression, offset *int, limit *int) ([]workitem.WorkItem, []workitem.WorkItemType, int, error) {
 	result := []workitem.WorkItem{}
+	wits := []workitem.WorkItemType{}
 	count := 0
 
 	backlogExp, err := generateBacklogExpression(ctx, db, spaceID, exp)
 	if err != nil || backlogExp == nil {
-		return result, count, err
+		return result, wits, count, err
 	}
 
 	err = application.Transactional(db, func(appl application.Application) error {
@@ -143,12 +139,16 @@ func getBacklogItems(ctx context.Context, db application.DB, spaceID uuid.UUID, 
 		if err != nil {
 			return errs.Wrap(err, "error listing backlog items")
 		}
+		wits, err = loadWorkItemTypesFromArr(ctx, appl, result)
+		if err != nil {
+			return errs.Wrap(err, "failed to load work item types")
+		}
 		return nil
 	})
 	if err != nil {
-		return result, count, err
+		return result, wits, count, err
 	}
-	return result, count, nil
+	return result, wits, count, nil
 }
 
 func countBacklogItems(ctx context.Context, db application.DB, spaceID uuid.UUID) (int, error) {

--- a/controller/planner_backlog.go
+++ b/controller/planner_backlog.go
@@ -60,8 +60,12 @@ func (c *PlannerBacklogController) List(ctx *app.ListPlannerBacklogContext) erro
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	return ctx.ConditionalEntities(result, c.config.GetCacheControlWorkItems, func() error {
+		wi, err := ConvertWorkItems(ctx.Request, wits, result)
+		if err != nil {
+			jsonapi.JSONErrorResponse(ctx, err)
+		}
 		response := app.WorkItemList{
-			Data:  ConvertWorkItems(ctx.Request, wits, result),
+			Data:  wi,
 			Links: &app.PagingLinks{},
 			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
 		}

--- a/controller/search.go
+++ b/controller/search.go
@@ -181,7 +181,7 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 		// Load all work item types
 		wits, err := loadWorkItemTypesFromArr(ctx.Context, c.db, result)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "failed to load work item types"))
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "failed to load work item types"))
 		}
 
 		wis, err := ConvertWorkItems(ctx.Request, wits, result, hasChildren, includeParent)

--- a/controller/work_item_comments.go
+++ b/controller/work_item_comments.go
@@ -164,11 +164,12 @@ func workItemIncludeCommentsAndTotal(ctx context.Context, db application.DB, par
 			return nil
 		})
 	}()
-	return func(request *http.Request, wi *workitem.WorkItem, wi2 *app.WorkItem) {
+	return func(request *http.Request, wi *workitem.WorkItem, wi2 *app.WorkItem) error {
 		wi2.Relationships.Comments = CreateCommentsRelation(request, wi)
 		wi2.Relationships.Comments.Meta = map[string]interface{}{
 			"totalCount": <-count,
 		}
+		return nil
 	}
 }
 

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -129,7 +129,11 @@ func getWorkItemsOfLinks(ctx context.Context, appl application.Application, req 
 		if err != nil {
 			return nil, errs.WithStack(err)
 		}
-		res = append(res, ConvertWorkItem(req, *wi))
+		wit, err := appl.WorkItemTypes().Load(ctx, wi.Type)
+		if err != nil {
+			return nil, errs.Wrapf(err, "failed to load work item type: %s", wi.Type)
+		}
+		res = append(res, ConvertWorkItem(req, *wit, *wi))
 	}
 	return res, nil
 }
@@ -150,14 +154,22 @@ func enrichLinkSingle(ctx context.Context, appl application.Application, req *ht
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(req, *sourceWi))
+	sourceWIT, err := appl.WorkItemTypes().Load(ctx, sourceWi.Type)
+	if err != nil {
+		return errs.WithStack(err)
+	}
+	appLinks.Included = append(appLinks.Included, ConvertWorkItem(req, *sourceWIT, *sourceWi))
 
 	// Include target work item
 	targetWi, err := appl.WorkItems().LoadByID(ctx, appLinks.Data.Relationships.Target.Data.ID)
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(req, *targetWi))
+	targetWIT, err := appl.WorkItemTypes().Load(ctx, targetWi.Type)
+	if err != nil {
+		return errs.WithStack(err)
+	}
+	appLinks.Included = append(appLinks.Included, ConvertWorkItem(req, *targetWIT, *targetWi))
 	return nil
 }
 

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -133,7 +133,11 @@ func getWorkItemsOfLinks(ctx context.Context, appl application.Application, req 
 		if err != nil {
 			return nil, errs.Wrapf(err, "failed to load work item type: %s", wi.Type)
 		}
-		res = append(res, ConvertWorkItem(req, *wit, *wi))
+		converted, err := ConvertWorkItem(req, *wit, *wi)
+		if err != nil {
+			return nil, errs.WithStack(err)
+		}
+		res = append(res, converted)
 	}
 	return res, nil
 }
@@ -158,7 +162,11 @@ func enrichLinkSingle(ctx context.Context, appl application.Application, req *ht
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(req, *sourceWIT, *sourceWi))
+	convertedSource, err := ConvertWorkItem(req, *sourceWIT, *sourceWi)
+	if err != nil {
+		return errs.WithStack(err)
+	}
+	appLinks.Included = append(appLinks.Included, convertedSource)
 
 	// Include target work item
 	targetWi, err := appl.WorkItems().LoadByID(ctx, appLinks.Data.Relationships.Target.Data.ID)
@@ -169,7 +177,11 @@ func enrichLinkSingle(ctx context.Context, appl application.Application, req *ht
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinks.Included = append(appLinks.Included, ConvertWorkItem(req, *targetWIT, *targetWi))
+	convertedTarget, err := ConvertWorkItem(req, *targetWIT, *targetWi)
+	if err != nil {
+		return errs.WithStack(err)
+	}
+	appLinks.Included = append(appLinks.Included, convertedTarget)
 	return nil
 }
 

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -154,13 +154,14 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 // Show does GET workitem
 func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 	var wi *workitem.WorkItem
+	var wit *workitem.WorkItemType
 	err := application.Transactional(c.db, func(appl application.Application) error {
 		var err error
 		wi, err = appl.WorkItems().LoadByID(ctx, ctx.WiID)
 		if err != nil {
 			return errs.Wrap(err, fmt.Sprintf("Fail to load work item with id %v", ctx.WiID))
 		}
-		wit, err := appl.WorkItemTypes().Load(ctx.Context, wi.Type)
+		wit, err = appl.WorkItemTypes().Load(ctx.Context, wi.Type)
 		if err != nil {
 			return errs.Wrapf(err, "failed to load work item type: %s", wi.Type)
 		}

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -252,6 +252,7 @@ func ConvertJSONAPIToWorkItem(ctx context.Context, method string, appl applicati
 	if err != nil {
 		return errs.Wrapf(err, "failed to load work item type: %s", witID)
 	}
+	_ = wit
 
 	// construct default values from input WI
 	version, err := getVersion(source.Attributes["version"])

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/fabric8-services/fabric8-wit/workitem/link"
 
 	"github.com/fabric8-services/fabric8-wit/ptr"

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -642,6 +642,7 @@ func workItemIncludeHasChildren(ctx context.Context, appl application.Applicatio
 					}, "unable to find out if work item has children: %s", wi.ID)
 					// enforce to have no children
 					hasChildren = false
+					return errs.Wrapf(err, "failed to determine if work item %s has children", wi.ID)
 				}
 			}
 		}

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -609,7 +609,7 @@ func ConvertWorkItem(request *http.Request, wit workitem.WorkItemType, wi workit
 	workItemIncludeChildren(request, &wi, op)
 	for _, add := range additional {
 		if err := add(request, &wi, op); err != nil {
-			return nil, errs.Wrapf(err, "failed to run additional conversion function")
+			return nil, errs.Wrap(err, "failed to run additional conversion function")
 		}
 	}
 	return op, nil
@@ -702,7 +702,7 @@ func (c *WorkitemController) ListChildren(ctx *app.ListChildrenWorkitemContext) 
 		}
 		wits, err = loadWorkItemTypesFromArr(ctx.Context, appl, result)
 		if err != nil {
-			return errs.Wrapf(err, "failed to load the work item types")
+			return errs.Wrap(err, "failed to load the work item types")
 		}
 		return nil
 	})

--- a/controller/workitem_whitebox_test.go
+++ b/controller/workitem_whitebox_test.go
@@ -314,33 +314,73 @@ func (rest *TestWorkItemREST) TestLoadWorkItemTypes() {
 		}),
 	)
 	rest.T().Run("from normal array of work items", func(t *testing.T) {
-		// given
-		wis := []workitem.WorkItem{*fxt.WorkItems[0], *fxt.WorkItems[1], *fxt.WorkItems[2]}
-		// when
-		wits, err := loadWorkItemTypesFromArr(rest.Ctx, rest.db, wis)
-		// then
-		require.NoError(t, err)
-		toBeFound := id.Slice{fxt.WorkItemTypes[0].ID, fxt.WorkItemTypes[1].ID, fxt.WorkItemTypes[2].ID}.ToMap()
-		for _, wit := range wits {
-			_, ok := toBeFound[wit.ID]
-			require.True(t, ok, "found unexpected work item type: %s (%s)", wit.ID, wit.Name)
-			delete(toBeFound, wit.ID)
-		}
-		require.Empty(t, toBeFound, "failed to find these work item types: %+v", toBeFound)
+		t.Run("not empty", func(t *testing.T) {
+			// given
+			wis := []workitem.WorkItem{*fxt.WorkItems[0], *fxt.WorkItems[1], *fxt.WorkItems[2]}
+			// when
+			wits, err := loadWorkItemTypesFromArr(rest.Ctx, rest.db, wis)
+			// then
+			require.NoError(t, err)
+			toBeFound := id.Slice{fxt.WorkItemTypes[0].ID, fxt.WorkItemTypes[1].ID, fxt.WorkItemTypes[2].ID}.ToMap()
+			for _, wit := range wits {
+				_, ok := toBeFound[wit.ID]
+				require.True(t, ok, "found unexpected work item type: %s (%s)", wit.ID, wit.Name)
+				delete(toBeFound, wit.ID)
+			}
+			require.Empty(t, toBeFound, "failed to find these work item types: %+v", toBeFound)
+		})
+		t.Run("empty", func(t *testing.T) {
+			// given
+			wis := []workitem.WorkItem{}
+			// when
+			wits, err := loadWorkItemTypesFromArr(rest.Ctx, rest.db, wis)
+			// then
+			require.NoError(t, err)
+			require.Empty(t, wits)
+		})
+		t.Run("nil", func(t *testing.T) {
+			// given
+			var wis []workitem.WorkItem
+			// when
+			wits, err := loadWorkItemTypesFromArr(rest.Ctx, rest.db, wis)
+			// then
+			require.NoError(t, err)
+			require.Empty(t, wits)
+		})
 	})
 	rest.T().Run("from pointer array of work items", func(t *testing.T) {
-		// given
-		wis := []*workitem.WorkItem{fxt.WorkItems[0], fxt.WorkItems[1], fxt.WorkItems[2]}
-		// when
-		wits, err := loadWorkItemTypesFromPtrArr(rest.Ctx, rest.db, wis)
-		// then
-		require.NoError(t, err)
-		toBeFound := id.Slice{fxt.WorkItemTypes[0].ID, fxt.WorkItemTypes[1].ID, fxt.WorkItemTypes[2].ID}.ToMap()
-		for _, wit := range wits {
-			_, ok := toBeFound[wit.ID]
-			require.True(t, ok, "found unexpected work item type: %s (%s)", wit.ID, wit.Name)
-			delete(toBeFound, wit.ID)
-		}
-		require.Empty(t, toBeFound, "failed to find these work item types: %+v", toBeFound)
+		t.Run("not empty", func(t *testing.T) {
+			// given
+			wis := []*workitem.WorkItem{fxt.WorkItems[0], fxt.WorkItems[1], fxt.WorkItems[2]}
+			// when
+			wits, err := loadWorkItemTypesFromPtrArr(rest.Ctx, rest.db, wis)
+			// then
+			require.NoError(t, err)
+			toBeFound := id.Slice{fxt.WorkItemTypes[0].ID, fxt.WorkItemTypes[1].ID, fxt.WorkItemTypes[2].ID}.ToMap()
+			for _, wit := range wits {
+				_, ok := toBeFound[wit.ID]
+				require.True(t, ok, "found unexpected work item type: %s (%s)", wit.ID, wit.Name)
+				delete(toBeFound, wit.ID)
+			}
+			require.Empty(t, toBeFound, "failed to find these work item types: %+v", toBeFound)
+		})
+		t.Run("empty", func(t *testing.T) {
+			// given
+			wis := []*workitem.WorkItem{}
+			// when
+			wits, err := loadWorkItemTypesFromPtrArr(rest.Ctx, rest.db, wis)
+			// then
+			require.NoError(t, err)
+			require.Empty(t, wits)
+		})
+		t.Run("nil", func(t *testing.T) {
+			// given
+			var wis []*workitem.WorkItem
+			// when
+			wits, err := loadWorkItemTypesFromPtrArr(rest.Ctx, rest.db, wis)
+			// then
+			require.NoError(t, err)
+			require.Empty(t, wits)
+		})
 	})
 }

--- a/controller/workitem_whitebox_test.go
+++ b/controller/workitem_whitebox_test.go
@@ -283,7 +283,8 @@ func (rest *TestWorkItemREST) TestConvertWorkItem() {
 				workitem.SystemDescription: "description",
 			},
 		}
-		wi2 := ConvertWorkItem(request, *fxt.WorkItemTypes[0], wi)
+		wi2, err := ConvertWorkItem(request, *fxt.WorkItemTypes[0], wi)
+		require.NoError(t, err)
 		assert.Equal(t, "title", wi2.Attributes[workitem.SystemTitle])
 		assert.Equal(t, "description", wi2.Attributes[workitem.SystemDescription])
 	})
@@ -296,7 +297,8 @@ func (rest *TestWorkItemREST) TestConvertWorkItem() {
 				workitem.SystemTitle: "title",
 			},
 		}
-		wi2 := ConvertWorkItem(request, *fxt.WorkItemTypes[0], wi)
+		wi2, err := ConvertWorkItem(request, *fxt.WorkItemTypes[0], wi)
+		require.NoError(t, err)
 		assert.Equal(t, "title", wi2.Attributes[workitem.SystemTitle])
 		assert.Nil(t, wi2.Attributes[workitem.SystemDescription])
 	})

--- a/controller/workitems.go
+++ b/controller/workitems.go
@@ -118,7 +118,7 @@ func (c *WorkitemsController) Create(ctx *app.CreateWorkitemsContext) error {
 			return err
 		}
 
-		err = ConvertJSONAPIToWorkItem(ctx, ctx.Method, appl, *ctx.Payload.Data, wi, ctx.SpaceID)
+		err = ConvertJSONAPIToWorkItem(ctx, ctx.Method, appl, *ctx.Payload.Data, wi, *wit, ctx.SpaceID)
 		if err != nil {
 			return errs.Wrap(err, fmt.Sprintf("Error creating work item"))
 		}
@@ -133,7 +133,11 @@ func (c *WorkitemsController) Create(ctx *app.CreateWorkitemsContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	hasChildren := workItemIncludeHasChildren(ctx, c.db)
-	wi2 := ConvertWorkItem(ctx.Request, *wi, hasChildren)
+	workItemType, err := c.db.WorkItemTypes().Load(ctx, *wit)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	wi2 := ConvertWorkItem(ctx.Request, *workItemType, *wi, hasChildren)
 	resp := &app.WorkItemSingle{
 		Data: wi2,
 		Links: &app.WorkItemLinks{
@@ -231,10 +235,14 @@ func (c *WorkitemsController) List(ctx *app.ListWorkitemsContext) error {
 	}
 	return ctx.ConditionalEntities(workitems, c.config.GetCacheControlWorkItems, func() error {
 		hasChildren := workItemIncludeHasChildren(ctx, c.db)
+		wits, err := loadWorkItemTypesFromArr(ctx.Context, c.db, workitems)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
 		response := app.WorkItemList{
 			Links: &app.PagingLinks{},
 			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
-			Data:  ConvertWorkItems(ctx.Request, workitems, hasChildren),
+			Data:  ConvertWorkItems(ctx.Request, wits, workitems, hasChildren),
 		}
 		setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(workitems), offset, limit, count, additionalQuery...)
 		addFilterLinks(response.Links, ctx.Request)
@@ -277,7 +285,7 @@ func (c *WorkitemsController) Reorder(ctx *app.ReorderWorkitemsContext) error {
 				return errors.NewNotFoundError("work item", strconv.Itoa(wi.Number))
 			}
 
-			err = ConvertJSONAPIToWorkItem(ctx, ctx.Method, appl, *ctx.Payload.Data[i], wi, ctx.SpaceID)
+			err = ConvertJSONAPIToWorkItem(ctx, ctx.Method, appl, *ctx.Payload.Data[i], wi, wi.Type, ctx.SpaceID)
 			if err != nil {
 				return errs.Wrap(err, "failed to reorder work item")
 			}
@@ -286,7 +294,11 @@ func (c *WorkitemsController) Reorder(ctx *app.ReorderWorkitemsContext) error {
 				return err
 			}
 			hasChildren := workItemIncludeHasChildren(ctx, c.db)
-			wi2 := ConvertWorkItem(ctx.Request, *wi, hasChildren)
+			wit, err := appl.WorkItemTypes().Load(ctx.Context, wi.Type)
+			if err != nil {
+				return errs.WithStack(err)
+			}
+			wi2 := ConvertWorkItem(ctx.Request, *wit, *wi, hasChildren)
 			dataArray = append(dataArray, wi2)
 		}
 		log.Debug(ctx, nil, "Reordered items: %d", len(dataArray))

--- a/controller/workitems.go
+++ b/controller/workitems.go
@@ -137,7 +137,10 @@ func (c *WorkitemsController) Create(ctx *app.CreateWorkitemsContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
-	wi2 := ConvertWorkItem(ctx.Request, *workItemType, *wi, hasChildren)
+	wi2, err := ConvertWorkItem(ctx.Request, *workItemType, *wi, hasChildren)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
 	resp := &app.WorkItemSingle{
 		Data: wi2,
 		Links: &app.WorkItemLinks{
@@ -239,10 +242,14 @@ func (c *WorkitemsController) List(ctx *app.ListWorkitemsContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
+		converted, err := ConvertWorkItems(ctx.Request, wits, workitems, hasChildren)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
 		response := app.WorkItemList{
 			Links: &app.PagingLinks{},
 			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
-			Data:  ConvertWorkItems(ctx.Request, wits, workitems, hasChildren),
+			Data:  converted,
 		}
 		setPagingLinks(response.Links, buildAbsoluteURL(ctx.Request), len(workitems), offset, limit, count, additionalQuery...)
 		addFilterLinks(response.Links, ctx.Request)
@@ -298,7 +305,10 @@ func (c *WorkitemsController) Reorder(ctx *app.ReorderWorkitemsContext) error {
 			if err != nil {
 				return errs.WithStack(err)
 			}
-			wi2 := ConvertWorkItem(ctx.Request, *wit, *wi, hasChildren)
+			wi2, err := ConvertWorkItem(ctx.Request, *wit, *wi, hasChildren)
+			if err != nil {
+				return errs.WithStack(err)
+			}
 			dataArray = append(dataArray, wi2)
 		}
 		log.Debug(ctx, nil, "Reordered items: %d", len(dataArray))


### PR DESCRIPTION
In this PR I've changed the signature of the `controller/ConvertWorkItem` and `controller/ConvertWorkItems` function. They now accept the work item type of the work item that is supposed to be converted. The type itself is **not yet** used but it will in a future PR.

This is needed to support generic fields (see #2070).