### PR TITLE
Fix error in WIT group creation

### DIFF
--- a/test/testfixture/make_functions.go
+++ b/test/testfixture/make_functions.go
@@ -318,7 +318,7 @@ func makeWorkItemTypeGroups(fxt *TestFixture) error {
 			return errs.WithStack(err)
 		}
 		if fxt.isolatedCreation {
-			if fxt.WorkItemTypes[i].SpaceTemplateID == uuid.Nil {
+			if fxt.WorkItemTypeGroups[i].SpaceTemplateID == uuid.Nil {
 				return errs.New("you must specify a space template ID for each work item type group")
 			}
 		}


### PR DESCRIPTION
Due to a copy'n'paste error I checked for the wrong entity to have a space template associated with it.

Thanks to @michaelkleinhenz for finding it.
