### PR TITLE
fix(deployments): add all environments endpoint

### DIFF
--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -381,6 +381,29 @@ func (c *DeploymentsController) ShowSpaceEnvironments(ctx *app.ShowSpaceEnvironm
 	return ctx.OK(res)
 }
 
+// ShowAllEnvironments runs the showAllEnvironments action.
+func (c *DeploymentsController) ShowAllEnvironments(ctx *app.ShowAllEnvironmentsDeploymentsContext) error {
+	kc, err := c.GetKubeClient(ctx)
+	defer cleanup(kc)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
+	envs, err := kc.GetEnvironments()
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "error retrieving environments"))
+	}
+	if envs == nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundErrorFromString("no environments found"))
+	}
+
+	res := &app.SimpleEnvironmentList{
+		Data: envs,
+	}
+
+	return ctx.OK(res)
+}
+
 func cleanup(kc kubernetes.KubeClientInterface) {
 	if kc != nil {
 		kc.Close()

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -279,4 +279,16 @@ var _ = a.Resource("deployments", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 	})
+
+	a.Action("showAllEnvironments", func() {
+		a.Routing(
+			a.GET("/environments"),
+		)
+		a.Description("list all environments")
+		a.Response(d.OK, simpleEnvironmentMultiple)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.BadRequest, JSONAPIErrors)
+	})
 })


### PR DESCRIPTION
This patch introduces a new endpoint to the deployment api that returns all environments. 

The endpoint is defined under "/api/deployments/environmetns" and returns all environments to the client. This behaviour currently exists under "api/deployments/spaces/$SPACE", which will be modified according to the note below.

Note : This is step 1/2 of https://github.com/openshiftio/openshift.io/issues/2889, the second being to modify the previously existing endpoint to actually use the spaceId parameter.