### PR TITLE
Add Kubernetes events watcher websocket endpoint

### DIFF
--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -20,6 +19,8 @@ import (
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/websocket"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -437,7 +438,6 @@ func (c *DeploymentsController) WatchEnvironmentEventsWSHandler(ctx *app.WatchEn
 			for {
 				var m string
 				err := websocket.Message.Receive(ws, &m)
-				fmt.Println("Server Recieved", m)
 				if err != nil {
 					if err != io.EOF {
 						log.Error(ctx, map[string]interface{}{
@@ -454,6 +454,13 @@ func (c *DeploymentsController) WatchEnvironmentEventsWSHandler(ctx *app.WatchEn
 			item, err := store.Pop(cache.PopProcessFunc(func(item interface{}) error {
 				return nil
 			}))
+
+			event, ok := item.(*v1.Event)
+			if !ok {
+				sendWebsocketJSON(ctx, ws, map[string]interface{}{"error": "Kubernetes event was an unexpected type"})
+				return
+			}
+
 			if err != nil {
 				if err != cache.FIFOClosedError {
 					log.Error(ctx, map[string]interface{}{
@@ -464,15 +471,69 @@ func (c *DeploymentsController) WatchEnvironmentEventsWSHandler(ctx *app.WatchEn
 				}
 				return
 			}
-			err = websocket.JSON.Send(ws, item)
+
+			eventItem := transformItem(event)
 			if err != nil {
-				log.Error(ctx, map[string]interface{}{
-					"err": err,
-				}, "error sending events")
-				return
+				sendWebsocketJSON(ctx, ws, map[string]interface{}{"error": "unable to parse Kubernetes event"})
+			} else {
+				err = websocket.JSON.Send(ws, eventItem)
+				if err != nil {
+					log.Error(ctx, map[string]interface{}{
+						"err": err,
+					}, "error sending events")
+					return
+				}
 			}
 		}
 	}
+}
+
+//DeploymentsEvent is the transformed Kubernetes v1.Event item
+type DeploymentsEvent struct {
+	// The object that this event is about.
+	InvolvedObject v1.ObjectReference `json:"involvedObject" protobuf:"bytes,2,opt,name=involvedObject"`
+
+	// This should be a short, machine understandable string that gives the reason
+	// for the transition into the object's current status.
+	// TODO: provide exact specification for format.
+	// +optional
+	Reason string `json:"reason,omitempty" protobuf:"bytes,3,opt,name=reason"`
+
+	// A human-readable description of the status of this operation.
+	// TODO: decide on maximum length.
+	// +optional
+	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
+
+	// The number of times this event has occurred.
+	// +optional
+	Count int32 `json:"count,omitempty" protobuf:"varint,8,opt,name=count"`
+
+	// Type of this event (Normal, Warning), new types could be added in the future
+	// +optional
+	Type string `json:"type,omitempty" protobuf:"bytes,9,opt,name=type"`
+
+	// CreationTimestamp is a timestamp representing the server time when this object was
+	// created. It is not guaranteed to be set in happens-before order across separate operations.
+	// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+	//
+	// Populated by the system.
+	// Read-only.
+	// Null for lists.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// +optional
+	CreationTimestamp metaV1.Time `json:"creationTimestamp,omitempty" protobuf:"bytes,8,opt,name=creationTimestamp"`
+}
+
+func transformItem(event *v1.Event) *DeploymentsEvent {
+	transformedItem := &DeploymentsEvent{
+		InvolvedObject:    event.InvolvedObject,
+		Reason:            event.Reason,
+		Message:           event.Message,
+		Count:             event.Count,
+		Type:              event.Type,
+		CreationTimestamp: event.ObjectMeta.CreationTimestamp,
+	}
+	return transformedItem
 }
 
 func sendWebsocketJSON(ctx *app.WatchEnvironmentEventsDeploymentsContext, ws *websocket.Conn, item interface{}) {

--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -436,6 +437,7 @@ func (c *DeploymentsController) WatchEnvironmentEventsWSHandler(ctx *app.WatchEn
 			for {
 				var m string
 				err := websocket.Message.Receive(ws, &m)
+				fmt.Println("Server Recieved", m)
 				if err != nil {
 					if err != io.EOF {
 						log.Error(ctx, map[string]interface{}{

--- a/controller/deployments_blackbox_test.go
+++ b/controller/deployments_blackbox_test.go
@@ -70,6 +70,10 @@ type deleteTestResults struct {
 	envName   string
 }
 
+type testWatchItem struct {
+	name string
+}
+
 func (c *testKubeClient) DeleteDeployment(spaceName string, appName string, envName string) error {
 	c.deleteResults = &deleteTestResults{
 		spaceName: spaceName,
@@ -538,7 +542,6 @@ func TestShowSpaceEnvironments(t *testing.T) {
 		test.ShowSpaceEnvironmentsDeploymentsOK(t, context.Background(), svc, ctrl, space.SystemSpace)
 		// then verify that the Close method was called
 		assert.Equal(t, uint64(1), kubeClientMock.CloseCounter)
-
 	})
 
 	t.Run("failure", func(t *testing.T) {
@@ -572,7 +575,6 @@ func TestShowSpaceEnvironments(t *testing.T) {
 			assert.Equal(t, uint64(1), kubeClientMock.CloseCounter)
 		})
 	})
-
 }
 
 func TestShowAllEnvironments(t *testing.T) {
@@ -666,3 +668,42 @@ func createOSIOClientMock(t minimock.Tester, spaceName string) *testcontroller.O
 	}
 	return osioClientMock
 }
+
+// func TestWatchEnvironmentEvents(t *testing.T) {
+// 	// given
+// 	clientGetterMock := testcontroller.NewClientGetterMock(t)
+// 	svc, ctrl, err := createDeploymentsController()
+// 	require.NoError(t, err)
+// 	ctrl.ClientGetter = clientGetterMock
+
+// 	t.Run("ok", func(t *testing.T) {
+// 		// given
+// 		mockKeyFunc := func(obj interface{}) (string, error) {
+// 			if v, ok := obj.(testWatchItem); ok {
+// 				return v.name, nil
+// 			}
+// 			return "default", nil
+// 		}
+
+// 		kubeClientMock := testk8s.NewKubeClientMock(t)
+// 		kubeClientMock.WatchEventsInNamespaceFunc = func(p string) (r *cache.FIFO, r1 chan struct{}) {
+// 			store := cache.NewFIFO(mockKeyFunc)
+// 			store.Add(testWatchItem{name: "one"})
+
+// 			return store, nil
+// 		}
+// 		kubeClientMock.CloseFunc = func() {}
+// 		clientGetterMock.GetKubeClientFunc = func(p context.Context) (kubernetes.KubeClientInterface, error) {
+// 			return kubeClientMock, nil
+// 		}
+// 		osioClientMock := testcontroller.NewOSIOClientMock(t)
+// 		clientGetterMock.GetAndCheckOSIOClientFunc = func(p context.Context) (controller.OpenshiftIOClient, error) {
+// 			return osioClientMock, nil
+// 		}
+
+// 		// when
+// 		test.ShowSpaceEnvironmentsDeploymentsOK(t, context.Background(), svc, ctrl, space.SystemSpace)
+// 		// then verify that the Close method was called
+// 		assert.Equal(t, uint64(1), kubeClientMock.CloseCounter)
+// 	})
+// }

--- a/controller/deployments_blackbox_test.go
+++ b/controller/deployments_blackbox_test.go
@@ -743,7 +743,7 @@ func TestWatchEnvironmentEvents(t *testing.T) {
 			return osioClientMock, nil
 		}
 
-		conn := WatchEnvironmentEventsDeploymentsOK(t, context.Background(), svc, ctrl, space.SystemSpace)
+		conn := WatchEnvironmentEventsDeploymentsOK(context.Background(), t, svc, ctrl, space.SystemSpace)
 
 		var buf []byte
 		for _, item := range testItems {
@@ -795,7 +795,7 @@ func (r *wsRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return r.server, rw, nil
 }
 
-func WatchEnvironmentEventsDeploymentsOK(t *testing.T, ctx context.Context, service *goa.Service, ctrl app.DeploymentsController, spaceID uuid.UUID) net.Conn {
+func WatchEnvironmentEventsDeploymentsOK(ctx context.Context, t *testing.T, service *goa.Service, ctrl app.DeploymentsController, spaceID uuid.UUID) net.Conn {
 	var (
 		logBuf     bytes.Buffer
 		respSetter goatest.ResponseSetterFunc = func(r interface{}) {}

--- a/design/api.go
+++ b/design/api.go
@@ -49,6 +49,12 @@ var _ = a.API("wit", func() {
 		a.Header("Authorization")
 	})
 
+	a.JWTSecurity("jwt-query-param", func() {
+		a.Description("JWT Token Query Parameter Auth")
+		a.TokenURL("/api/login/authorize")
+		a.Query("access_token")
+	})
+
 	a.ResponseTemplate(d.OK, func() {
 		a.Description("Resource created")
 		a.Status(200)

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -294,6 +294,7 @@ var _ = a.Resource("deployments", func() {
 	})
 
 	a.Action("watchEnvironmentEvents", func() {
+		a.Security("jwt-query-param")
 		a.Routing(
 			a.GET("/environments/:envName/events/watch"),
 		)

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -292,4 +292,17 @@ var _ = a.Resource("deployments", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 	})
+
+	a.Action("watchEnvironmentEvents", func() {
+		a.Routing(
+			a.GET("/environments/:envName/events/watch"),
+		)
+		a.Params(func() {
+			a.Param("envName", d.String, "Name of the environment")
+		})
+		a.Description("watch events for an environment")
+		a.Scheme("wss")
+		a.Response(d.SwitchingProtocols)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
 })

--- a/goamiddleware/jwt_middleware.go
+++ b/goamiddleware/jwt_middleware.go
@@ -1,0 +1,284 @@
+package goamiddleware
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"context"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/goadesign/goa"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+)
+
+// New returns a middleware to be used with the JWTSecurity DSL definitions of goa.  It supports the
+// scopes claim in the JWT and ensures goa-defined Security DSLs are properly validated.
+//
+// The steps taken by the middleware are:
+//
+//     1. Extract the "Bearer" token from the Authorization header or query parameter
+//     2. Validate the "Bearer" token against the key(s)
+//        given to New
+//     3. If scopes are defined in the design for the action, validate them
+//        against the scopes presented by the JWT in the claim "scope", or if
+//        that's not defined, "scopes".
+//
+// The `exp` (expiration) and `nbf` (not before) date checks are validated by the JWT library.
+//
+// validationKeys can be one of these:
+//
+//     * a string (for HMAC)
+//     * a []byte (for HMAC)
+//     * an rsa.PublicKey
+//     * an ecdsa.PublicKey
+//     * a slice of any of the above
+//
+// The type of the keys determine the algorithm that will be used to do the check.  The goal of
+// having lists of keys is to allow for key rotation, still check the previous keys until rotation
+// has been completed.
+//
+// You can define an optional function to do additional validations on the token once the signature
+// and the claims requirements are proven to be valid.  Example:
+//
+//    validationHandler, _ := goa.NewMiddleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+//        token := jwt.ContextJWT(ctx)
+//        if val, ok := token.Claims["is_uncle"].(string); !ok || val != "ben" {
+//            return jwt.ErrJWTError("you are not uncle ben's")
+//        }
+//    })
+//
+// Mount the middleware with the generated UseXX function where XX is the name of the scheme as
+// defined in the design, e.g.:
+//
+//    app.UseJWT(jwt.New("secret", validationHandler, app.NewJWTSecurity()))
+//
+func New(validationKeys interface{}, validationFunc goa.Middleware, scheme *goa.JWTSecurity) goa.Middleware {
+	var rsaKeys []*rsa.PublicKey
+	var hmacKeys [][]byte
+
+	rsaKeys, ecdsaKeys, hmacKeys := partitionKeys(validationKeys)
+
+	return func(nextHandler goa.Handler) goa.Handler {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			var (
+				incomingToken string
+				err           error
+			)
+
+			if scheme.In == goa.LocHeader {
+				if incomingToken, err = extractTokenFromHeader(scheme.Name, req); err != nil {
+					return err
+				}
+			} else if scheme.In == goa.LocQuery {
+				if incomingToken, err = extractTokenFromQueryParam(scheme.Name, req); err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("whoops, security scheme with location (in) %q not supported", scheme.In)
+			}
+
+			var (
+				token     *jwt.Token
+				validated = false
+			)
+
+			if len(rsaKeys) > 0 {
+				token, err = validateRSAKeys(rsaKeys, "RS", incomingToken)
+				validated = err == nil
+			}
+
+			if !validated && len(ecdsaKeys) > 0 {
+				token, err = validateECDSAKeys(ecdsaKeys, "ES", incomingToken)
+				validated = err == nil
+			}
+
+			if !validated && len(hmacKeys) > 0 {
+				token, err = validateHMACKeys(hmacKeys, "HS", incomingToken)
+				//validated = err == nil
+			}
+
+			if err != nil {
+				return ErrJWTError(fmt.Sprintf("JWT validation failed: %s", err))
+			}
+
+			scopesInClaim, scopesInClaimList, err := parseClaimScopes(token)
+			if err != nil {
+				goa.LogError(ctx, err.Error())
+				return ErrJWTError(err)
+			}
+
+			requiredScopes := goa.ContextRequiredScopes(ctx)
+
+			for _, scope := range requiredScopes {
+				if !scopesInClaim[scope] {
+					msg := "authorization failed: required 'scope' or 'scopes' not present in JWT claim"
+					return ErrJWTError(msg, "required", requiredScopes, "scopes", scopesInClaimList)
+				}
+			}
+
+			ctx = goajwt.WithJWT(ctx, token)
+			if validationFunc != nil {
+				nextHandler = validationFunc(nextHandler)
+			}
+			return nextHandler(ctx, rw, req)
+		}
+	}
+}
+
+func extractTokenFromHeader(schemeName string, req *http.Request) (string, error) {
+	val := req.Header.Get(schemeName)
+	if val == "" {
+		return "", ErrJWTError(fmt.Sprintf("missing header %q", schemeName))
+	}
+
+	if !strings.HasPrefix(strings.ToLower(val), "bearer ") {
+		return "", ErrJWTError(fmt.Sprintf("invalid or malformed %q header, expected 'Bearer JWT-token...'", val))
+	}
+
+	incomingToken := strings.Split(val, " ")[1]
+
+	return incomingToken, nil
+}
+
+func extractTokenFromQueryParam(schemeName string, req *http.Request) (string, error) {
+	incomingToken := req.URL.Query().Get(schemeName)
+	if incomingToken == "" {
+		return "", ErrJWTError(fmt.Sprintf("missing parameter %q", schemeName))
+	}
+
+	return incomingToken, nil
+}
+
+// validScopeClaimKeys are the claims under which scopes may be found in a token
+var validScopeClaimKeys = []string{"scope", "scopes"}
+
+// parseClaimScopes parses the "scope" or "scopes" parameter in the Claims. It
+// supports two formats:
+//
+// * a list of strings
+//
+// * a single string with space-separated scopes (akin to OAuth2's "scope").
+//
+// An empty string is an explicit claim of no scopes.
+func parseClaimScopes(token *jwt.Token) (map[string]bool, []string, error) {
+	scopesInClaim := make(map[string]bool)
+	var scopesInClaimList []string
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, nil, fmt.Errorf("unsupport claims shape")
+	}
+	for _, k := range validScopeClaimKeys {
+		if rawscopes, ok := claims[k]; ok && rawscopes != nil {
+			switch scopes := rawscopes.(type) {
+			case string:
+				for _, scope := range strings.Split(scopes, " ") {
+					scopesInClaim[scope] = true
+					scopesInClaimList = append(scopesInClaimList, scope)
+				}
+			case []interface{}:
+				for _, scope := range scopes {
+					if val, ok := scope.(string); ok {
+						scopesInClaim[val] = true
+						scopesInClaimList = append(scopesInClaimList, val)
+					}
+				}
+			default:
+				return nil, nil, fmt.Errorf("unsupported scope format in incoming JWT claim, was type %T", scopes)
+			}
+			break
+		}
+	}
+	sort.Strings(scopesInClaimList)
+	return scopesInClaim, scopesInClaimList, nil
+}
+
+// ErrJWTError is the error returned by this middleware when any sort of validation or assertion
+// fails during processing.
+var ErrJWTError = goa.NewErrorClass("jwt_security_error", 401)
+
+type contextKey int
+
+const (
+	jwtKey contextKey = iota + 1
+)
+
+// partitionKeys sorts keys by their type.
+func partitionKeys(k interface{}) ([]*rsa.PublicKey, []*ecdsa.PublicKey, [][]byte) {
+	var (
+		rsaKeys   []*rsa.PublicKey
+		ecdsaKeys []*ecdsa.PublicKey
+		hmacKeys  [][]byte
+	)
+
+	switch typed := k.(type) {
+	case []byte:
+		hmacKeys = append(hmacKeys, typed)
+	case [][]byte:
+		hmacKeys = typed
+	case string:
+		hmacKeys = append(hmacKeys, []byte(typed))
+	case []string:
+		for _, s := range typed {
+			hmacKeys = append(hmacKeys, []byte(s))
+		}
+	case *rsa.PublicKey:
+		rsaKeys = append(rsaKeys, typed)
+	case []*rsa.PublicKey:
+		rsaKeys = typed
+	case *ecdsa.PublicKey:
+		ecdsaKeys = append(ecdsaKeys, typed)
+	case []*ecdsa.PublicKey:
+		ecdsaKeys = typed
+	}
+
+	return rsaKeys, ecdsaKeys, hmacKeys
+}
+
+func validateRSAKeys(rsaKeys []*rsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
+	for _, pubkey := range rsaKeys {
+		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
+			if !strings.HasPrefix(token.Method.Alg(), algo) {
+				return nil, ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
+			}
+			return pubkey, nil
+		})
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+func validateECDSAKeys(ecdsaKeys []*ecdsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
+	for _, pubkey := range ecdsaKeys {
+		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
+			if !strings.HasPrefix(token.Method.Alg(), algo) {
+				return nil, ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
+			}
+			return pubkey, nil
+		})
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+func validateHMACKeys(hmacKeys [][]byte, algo, incomingToken string) (token *jwt.Token, err error) {
+	for _, key := range hmacKeys {
+		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
+			if !strings.HasPrefix(token.Method.Alg(), algo) {
+				return nil, ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
+			}
+			return key, nil
+		})
+		if err == nil {
+			return
+		}
+	}
+	return
+}

--- a/goamiddleware/jwt_middleware.go
+++ b/goamiddleware/jwt_middleware.go
@@ -1,12 +1,31 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2015 Raphael Simon and goa Contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package goamiddleware
 
 import (
-	"crypto/ecdsa"
 	"crypto/rsa"
 	"fmt"
 	"net/http"
-	"sort"
-	"strings"
 
 	"context"
 
@@ -102,13 +121,13 @@ func New(validationKeys interface{}, validationFunc goa.Middleware, scheme *goa.
 			}
 
 			if err != nil {
-				return ErrJWTError(fmt.Sprintf("JWT validation failed: %s", err))
+				return goajwt.ErrJWTError(fmt.Sprintf("JWT validation failed: %s", err))
 			}
 
 			scopesInClaim, scopesInClaimList, err := parseClaimScopes(token)
 			if err != nil {
 				goa.LogError(ctx, err.Error())
-				return ErrJWTError(err)
+				return goajwt.ErrJWTError(err)
 			}
 
 			requiredScopes := goa.ContextRequiredScopes(ctx)
@@ -116,7 +135,7 @@ func New(validationKeys interface{}, validationFunc goa.Middleware, scheme *goa.
 			for _, scope := range requiredScopes {
 				if !scopesInClaim[scope] {
 					msg := "authorization failed: required 'scope' or 'scopes' not present in JWT claim"
-					return ErrJWTError(msg, "required", requiredScopes, "scopes", scopesInClaimList)
+					return goajwt.ErrJWTError(msg, "required", requiredScopes, "scopes", scopesInClaimList)
 				}
 			}
 
@@ -127,158 +146,4 @@ func New(validationKeys interface{}, validationFunc goa.Middleware, scheme *goa.
 			return nextHandler(ctx, rw, req)
 		}
 	}
-}
-
-func extractTokenFromHeader(schemeName string, req *http.Request) (string, error) {
-	val := req.Header.Get(schemeName)
-	if val == "" {
-		return "", ErrJWTError(fmt.Sprintf("missing header %q", schemeName))
-	}
-
-	if !strings.HasPrefix(strings.ToLower(val), "bearer ") {
-		return "", ErrJWTError(fmt.Sprintf("invalid or malformed %q header, expected 'Bearer JWT-token...'", val))
-	}
-
-	incomingToken := strings.Split(val, " ")[1]
-
-	return incomingToken, nil
-}
-
-func extractTokenFromQueryParam(schemeName string, req *http.Request) (string, error) {
-	incomingToken := req.URL.Query().Get(schemeName)
-	if incomingToken == "" {
-		return "", ErrJWTError(fmt.Sprintf("missing parameter %q", schemeName))
-	}
-
-	return incomingToken, nil
-}
-
-// validScopeClaimKeys are the claims under which scopes may be found in a token
-var validScopeClaimKeys = []string{"scope", "scopes"}
-
-// parseClaimScopes parses the "scope" or "scopes" parameter in the Claims. It
-// supports two formats:
-//
-// * a list of strings
-//
-// * a single string with space-separated scopes (akin to OAuth2's "scope").
-//
-// An empty string is an explicit claim of no scopes.
-func parseClaimScopes(token *jwt.Token) (map[string]bool, []string, error) {
-	scopesInClaim := make(map[string]bool)
-	var scopesInClaimList []string
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, nil, fmt.Errorf("unsupport claims shape")
-	}
-	for _, k := range validScopeClaimKeys {
-		if rawscopes, ok := claims[k]; ok && rawscopes != nil {
-			switch scopes := rawscopes.(type) {
-			case string:
-				for _, scope := range strings.Split(scopes, " ") {
-					scopesInClaim[scope] = true
-					scopesInClaimList = append(scopesInClaimList, scope)
-				}
-			case []interface{}:
-				for _, scope := range scopes {
-					if val, ok := scope.(string); ok {
-						scopesInClaim[val] = true
-						scopesInClaimList = append(scopesInClaimList, val)
-					}
-				}
-			default:
-				return nil, nil, fmt.Errorf("unsupported scope format in incoming JWT claim, was type %T", scopes)
-			}
-			break
-		}
-	}
-	sort.Strings(scopesInClaimList)
-	return scopesInClaim, scopesInClaimList, nil
-}
-
-// ErrJWTError is the error returned by this middleware when any sort of validation or assertion
-// fails during processing.
-var ErrJWTError = goa.NewErrorClass("jwt_security_error", 401)
-
-type contextKey int
-
-const (
-	jwtKey contextKey = iota + 1
-)
-
-// partitionKeys sorts keys by their type.
-func partitionKeys(k interface{}) ([]*rsa.PublicKey, []*ecdsa.PublicKey, [][]byte) {
-	var (
-		rsaKeys   []*rsa.PublicKey
-		ecdsaKeys []*ecdsa.PublicKey
-		hmacKeys  [][]byte
-	)
-
-	switch typed := k.(type) {
-	case []byte:
-		hmacKeys = append(hmacKeys, typed)
-	case [][]byte:
-		hmacKeys = typed
-	case string:
-		hmacKeys = append(hmacKeys, []byte(typed))
-	case []string:
-		for _, s := range typed {
-			hmacKeys = append(hmacKeys, []byte(s))
-		}
-	case *rsa.PublicKey:
-		rsaKeys = append(rsaKeys, typed)
-	case []*rsa.PublicKey:
-		rsaKeys = typed
-	case *ecdsa.PublicKey:
-		ecdsaKeys = append(ecdsaKeys, typed)
-	case []*ecdsa.PublicKey:
-		ecdsaKeys = typed
-	}
-
-	return rsaKeys, ecdsaKeys, hmacKeys
-}
-
-func validateRSAKeys(rsaKeys []*rsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, pubkey := range rsaKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
-			}
-			return pubkey, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func validateECDSAKeys(ecdsaKeys []*ecdsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, pubkey := range ecdsaKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
-			}
-			return pubkey, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func validateHMACKeys(hmacKeys [][]byte, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, key := range hmacKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
-			}
-			return key, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
 }

--- a/goamiddleware/jwt_shared.go
+++ b/goamiddleware/jwt_shared.go
@@ -1,0 +1,179 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2015 Raphael Simon and goa Contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goamiddleware
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+)
+
+func extractTokenFromHeader(schemeName string, req *http.Request) (string, error) {
+	val := req.Header.Get(schemeName)
+	if val == "" {
+		return "", goajwt.ErrJWTError(fmt.Sprintf("missing header %q", schemeName))
+	}
+
+	if !strings.HasPrefix(strings.ToLower(val), "bearer ") {
+		return "", goajwt.ErrJWTError(fmt.Sprintf("invalid or malformed %q header, expected 'Bearer JWT-token...'", val))
+	}
+
+	incomingToken := strings.Split(val, " ")[1]
+
+	return incomingToken, nil
+}
+
+func extractTokenFromQueryParam(schemeName string, req *http.Request) (string, error) {
+	incomingToken := req.URL.Query().Get(schemeName)
+	if incomingToken == "" {
+		return "", goajwt.ErrJWTError(fmt.Sprintf("missing parameter %q", schemeName))
+	}
+
+	return incomingToken, nil
+}
+
+// validScopeClaimKeys are the claims under which scopes may be found in a token
+var validScopeClaimKeys = []string{"scope", "scopes"}
+
+// parseClaimScopes parses the "scope" or "scopes" parameter in the Claims. It
+// supports two formats:
+//
+// * a list of strings
+//
+// * a single string with space-separated scopes (akin to OAuth2's "scope").
+//
+// An empty string is an explicit claim of no scopes.
+func parseClaimScopes(token *jwt.Token) (map[string]bool, []string, error) {
+	scopesInClaim := make(map[string]bool)
+	var scopesInClaimList []string
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, nil, fmt.Errorf("unsupport claims shape")
+	}
+	for _, k := range validScopeClaimKeys {
+		if rawscopes, ok := claims[k]; ok && rawscopes != nil {
+			switch scopes := rawscopes.(type) {
+			case string:
+				for _, scope := range strings.Split(scopes, " ") {
+					scopesInClaim[scope] = true
+					scopesInClaimList = append(scopesInClaimList, scope)
+				}
+			case []interface{}:
+				for _, scope := range scopes {
+					if val, ok := scope.(string); ok {
+						scopesInClaim[val] = true
+						scopesInClaimList = append(scopesInClaimList, val)
+					}
+				}
+			default:
+				return nil, nil, fmt.Errorf("unsupported scope format in incoming JWT claim, was type %T", scopes)
+			}
+			break
+		}
+	}
+	sort.Strings(scopesInClaimList)
+	return scopesInClaim, scopesInClaimList, nil
+}
+
+// partitionKeys sorts keys by their type.
+func partitionKeys(k interface{}) ([]*rsa.PublicKey, []*ecdsa.PublicKey, [][]byte) {
+	var (
+		rsaKeys   []*rsa.PublicKey
+		ecdsaKeys []*ecdsa.PublicKey
+		hmacKeys  [][]byte
+	)
+
+	switch typed := k.(type) {
+	case []byte:
+		hmacKeys = append(hmacKeys, typed)
+	case [][]byte:
+		hmacKeys = typed
+	case string:
+		hmacKeys = append(hmacKeys, []byte(typed))
+	case []string:
+		for _, s := range typed {
+			hmacKeys = append(hmacKeys, []byte(s))
+		}
+	case *rsa.PublicKey:
+		rsaKeys = append(rsaKeys, typed)
+	case []*rsa.PublicKey:
+		rsaKeys = typed
+	case *ecdsa.PublicKey:
+		ecdsaKeys = append(ecdsaKeys, typed)
+	case []*ecdsa.PublicKey:
+		ecdsaKeys = typed
+	}
+
+	return rsaKeys, ecdsaKeys, hmacKeys
+}
+
+func validateRSAKeys(rsaKeys []*rsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
+	for _, pubkey := range rsaKeys {
+		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
+			if !strings.HasPrefix(token.Method.Alg(), algo) {
+				return nil, goajwt.ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
+			}
+			return pubkey, nil
+		})
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+func validateECDSAKeys(ecdsaKeys []*ecdsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
+	for _, pubkey := range ecdsaKeys {
+		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
+			if !strings.HasPrefix(token.Method.Alg(), algo) {
+				return nil, goajwt.ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
+			}
+			return pubkey, nil
+		})
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+func validateHMACKeys(hmacKeys [][]byte, algo, incomingToken string) (token *jwt.Token, err error) {
+	for _, key := range hmacKeys {
+		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
+			if !strings.HasPrefix(token.Method.Alg(), algo) {
+				return nil, goajwt.ErrJWTError(fmt.Sprintf("Unexpected signing method: %v", token.Header["alg"]))
+			}
+			return key, nil
+		})
+		if err == nil {
+			return
+		}
+	}
+	return
+}

--- a/goamiddleware/jwt_token_context.go
+++ b/goamiddleware/jwt_token_context.go
@@ -77,38 +77,6 @@ func TokenContext(validationKeys interface{}, validationFunc goa.Middleware, sch
 	}
 }
 
-// partitionKeys sorts keys by their type.
-func partitionKeys(k interface{}) ([]*rsa.PublicKey, []*ecdsa.PublicKey, [][]byte) {
-	var (
-		rsaKeys   []*rsa.PublicKey
-		ecdsaKeys []*ecdsa.PublicKey
-		hmacKeys  [][]byte
-	)
-
-	switch typed := k.(type) {
-	case []byte:
-		hmacKeys = append(hmacKeys, typed)
-	case [][]byte:
-		hmacKeys = typed
-	case string:
-		hmacKeys = append(hmacKeys, []byte(typed))
-	case []string:
-		for _, s := range typed {
-			hmacKeys = append(hmacKeys, []byte(s))
-		}
-	case *rsa.PublicKey:
-		rsaKeys = append(rsaKeys, typed)
-	case []*rsa.PublicKey:
-		rsaKeys = typed
-	case *ecdsa.PublicKey:
-		ecdsaKeys = append(ecdsaKeys, typed)
-	case []*ecdsa.PublicKey:
-		ecdsaKeys = typed
-	}
-
-	return rsaKeys, ecdsaKeys, hmacKeys
-}
-
 func parseRSAKeys(rsaKeys []*rsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
 	for _, pubkey := range rsaKeys {
 		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {

--- a/goamiddleware/jwt_token_context.go
+++ b/goamiddleware/jwt_token_context.go
@@ -1,7 +1,28 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2015 Raphael Simon and goa Contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package goamiddleware
 
 import (
-	"crypto/ecdsa"
 	"crypto/rsa"
 	"fmt"
 	"net/http"
@@ -45,21 +66,21 @@ func TokenContext(validationKeys interface{}, validationFunc goa.Middleware, sch
 				)
 
 				if len(rsaKeys) > 0 {
-					token, err = parseRSAKeys(rsaKeys, "RS", incomingToken)
+					token, err = validateRSAKeys(rsaKeys, "RS", incomingToken)
 					if err == nil {
 						parsed = true
 					}
 				}
 
 				if !parsed && len(ecdsaKeys) > 0 {
-					token, err = parseECDSAKeys(ecdsaKeys, "ES", incomingToken)
+					token, err = validateECDSAKeys(ecdsaKeys, "ES", incomingToken)
 					if err == nil {
 						parsed = true
 					}
 				}
 
 				if !parsed && len(hmacKeys) > 0 {
-					token, err = parseHMACKeys(hmacKeys, "HS", incomingToken)
+					token, err = validateHMACKeys(hmacKeys, "HS", incomingToken)
 					if err == nil {
 						parsed = true
 					}
@@ -75,49 +96,4 @@ func TokenContext(validationKeys interface{}, validationFunc goa.Middleware, sch
 			return nextHandler(ctx, rw, req)
 		}
 	}
-}
-
-func parseRSAKeys(rsaKeys []*rsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, pubkey := range rsaKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, goajwt.ErrJWTError(fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]))
-			}
-			return pubkey, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func parseECDSAKeys(ecdsaKeys []*ecdsa.PublicKey, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, pubkey := range ecdsaKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, goajwt.ErrJWTError(fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]))
-			}
-			return pubkey, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func parseHMACKeys(hmacKeys [][]byte, algo, incomingToken string) (token *jwt.Token, err error) {
-	for _, key := range hmacKeys {
-		token, err = jwt.Parse(incomingToken, func(token *jwt.Token) (interface{}, error) {
-			if !strings.HasPrefix(token.Method.Alg(), algo) {
-				return nil, goajwt.ErrJWTError(fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]))
-			}
-			return key, nil
-		})
-		if err == nil {
-			return
-		}
-	}
-	return
 }

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -1862,10 +1862,6 @@ func TestWatchEventsInNamespace(t *testing.T) {
 	}
 }
 
-func printObj(obj interface{}) {
-	fmt.Println(obj)
-}
-
 func checkEventItems(t *testing.T, eventList *v1.EventList, store *cache.FIFO) {
 	for _, item := range eventList.Items {
 		_, exists, _ := store.Get(item)

--- a/log/log.go
+++ b/log/log.go
@@ -141,7 +141,15 @@ func Error(ctx context.Context, fields map[string]interface{}, format string, ar
 					entry = entry.WithField("req_headers", headers)
 				}
 				if len(req.Params) > 0 {
-					entry = entry.WithField("req_params", req.Params)
+					params := make(map[string]interface{}, len(req.Params))
+					for k, v := range req.Params {
+						if k == "access_token" {
+							params[string(k)] = "*****"
+						} else {
+							params[string(k)] = v
+						}
+					}
+					entry = entry.WithField("req_params", params)
 				}
 				if req.ContentLength > 0 {
 					if mp, ok := req.Payload.(map[string]interface{}); ok && mp != nil {

--- a/main.go
+++ b/main.go
@@ -199,7 +199,9 @@ func main() {
 
 	service.Use(login.InjectTokenManager(tokenManager))
 	service.Use(log.LogRequest(config.IsPostgresDeveloperModeEnabled()))
+
 	app.UseJWTMiddleware(service, goajwt.New(tokenManager.PublicKeys(), nil, app.NewJWTSecurity()))
+	app.UseJWTQueryParamMiddleware(service, witmiddleware.New(tokenManager.PublicKeys(), nil, app.NewJWTQueryParamSecurity()))
 
 	spaceAuthzService := authz.NewAuthzService(config)
 	service.Use(authz.InjectAuthzService(spaceAuthzService))


### PR DESCRIPTION
This addresses the 'events' side of https://github.com/openshiftio/openshift.io/issues/2380

The endpoint `api/deployments/environments/{environmentId}/events/watch` is added that allows websocket clients to connect and receive the Kubernetes Events ListAndWatch results.

This is a WIP PR and contains commits and files that need to be cleaned before merging. These are:

Commit: 
temp(deployments): set localhost
fix(deployments): add readme for websockets prototype

Files:
examples/client.go