### PR TITLE
WIP: Ensure we have at least a printed stack trace when application.Transaction recovers

### DIFF
--- a/application/transaction.go
+++ b/application/transaction.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"runtime/debug"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/log"
@@ -35,7 +36,7 @@ func Transactional(db DB, todo func(f Application) error) error {
 		go func(tx Transaction) {
 			defer func() {
 				if err := recover(); err != nil {
-					errorChan <- errors.Errorf("recovered %v", err)
+					errorChan <- errors.Errorf("recovered %v. stack: %s", err, debug.Stack())
 				}
 			}()
 			errorChan <- todo(tx)


### PR DESCRIPTION
See #2093

This PR only adds the stack trace to the error text. Maybe we can also augment the error with a real stack trace.

