### PR TITLE
Add capacity flag to namespaces - `cluster-capacity-exhausted`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -121,7 +121,7 @@
 [[projects]]
   name = "github.com/fabric8-services/fabric8-tenant"
   packages = ["design"]
-  revision = "master"
+  revision = "6beeca9797d2176629220380c1ebd742086db4a7"
 
 [[projects]]
   name = "github.com/fatih/structs"
@@ -812,6 +812,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "843238741f4e88d78a8acaa703af920f93880a14b119627c75831c56a6e20393"
+  inputs-digest = "27ec3965c3cded24a72f3318b9e6fe4c0ed0076c03079543abba7cda3a1a19f4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -124,7 +124,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/fabric8-services/fabric8-tenant"
-  revision = "master"
+  revision = "6beeca9797d2176629220380c1ebd742086db4a7"
 
 [[constraint]]
   name = "github.com/jstemmer/go-junit-report"

--- a/controller/user_service.go
+++ b/controller/user_service.go
@@ -52,17 +52,18 @@ func convert(t *tenant.TenantSingle) *app.UserServiceSingle {
 	var ns []*app.NamespaceAttributes
 	for _, tn := range t.Data.Attributes.Namespaces {
 		ns = append(ns, &app.NamespaceAttributes{
-			CreatedAt:         tn.CreatedAt,
-			UpdatedAt:         tn.UpdatedAt,
-			Name:              tn.Name,
-			State:             tn.State,
-			Version:           tn.Version,
-			Type:              tn.Type,
-			ClusterURL:        tn.ClusterURL,
-			ClusterConsoleURL: tn.ClusterConsoleURL,
-			ClusterMetricsURL: tn.ClusterMetricsURL,
-			ClusterLoggingURL: tn.ClusterLoggingURL,
-			ClusterAppDomain:  tn.ClusterAppDomain,
+			CreatedAt:                tn.CreatedAt,
+			UpdatedAt:                tn.UpdatedAt,
+			Name:                     tn.Name,
+			State:                    tn.State,
+			Version:                  tn.Version,
+			Type:                     tn.Type,
+			ClusterURL:               tn.ClusterURL,
+			ClusterConsoleURL:        tn.ClusterConsoleURL,
+			ClusterMetricsURL:        tn.ClusterMetricsURL,
+			ClusterLoggingURL:        tn.ClusterLoggingURL,
+			ClusterAppDomain:         tn.ClusterAppDomain,
+			ClusterCapacityExhausted: tn.ClusterCapacityExhausted,
 		})
 	}
 	id := uuid.UUID(*t.Data.ID)

--- a/controller/user_service_test.go
+++ b/controller/user_service_test.go
@@ -1,0 +1,83 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fabric8-services/fabric8-wit/account/tenant"
+	"github.com/fabric8-services/fabric8-wit/app"
+	"github.com/fabric8-services/fabric8-wit/ptr"
+
+	goauuid "github.com/goadesign/goa/uuid"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	pts = ptr.String
+	ptb = ptr.Bool
+)
+
+func Test_convert(t *testing.T) {
+	nsTime := time.Now()
+	nsInput := []*tenant.NamespaceAttributes{
+		{
+			CreatedAt:                &nsTime,
+			UpdatedAt:                &nsTime,
+			Name:                     pts("foons"),
+			State:                    pts("created"),
+			Version:                  pts("1.0"),
+			Type:                     pts("che"),
+			ClusterURL:               pts("http://test.org"),
+			ClusterConsoleURL:        pts("https://console.example.com/console"),
+			ClusterMetricsURL:        pts("https://metrics.example.com"),
+			ClusterLoggingURL:        pts("https://console.example.com/console"),
+			ClusterAppDomain:         pts("apps.example.com"),
+			ClusterCapacityExhausted: ptb(true),
+		},
+	}
+
+	tenantID := goauuid.NewV4()
+	tenantCreated := time.Now()
+	tenantSingle := &tenant.TenantSingle{
+		Data: &tenant.Tenant{
+			ID: &tenantID,
+			Attributes: &tenant.TenantAttributes{
+				CreatedAt:  &tenantCreated,
+				Namespaces: nsInput,
+			},
+		},
+	}
+
+	nsOutput := []*app.NamespaceAttributes{
+		{
+			CreatedAt:                &nsTime,
+			UpdatedAt:                &nsTime,
+			Name:                     pts("foons"),
+			State:                    pts("created"),
+			Version:                  pts("1.0"),
+			Type:                     pts("che"),
+			ClusterURL:               pts("http://test.org"),
+			ClusterConsoleURL:        pts("https://console.example.com/console"),
+			ClusterMetricsURL:        pts("https://metrics.example.com"),
+			ClusterLoggingURL:        pts("https://console.example.com/console"),
+			ClusterAppDomain:         pts("apps.example.com"),
+			ClusterCapacityExhausted: ptb(true),
+		},
+	}
+	tenantIDConv, err := uuid.FromString(tenantID.String())
+	require.NoError(t, err)
+	expected := &app.UserServiceSingle{
+		Data: &app.UserService{
+			Attributes: &app.UserServiceAttributes{
+				CreatedAt:  &tenantCreated,
+				Namespaces: nsOutput,
+			},
+			ID:   &tenantIDConv,
+			Type: "userservices",
+		},
+	}
+
+	actual := convert(tenantSingle)
+	require.Equal(t, expected, actual)
+}

--- a/design/user_service.go
+++ b/design/user_service.go
@@ -52,6 +52,8 @@ var namespaceAttributes = a.Type("NamespaceAttributes", func() {
 	})
 	a.Attribute("cluster-app-domain", d.String, "The cluster app domain", func() {
 	})
+	a.Attribute("cluster-capacity-exhausted", d.Boolean, "Whether cluster hosting this namespace exhausted it's capacity", func() {
+	})
 	a.Attribute("type", d.String, "The tenant namespaces", func() {
 		a.Enum("che", "jenkins", "stage", "test", "run")
 	})


### PR DESCRIPTION
Now when calling `/user/services`, the namespaces information that is
returned by wit service will also include an attribute
`cluster-capacity-exhausted` which is a boolean which indicates if the
cluster this namespace is hosted on has exhausted it's resources or is
still capable of running more workloads.

This information can be used by OSIO services to make a decision whether
to spawn any new OSIO service in user namespace on that cluster.

Related to openshiftio/openshift.io#3320