### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -154,9 +154,9 @@ function deploy() {
   make docker-image-deploy
 
   if [ "$TARGET" = "rhel" ]; then
-    image_url="${registry}/openshiftio/rhel-fabric8-services/fabric8-wit"
+    image_url="${registry}/openshiftio/rhel-fabric8-services-fabric8-wit"
   else
-    image_url="${registry}/openshiftio/fabric8-services/fabric8-wit"
+    image_url="${registry}/openshiftio/fabric8-services-fabric8-wit"
   fi
 
   tag_push "${image_url}:${tag}"

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -12,12 +12,19 @@ set -e
 # See https://github.com/openshiftio/openshiftio-cico-jobs/pull/186 for an approach
 # using "declare -p" on the site that creates the .jenkins-env file.
 function load_jenkins_vars() {
-  if [ -e "jenkins-env" ]; then
-    cat jenkins-env \
-      | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-      | sed 's/^/export /g' \
-      > ~/.jenkins-env
-    source ~/.jenkins-env
+  if [ -e "jenkins-env.json" ]; then
+    eval "$(./env-toolkit load -f jenkins-env.json \
+              DEVSHIFT_TAG_LEN \
+              QUAY_USERNAME \
+              QUAY_PASSWORD \
+              JENKINS_URL \
+              GIT_BRANCH \
+              GIT_COMMIT \
+              BUILD_NUMBER \
+              ghprbSourceBranch \
+              ghprbActualCommit \
+              BUILD_URL \
+              ghprbPullId)"
   fi
 }
 
@@ -134,10 +141,10 @@ function tag_push() {
 function deploy() {
   local tag=$1
   local push_latest=$2
-  local registry="push.registry.devshift.net"
+  local registry="quay.io"
 
-  if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-    docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${registry}
+  if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+    docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${registry}
   else
     echo "Could not login, missing credentials for the registry"
     exit 1
@@ -147,15 +154,14 @@ function deploy() {
   make docker-image-deploy
 
   if [ "$TARGET" = "rhel" ]; then
-    base_registry_url="${registry}/osio-prod"
+    image_url="${registry}/openshiftio/rhel-fabric8-services/fabric8-wit"
   else
-    base_registry_url="${registry}"
+    image_url="${registry}/openshiftio/fabric8-services/fabric8-wit"
   fi
 
-  tag_push ${base_registry_url}/fabric8-services/fabric8-wit:${tag}
-  if ( ${push_latest} ); then
-    tag_push ${base_registry_url}/fabric8-services/fabric8-wit:latest
-  fi
+  tag_push "${image_url}:${tag}"
+  [ -n "${push_latest}" ] && tag_push "${image_url}:latest"
+
   echo 'CICO: Image pushed, ready to update deployed app'
 }
 

--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -208,7 +208,7 @@ objects:
     sessionAffinity: null
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8-services/fabric8-wit
+  value: quay.io/openshiftio/rhel-fabric8-services-fabric8-wit
 - name: IMAGE_TAG
   value: latest
 - description: Number of deployment replicas


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-openshiftio/pull/919