### PR TITLE
osio-3320: Adding support of 'clusterFull' property while obtaining Che server state

### DIFF
--- a/codebase/che/client.go
+++ b/codebase/che/client.go
@@ -480,4 +480,5 @@ func (err *StarterError) String() string {
 type ServerStateResponse struct {
 	Running     bool `json:"running"`
 	MultiTenant bool `json:"multiTenant"`
+	ClusterFull bool `json:"clusterFull"`
 }

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -444,9 +444,12 @@ func (c *CodebaseController) CheState(ctx *app.CheStateCodebaseContext) error {
 
 	isRunning := cheState.Running
 	isMultiTenant := cheState.MultiTenant
+	isClusterFull := cheState.ClusterFull
+
 	state := app.CheServerState{
 		Running:     &isRunning,
 		MultiTenant: &isMultiTenant,
+		ClusterFull: &isClusterFull,
 	}
 	return ctx.OK(&state)
 }
@@ -477,9 +480,12 @@ func (c *CodebaseController) CheStart(ctx *app.CheStartCodebaseContext) error {
 
 	isRunning := cheState.Running
 	isMultiTenant := cheState.MultiTenant
+	isClusterFull := cheState.ClusterFull
+
 	state := app.CheServerState{
 		Running:     &isRunning,
 		MultiTenant: &isMultiTenant,
+		ClusterFull: &isClusterFull,
 	}
 
 	if isRunning {

--- a/design/codebases.go
+++ b/design/codebases.go
@@ -134,12 +134,14 @@ var cheServerState = a.MediaType("CheServerState", func() {
 	a.TypeName("CheServerState")
 	a.Description(`JSONAPI store Che Server state.  See also http://jsonapi.org/format/#document-resource-object`)
 	a.Attributes(func() {
-		a.Attribute("running", d.Boolean, "Che server state")
+		a.Attribute("running", d.Boolean, "Holds info about Che server state - running / not running")
 		a.Attribute("multiTenant", d.Boolean, "Holds info about Che server type - multi-tenant / single-tenant")
+		a.Attribute("clusterFull", d.Boolean, "Holds info about OSO cluster capacity - full / not full")
 	})
 	a.View("default", func() {
 		a.Attribute("running")
 		a.Attribute("multiTenant")
+		a.Attribute("clusterFull")
 	})
 })
 


### PR DESCRIPTION
che-starter PR - https://github.com/redhat-developer/che-starter/pull/303
osio issue - https://github.com/openshiftio/openshift.io/issues/3320

Adding support of new `clusterFull` property exposed on che-starter side while obtaining Che state - http://che-starter-dsaas-preview.b6ff.rh-idev.openshiftapps.com/swagger-ui.html#!/che-server-controller/getCheServerInfoUsingGET