### PR TITLE
fix panic when deleting an OpenShift resource failed

### DIFF
--- a/controller/space.go
+++ b/controller/space.go
@@ -226,7 +226,7 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 			"error":    err,
 		}, "could not delete OpenShift resources")
 		return jsonapi.JSONErrorResponse(
-			ctx, errors.NewInternalError(ctx, spaceDeletionErrorExternal))
+			ctx, errors.NewInternalError(ctx, err))
 	}
 
 	err = application.Transactional(c.db, func(appl application.Application) error {

--- a/controller/space.go
+++ b/controller/space.go
@@ -289,7 +289,10 @@ func deleteCodebases(
 			return errors.NewInternalError(ctx,
 				fmt.Errorf("could not decode JSON formatted errors returned while listing codebases: %v", err))
 		}
-		return errors.NewInternalError(ctx, formattedErrors.Validate())
+		if len(formattedErrors.Errors) > 0 {
+			return errors.NewInternalError(ctx, errs.Errorf(formattedErrors.Errors[0].Detail))
+		}
+		return errors.NewInternalError(ctx, errs.Errorf("unknown error"))
 	}
 	codebases, err := cl.DecodeCodebaseList(resp)
 	if err != nil {
@@ -314,7 +317,9 @@ func deleteCodebases(
 					errs.Wrapf(err, "could not decode JSON formatted errors returned while deleting codebase %s", cb.ID))
 				continue
 			}
-			errorsList = append(errorsList, formattedErrors.Validate())
+			if len(formattedErrors.Errors) > 0 {
+				errorsList = append(errorsList, errs.Errorf(formattedErrors.Errors[0].Detail))
+			}
 		}
 	}
 	if len(errorsList) != 0 {
@@ -404,7 +409,9 @@ func deleteOpenShiftResource(
 						errs.Wrapf(err, "could not decode JSON formatted errors returned while deleting deployment for space=%s, app=%s, env=%s", spaceID, app.Attributes.Name, env.Attributes.Name))
 					continue
 				}
-				errorsList = append(errorsList, formattedErrors.Validate())
+				if len(formattedErrors.Errors) > 0 {
+					errorsList = append(errorsList, errs.Errorf(formattedErrors.Errors[0].Detail))
+				}
 			}
 		}
 	}

--- a/test/data/deployments/deployments_delete_space.404.space_not_found.yaml
+++ b/test/data/deployments/deployments_delete_space.404.space_not_found.yaml
@@ -1,0 +1,21 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    url: http://core/api/deployments/spaces/aec5f659-0680-4633-8599-5f14f1deeabc
+    method: GET
+  response:
+    status: 404 Not Found
+    code: 404
+    body: '{
+      "errors": [ 
+        {
+          "code":"not_found",
+          "detail":"osio space with id aec5f659-0680-4633-8599-5f14f1deeabc not found",
+          "status":"404",
+          "title":"Not found error"
+        }
+      ]
+    }'


### PR DESCRIPTION
instead of validating the JSON-API errors, we just retrieve the first error (assuming there's only one) and return an InternalError using the error's detail

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>