### PR TITLE
fix codebase deletion return code check

### DIFF
--- a/controller/space.go
+++ b/controller/space.go
@@ -283,7 +283,7 @@ func deleteCodebases(
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if 200 < resp.StatusCode && resp.StatusCode >= 300 {
 		formattedErrors, err := cl.DecodeJSONAPIErrors(resp)
 		if err != nil {
 			return errors.NewInternalError(ctx,
@@ -307,7 +307,7 @@ func deleteCodebases(
 				errs.Wrapf(err, "could not delete codebase %s", cb.ID))
 			continue
 		}
-		if resp.StatusCode != http.StatusOK {
+		if 200 < resp.StatusCode && resp.StatusCode >= 300 {
 			formattedErrors, err := cl.DecodeJSONAPIErrors(resp)
 			if err != nil {
 				errorsList = append(errorsList,
@@ -358,7 +358,7 @@ func deleteOpenShiftResource(
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if 200 < resp.StatusCode && resp.StatusCode >= 300 {
 		formattedErrors, err := cl.DecodeJSONAPIErrors(resp)
 		if err != nil {
 			return errors.NewInternalError(ctx,
@@ -387,7 +387,7 @@ func deleteOpenShiftResource(
 					errs.Wrapf(err, "could not delete deployment for space=%s, app=%s, env=%s", spaceID, app.Attributes.Name, env.Attributes.Name))
 				continue
 			}
-			if resp.StatusCode != http.StatusOK {
+			if 200 < resp.StatusCode && resp.StatusCode >= 300 {
 				formattedErrors, err := cl.DecodeJSONAPIErrors(resp)
 				if err != nil {
 					errorsList = append(errorsList,

--- a/test/data/codebases/codebases_delete_space.ok.yaml
+++ b/test/data/codebases/codebases_delete_space.ok.yaml
@@ -94,11 +94,11 @@ interactions:
   response:
     # headers:
     status: 200 OK
-    code: 200
+    code: 204
 - request:
     url: http://core/api/codebases/aed02e9b-1b51-4fa8-98c9-06ef56a28c88
     method: DELETE
   response:
     # headers:
     status: 200 OK
-    code: 200
+    code: 204


### PR DESCRIPTION
Before when codebases were deleted we were only checking if the return
code is 200. But the codebase deletion API returns 204 or No content. So
this commit fixes that, by adding a check for all return code from 200
to 299.
