### PR TITLE
Use underscore to test if interface is implemented

### DIFF
--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -47,9 +47,9 @@ const (
 	TXIsoLevelSerializable
 )
 
-var x application.Application = &GormDB{}
+var _ application.Application = &GormDB{}
 
-var y application.Application = &GormTransaction{}
+var _ application.Application = &GormTransaction{}
 
 func NewGormDB(db *gorm.DB) *GormDB {
 	return &GormDB{GormBase{db}, ""}


### PR DESCRIPTION
No need to create two variables (`x` and `y`) for it.