### PR TITLE
delete openshift resources before spaces

### DIFF
--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -437,6 +437,10 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		spaceID := fxt.Spaces[0].ID
 		identity := *fxt.Identities[0]
 
+		rDeployments, err := recorder.New("../test/data/deployments/deployments_delete_space.401")
+		require.NoError(t, err)
+		defer rDeployments.Stop()
+
 		rCodebase, err := recorder.New("../test/data/codebases/codebases_delete_space.401")
 		require.NoError(t, err)
 		defer rCodebase.Stop()
@@ -446,6 +450,7 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		}
 		svc, ctrl := s.SecuredControllerWithDummyResourceManager(
 			identity, r,
+			withDeploymentsClient(&http.Client{Transport: rDeployments.Transport}),
 			withCodebaseClient(&http.Client{Transport: rCodebase.Transport}),
 		)
 		test.DeleteSpaceUnauthorized(t, svc.Context, svc, ctrl, spaceID)
@@ -464,6 +469,10 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		spaceID := fxt.Spaces[0].ID
 		identity := *fxt.Identities[0]
 
+		rDeployments, err := recorder.New("../test/data/deployments/deployments_delete_space.403")
+		require.NoError(t, err)
+		defer rDeployments.Stop()
+
 		rCodebase, err := recorder.New("../test/data/codebases/codebases_delete_space.403")
 		require.NoError(t, err)
 		defer rCodebase.Stop()
@@ -473,6 +482,7 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		}
 		svc, ctrl := s.SecuredControllerWithDummyResourceManager(
 			identity, r,
+			withDeploymentsClient(&http.Client{Transport: rDeployments.Transport}),
 			withCodebaseClient(&http.Client{Transport: rCodebase.Transport}),
 		)
 		test.DeleteSpaceForbidden(t, svc.Context, svc, ctrl, spaceID)
@@ -491,6 +501,10 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		spaceID := fxt.Spaces[0].ID
 		identity := *fxt.Identities[0]
 
+		rDeployments, err := recorder.New("../test/data/deployments/deployments_delete_space.404")
+		require.NoError(t, err)
+		defer rDeployments.Stop()
+
 		rCodebase, err := recorder.New("../test/data/codebases/codebases_delete_space.404")
 		require.NoError(t, err)
 		defer rCodebase.Stop()
@@ -500,6 +514,7 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		}
 		svc, ctrl := s.SecuredControllerWithDummyResourceManager(
 			identity, r,
+			withDeploymentsClient(&http.Client{Transport: rDeployments.Transport}),
 			withCodebaseClient(&http.Client{Transport: rCodebase.Transport}),
 		)
 		test.DeleteSpaceNotFound(t, svc.Context, svc, ctrl, spaceID)
@@ -518,6 +533,10 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		spaceID := fxt.Spaces[0].ID
 		identity := *fxt.Identities[0]
 
+		rDeployments, err := recorder.New("../test/data/deployments/deployments_delete_space.500")
+		require.NoError(t, err)
+		defer rDeployments.Stop()
+
 		rCodebase, err := recorder.New("../test/data/codebases/codebases_delete_space.500")
 		require.NoError(t, err)
 		defer rCodebase.Stop()
@@ -527,6 +546,7 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		}
 		svc, ctrl := s.SecuredControllerWithDummyResourceManager(
 			identity, r,
+			withDeploymentsClient(&http.Client{Transport: rDeployments.Transport}),
 			withCodebaseClient(&http.Client{Transport: rCodebase.Transport}),
 		)
 		test.DeleteSpaceInternalServerError(t, svc.Context, svc, ctrl, spaceID)
@@ -545,12 +565,17 @@ func (s *SpaceControllerTestSuite) TestDeleteSpace() {
 		spaceID := fxt.Spaces[0].ID
 		identity := testsupport.TestIdentity
 
+		rDeployments, err := recorder.New("../test/data/deployments/deployments_delete_space.different-owner")
+		require.NoError(t, err)
+		defer rDeployments.Stop()
+
 		rCodebase, err := recorder.New("../test/data/codebases/codebases_delete_space.different-owner")
 		require.NoError(t, err)
 		defer rCodebase.Stop()
 
 		svc, ctrl := s.SecuredController(
 			identity,
+			withDeploymentsClient(&http.Client{Transport: rDeployments.Transport}),
 			withCodebaseClient(&http.Client{Transport: rCodebase.Transport}),
 		)
 		test.DeleteSpaceForbidden(t, svc.Context, svc, ctrl, spaceID)

--- a/test/data/deployments/deployments_delete_space.401.yaml
+++ b/test/data/deployments/deployments_delete_space.401.yaml
@@ -1,0 +1,166 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: http://core/api/deployments/spaces/ebd40c77-2fba-4cf6-a9bb-08b25a87e5e3
+    method: GET
+  response:
+    body: '{
+  "data": {
+    "attributes": {
+      "applications": [
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace1"
+          },
+          "id": "testspace1",
+          "type": "application"
+        },
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace2"
+          },
+          "id": "testspace2",
+          "type": "application"
+        }
+      ],
+      "name": "testspace"
+    },
+    "id": "ebd40c77-2fba-4cf6-a9bb-08b25a87e5e3",
+    "type": "space"
+  }
+}'
+    # headers:
+
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/ebd40c77-2fba-4cf6-a9bb-08b25a87e5e3/applications/testspace1/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/ebd40c77-2fba-4cf6-a9bb-08b25a87e5e3/applications/testspace1/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/ebd40c77-2fba-4cf6-a9bb-08b25a87e5e3/applications/testspace2/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/ebd40c77-2fba-4cf6-a9bb-08b25a87e5e3/applications/testspace2/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200

--- a/test/data/deployments/deployments_delete_space.403.yaml
+++ b/test/data/deployments/deployments_delete_space.403.yaml
@@ -1,0 +1,166 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: http://core/api/deployments/spaces/49f0871e-d011-48ba-ad9c-74ee4001d2d6
+    method: GET
+  response:
+    body: '{
+  "data": {
+    "attributes": {
+      "applications": [
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace1"
+          },
+          "id": "testspace1",
+          "type": "application"
+        },
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace2"
+          },
+          "id": "testspace2",
+          "type": "application"
+        }
+      ],
+      "name": "testspace"
+    },
+    "id": "49f0871e-d011-48ba-ad9c-74ee4001d2d6",
+    "type": "space"
+  }
+}'
+    # headers:
+
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/49f0871e-d011-48ba-ad9c-74ee4001d2d6/applications/testspace1/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/49f0871e-d011-48ba-ad9c-74ee4001d2d6/applications/testspace1/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/49f0871e-d011-48ba-ad9c-74ee4001d2d6/applications/testspace2/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/49f0871e-d011-48ba-ad9c-74ee4001d2d6/applications/testspace2/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200

--- a/test/data/deployments/deployments_delete_space.404.yaml
+++ b/test/data/deployments/deployments_delete_space.404.yaml
@@ -1,0 +1,166 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: http://core/api/deployments/spaces/a550edb8-20df-417c-aae8-30b6afd3dfd3
+    method: GET
+  response:
+    body: '{
+  "data": {
+    "attributes": {
+      "applications": [
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace1"
+          },
+          "id": "testspace1",
+          "type": "application"
+        },
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace2"
+          },
+          "id": "testspace2",
+          "type": "application"
+        }
+      ],
+      "name": "testspace"
+    },
+    "id": "a550edb8-20df-417c-aae8-30b6afd3dfd3",
+    "type": "space"
+  }
+}'
+    # headers:
+
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/a550edb8-20df-417c-aae8-30b6afd3dfd3/applications/testspace1/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/a550edb8-20df-417c-aae8-30b6afd3dfd3/applications/testspace1/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/a550edb8-20df-417c-aae8-30b6afd3dfd3/applications/testspace2/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/a550edb8-20df-417c-aae8-30b6afd3dfd3/applications/testspace2/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200

--- a/test/data/deployments/deployments_delete_space.500.yaml
+++ b/test/data/deployments/deployments_delete_space.500.yaml
@@ -1,0 +1,166 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: http://core/api/deployments/spaces/634f997f-22d5-457b-9e27-cd2d148bee30
+    method: GET
+  response:
+    body: '{
+  "data": {
+    "attributes": {
+      "applications": [
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace1"
+          },
+          "id": "testspace1",
+          "type": "application"
+        },
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace2"
+          },
+          "id": "testspace2",
+          "type": "application"
+        }
+      ],
+      "name": "testspace"
+    },
+    "id": "634f997f-22d5-457b-9e27-cd2d148bee30",
+    "type": "space"
+  }
+}'
+    # headers:
+
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/634f997f-22d5-457b-9e27-cd2d148bee30/applications/testspace1/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/634f997f-22d5-457b-9e27-cd2d148bee30/applications/testspace1/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/634f997f-22d5-457b-9e27-cd2d148bee30/applications/testspace2/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/634f997f-22d5-457b-9e27-cd2d148bee30/applications/testspace2/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200

--- a/test/data/deployments/deployments_delete_space.different-owner.yaml
+++ b/test/data/deployments/deployments_delete_space.different-owner.yaml
@@ -1,0 +1,166 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: http://core/api/deployments/spaces/688cab16-ba0b-4d48-8587-f187ebc0d9ff
+    method: GET
+  response:
+    body: '{
+  "data": {
+    "attributes": {
+      "applications": [
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace1"
+          },
+          "id": "testspace1",
+          "type": "application"
+        },
+        {
+          "attributes": {
+            "deployments": [
+              {
+                "attributes": {
+                  "name": "stage",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "stage",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              },
+              {
+                "attributes": {
+                  "name": "run",
+                  "pod_total": 1,
+                  "pods": [
+                    [
+                      "Running",
+                      "1"
+                    ]
+                  ],
+                  "pods_quota": {
+                    "cpucores": 1,
+                    "memory": 536870912
+                  },
+                  "version": "1.0.1"
+                },
+                "id": "run",
+                "links": {
+                  "application": "",
+                  "console": "",
+                  "logs": ""
+                },
+                "type": "deployment"
+              }
+            ],
+            "name": "testspace2"
+          },
+          "id": "testspace2",
+          "type": "application"
+        }
+      ],
+      "name": "testspace"
+    },
+    "id": "688cab16-ba0b-4d48-8587-f187ebc0d9ff",
+    "type": "space"
+  }
+}'
+    # headers:
+
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/688cab16-ba0b-4d48-8587-f187ebc0d9ff/applications/testspace1/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/688cab16-ba0b-4d48-8587-f187ebc0d9ff/applications/testspace1/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/688cab16-ba0b-4d48-8587-f187ebc0d9ff/applications/testspace2/deployments/stage
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200
+- request:
+    url: http://core/api/deployments/spaces/688cab16-ba0b-4d48-8587-f187ebc0d9ff/applications/testspace2/deployments/run
+    method: DELETE
+  response:
+    # headers:
+    status: 200 OK
+    code: 200


### PR DESCRIPTION
The order of deletion of spaces is changed to look like following:
```    
del-space/
├── 00-list-codebases
├── 01-delete-each-codebase
├── 02-delete-all-openshift-resources
└── 03-delete-space-from-db
```