### PR TITLE
Update workitem events API to handle fields with type float and int

### DIFF
--- a/controller/test-files/event/list/ok-kindFloat.res.headers.golden.json
+++ b/controller/test-files/event/list/ok-kindFloat.res.headers.golden.json
@@ -1,0 +1,14 @@
+{
+  "Cache-Control": [
+    "max-age=2"
+  ],
+  "Content-Type": [
+    "application/vnd.api+json"
+  ],
+  "Etag": [
+    "1GmclFDDPcLR1ZWPZnykWw=="
+  ],
+  "Last-Modified": [
+    "Mon, 01 Jan 0001 00:00:00 GMT"
+  ]
+}

--- a/controller/test-files/event/list/ok-kindFloat.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-kindFloat.res.payload.golden.json
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "myFloatType",
+        "newValue": "2.99",
+        "oldValue": "1.99",
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000002"
+            },
+            "type": "identities"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok-kindInt.res.headers.golden.json
+++ b/controller/test-files/event/list/ok-kindInt.res.headers.golden.json
@@ -1,0 +1,14 @@
+{
+  "Cache-Control": [
+    "max-age=2"
+  ],
+  "Content-Type": [
+    "application/vnd.api+json"
+  ],
+  "Etag": [
+    "1GmclFDDPcLR1ZWPZnykWw=="
+  ],
+  "Last-Modified": [
+    "Mon, 01 Jan 0001 00:00:00 GMT"
+  ]
+}

--- a/controller/test-files/event/list/ok-kindInt.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-kindInt.res.payload.golden.json
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "myIntType",
+        "newValue": "4235",
+        "oldValue": "200",
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "links": {
+              "related": "http:///api/users/00000000-0000-0000-0000-000000000002"
+            },
+            "type": "identities"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/work_item_events.go
+++ b/controller/work_item_events.go
@@ -202,6 +202,20 @@ func ConvertEvent(appl application.Application, request *http.Request, wiEvent e
 				},
 			},
 		}
+	default:
+		e = &app.Event{
+			Type: event.APIStringTypeEvents,
+			ID:   &wiEvent.ID,
+			Attributes: map[string]interface{}{
+				"name":      wiEvent.Name,
+				"newValue":  wiEvent.New,
+				"oldValue":  wiEvent.Old,
+				"timestamp": wiEvent.Timestamp,
+			},
+			Relationships: &app.EventRelations{
+				Modifier: modifier,
+			},
+		}
 	}
 	return e
 }

--- a/workitem/event/event_repository.go
+++ b/workitem/event/event_repository.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/jinzhu/gorm"
@@ -110,7 +111,6 @@ func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event
 					}
 				default:
 					return nil, errors.NewNotFoundError("Unknown field:", fieldName)
-
 				}
 			case workitem.EnumType:
 				var p string
@@ -133,7 +133,6 @@ func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event
 					n, _ = newValue.(string)
 
 				}
-
 				if p != n {
 					wie := Event{
 						ID:        revisionList[k].ID,
@@ -182,7 +181,7 @@ func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event
 						}
 						eventList = append(eventList, wie)
 					}
-				case workitem.KindString, workitem.KindIteration, workitem.KindArea:
+				case workitem.KindString, workitem.KindIteration, workitem.KindArea, workitem.KindFloat, workitem.KindInteger:
 					var p string
 					var n string
 
@@ -192,6 +191,10 @@ func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event
 					switch previousValue.(type) {
 					case nil:
 						p = ""
+					case float32, float64:
+						p = fmt.Sprintf("%f", previousValue)
+					case int:
+						p = fmt.Sprintf("%d", previousValue)
 					case interface{}:
 						p, _ = previousValue.(string)
 					}
@@ -199,11 +202,13 @@ func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event
 					switch newValue.(type) {
 					case nil:
 						n = ""
+					case float32, float64:
+						n = fmt.Sprintf("%f", newValue)
+					case int:
+						n = fmt.Sprintf("%d", newValue)
 					case interface{}:
 						n, _ = newValue.(string)
-
 					}
-
 					if p != n {
 						wie := Event{
 							ID:        revisionList[k].ID,

--- a/workitem/event/event_repository.go
+++ b/workitem/event/event_repository.go
@@ -188,26 +188,26 @@ func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event
 					previousValue := revisionList[k-1].WorkItemFields[fieldName]
 					newValue := revisionList[k].WorkItemFields[fieldName]
 
-					switch previousValue.(type) {
+					switch v := previousValue.(type) {
 					case nil:
 						p = ""
-					case float32, float64:
-						p = fmt.Sprintf("%f", previousValue)
-					case int:
-						p = fmt.Sprintf("%d", previousValue)
-					case interface{}:
-						p, _ = previousValue.(string)
+					case float32, float64, int:
+						p = fmt.Sprintf("%g", previousValue)
+					case string:
+						p = v
+					default:
+						return nil, errors.NewConversionError("Failed to convert")
 					}
 
-					switch newValue.(type) {
+					switch v := newValue.(type) {
 					case nil:
 						n = ""
-					case float32, float64:
-						n = fmt.Sprintf("%f", newValue)
-					case int:
-						n = fmt.Sprintf("%d", newValue)
-					case interface{}:
-						n, _ = newValue.(string)
+					case float32, float64, int:
+						n = fmt.Sprintf("%g", newValue)
+					case string:
+						n = v
+					default:
+						return nil, errors.NewConversionError("Failed to convert")
 					}
 					if p != n {
 						wie := Event{
@@ -224,7 +224,6 @@ func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event
 			default:
 				return nil, errors.NewNotFoundError("Unknown field:", fieldName)
 			}
-
 		}
 	}
 	return eventList, nil


### PR DESCRIPTION
The events API didn't not handle dynamic fields with `Kind=float/int`.
This PR updates the event API to deal with the missing types.


Fixes https://github.com/fabric8-services/fabric8-wit/issues/2107


Note - I cannot add tests for this PR since we do not have test fixtures capable of creating the workitem wtih type `Epic` (or any other type from Scrum template)