### PR TITLE
Switch permission check from KC to Auth service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ clean-generated:
 	-rm -f ./migration/sqlbindata.go
 	-rm -f ./migration/sqlbindata_test.go
 	-rm -rf ./account/tenant
+	-rm -rf ./notification/client
 	-rm -rf ./auth/authservice
 	-rm -f ./spacetemplate/template_assets.go
 

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	"github.com/fabric8-services/fabric8-wit/application"
+	"github.com/fabric8-services/fabric8-wit/auth"
 	"github.com/fabric8-services/fabric8-wit/comment"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/errors"
@@ -25,10 +26,10 @@ import (
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/space"
-	"github.com/fabric8-services/fabric8-wit/space/authz"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
 	notificationsupport "github.com/fabric8-services/fabric8-wit/test/notification"
 	"github.com/fabric8-services/fabric8-wit/workitem"
+
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/satori/go.uuid"
@@ -611,7 +612,7 @@ type TestSpaceAuthzService struct {
 	userIDs string
 }
 
-func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (bool, error) {
+func (s *TestSpaceAuthzService) Authorize(ctx context.Context, spaceID string) (bool, error) {
 	jwtToken := goajwt.ContextJWT(ctx)
 	if jwtToken == nil {
 		return false, errors.NewUnauthorizedError("Missing token")
@@ -620,6 +621,6 @@ func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, 
 	return s.owner.ID.String() == id || strings.Contains(s.userIDs, id), nil
 }
 
-func (s *TestSpaceAuthzService) Configuration() authz.AuthzConfiguration {
+func (s *TestSpaceAuthzService) Configuration() auth.ServiceConfiguration {
 	return nil
 }

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/app/test"
 	"github.com/fabric8-services/fabric8-wit/application"
+	witauth "github.com/fabric8-services/fabric8-wit/auth"
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/gormapplication"
@@ -23,13 +24,12 @@ import (
 	"github.com/fabric8-services/fabric8-wit/iteration"
 	"github.com/fabric8-services/fabric8-wit/ptr"
 	"github.com/fabric8-services/fabric8-wit/space"
-	"github.com/fabric8-services/fabric8-wit/space/authz"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -78,7 +78,7 @@ type DummySpaceAuthzService struct {
 	rest *TestIterationREST
 }
 
-func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (bool, error) {
+func (s *DummySpaceAuthzService) Authorize(ctx context.Context, spaceID string) (bool, error) {
 	jwtToken := goajwt.ContextJWT(ctx)
 	if jwtToken == nil {
 		return false, errors.NewUnauthorizedError("Missing token")
@@ -87,7 +87,7 @@ func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string,
 	return strings.Contains(s.rest.policy.Config.UserIDs, id), nil
 }
 
-func (s *DummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
+func (s *DummySpaceAuthzService) Configuration() witauth.ServiceConfiguration {
 	return nil
 }
 

--- a/rest/http.go
+++ b/rest/http.go
@@ -1,0 +1,33 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/goadesign/goa/client"
+)
+
+// Doer is a wrapper interface for goa client Doer
+type HttpDoer interface {
+	client.Doer
+}
+
+// HttpClient defines the Do method of the http client.
+type HttpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// HttpClientDoer implements HttpDoer
+type HttpClientDoer struct {
+	HttpClient HttpClient
+}
+
+// DefaultHttpDoer creates a new HttpDoer with default http client
+func DefaultHttpDoer() HttpDoer {
+	return &HttpClientDoer{HttpClient: http.DefaultClient}
+}
+
+// Do overrides Do method of the default goa client Doer. It's needed for mocking http clients in tests.
+func (d *HttpClientDoer) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	return d.HttpClient.Do(req)
+}

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -1,16 +1,25 @@
 package authz_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
-	"github.com/fabric8-services/fabric8-wit/configuration"
-	"github.com/fabric8-services/fabric8-wit/errors"
+	"github.com/fabric8-services/fabric8-wit/auth"
+	witerrors "github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/resource"
-	"github.com/fabric8-services/fabric8-wit/space/authz"
+	"github.com/fabric8-services/fabric8-wit/rest"
+	. "github.com/fabric8-services/fabric8-wit/space/authz"
+	testsupport "github.com/fabric8-services/fabric8-wit/test"
+	testsuite "github.com/fabric8-services/fabric8-wit/test/suite"
+	"github.com/fabric8-services/fabric8-wit/test/token"
 
 	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -21,23 +30,110 @@ func TestAuthz(t *testing.T) {
 }
 
 type TestAuthzSuite struct {
-	suite.Suite
-	authzService *authz.KeycloakAuthzService
-	config       *configuration.Registry
+	testsuite.UnitTestSuite
+	authzService *AuthzRoleService
+	doer         *testsupport.DummyHttpDoer
+	authzConfig  *auth.ServiceConfiguration
 }
 
 func (s *TestAuthzSuite) SetupSuite() {
-	var err error
-	s.config, err = configuration.Get()
-	if err != nil {
-		panic(fmt.Errorf("failed to setup the configuration: %s", err.Error()))
-	}
-	s.authzService = authz.NewAuthzService(s.config)
+	s.UnitTestSuite.SetupSuite()
+	s.authzService = NewAuthzService(&authURLConfig{authURL: "https://some.auth.io"})
+	doer := testsupport.NewDummyHttpDoer()
+	s.authzService.Doer = doer
+	s.doer = doer
 }
 
 func (s *TestAuthzSuite) TestFailsIfNoTokenInContext() {
-	ctx := context.Background()
-	_, err := s.authzService.Authorize(ctx, uuid.NewV4().String())
+	_, err := s.authzService.Authorize(context.Background(), uuid.NewV4().String())
 	require.Error(s.T(), err)
-	require.IsType(s.T(), errors.UnauthorizedError{}, err)
+	require.IsType(s.T(), witerrors.UnauthorizedError{}, err)
+}
+
+func (s *TestAuthzSuite) TestDefaultDoer() {
+	c := &authURLConfig{}
+	as := NewAuthzService(c)
+	assert.Equal(s.T(), c, as.Config)
+	assert.Equal(s.T(), rest.DefaultHttpDoer(), as.Doer)
+}
+
+func (s *TestAuthzSuite) TestAuthorizeOK() {
+	ctx, identityID, tokenString, reqID := token.ContextWithTokenAndRequestID(s.T())
+
+	// One admin
+	responsePayload := fmt.Sprintf("{\"data\":[{\"role_name\":\"admin\",\"assignee_id\":\"%s\"}]}", identityID.String())
+	s.checkAuthorize(ctx, identityID, tokenString, reqID, responsePayload, true)
+
+	// One contributor
+	responsePayload = fmt.Sprintf("{\"data\":[{\"role_name\":\"contributor\",\"assignee_id\":\"%s\"}]}", identityID.String())
+	s.checkAuthorize(ctx, identityID, tokenString, reqID, responsePayload, true)
+
+	// Multiple users and the expected one is among them
+	responsePayload = fmt.Sprintf("{\"data\":[{\"role_name\":\"admin\",\"assignee_id\":\"%s\"},{\"role_name\":\"contributor\",\"assignee_id\":\"%s\"}]}", uuid.NewV4().String(), identityID.String())
+	s.checkAuthorize(ctx, identityID, tokenString, reqID, responsePayload, true)
+
+	// Viewer is forbidden
+	responsePayload = fmt.Sprintf("{\"data\":[{\"role_name\":\"viewer\",\"assignee_id\":\"%s\"}]}", identityID.String())
+	s.checkAuthorize(ctx, identityID, tokenString, reqID, responsePayload, false)
+
+	// If the user is not among the roles then it's forbidden too
+	responsePayload = fmt.Sprintf("{\"data\":[{\"role_name\":\"admin\",\"assignee_id\":\"%s\"},{\"role_name\":\"contributor\",\"assignee_id\":\"%s\"}]}", uuid.NewV4().String(), uuid.NewV4().String())
+	s.checkAuthorize(ctx, identityID, tokenString, reqID, responsePayload, false)
+}
+
+func (s *TestAuthzSuite) TestAuthorizeFailWithError() {
+	ctx, _, _, _ := token.ContextWithTokenAndRequestID(s.T())
+	spaceID := uuid.NewV4().String()
+
+	// Fail if client returned an error
+	s.doer.Client.Error = errors.New("oopsie woopsie")
+	_, err := s.authzService.Authorize(ctx, spaceID)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "oopsie woopsie", err.Error())
+
+	// Fail if client returned unexpected status
+	body := ioutil.NopCloser(bytes.NewReader([]byte{}))
+	s.doer.Client.Response = &http.Response{Body: body, StatusCode: http.StatusInternalServerError, Status: "500"}
+	s.doer.Client.Error = nil
+	_, err = s.authzService.Authorize(ctx, spaceID)
+	require.Error(s.T(), err)
+	testsupport.AssertError(s.T(), err, witerrors.InternalError{}, "unable to get space roles. Response status: 500. Response body: ")
+}
+
+func (s *TestAuthzSuite) checkAuthorize(ctx context.Context, identityID uuid.UUID, token, reqID, responsePayload string, expectedAllowed bool) {
+	spaceID := uuid.NewV4().String()
+
+	// Set up expected request
+	s.doer.Client.Error = nil
+
+	body := ioutil.NopCloser(bytes.NewReader([]byte(responsePayload)))
+	s.doer.Client.Response = &http.Response{Body: body, StatusCode: http.StatusOK}
+
+	s.doer.Client.AssertRequest = func(req *http.Request) {
+		assert.Equal(s.T(), "GET", req.Method)
+		assert.Equal(s.T(), fmt.Sprintf("https://some.auth.io/api/resources/%s/roles", spaceID), req.URL.String())
+		assert.Equal(s.T(), "Bearer "+token, req.Header.Get("Authorization"))
+		assert.Equal(s.T(), reqID, req.Header.Get("X-Request-Id"))
+	}
+
+	// OK
+	ok, err := s.authzService.Authorize(ctx, spaceID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), expectedAllowed, ok)
+}
+
+type authURLConfig struct {
+	authURL string
+}
+
+func (c *authURLConfig) GetAuthServiceURL() string {
+	return c.authURL
+}
+
+func (c *authURLConfig) GetAuthShortServiceHostName() string {
+	return ""
+}
+
+func (c *authURLConfig) IsAuthorizationEnabled() bool {
+	return true
 }

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -37,7 +37,7 @@ func (s *TestAuthzSuite) SetupSuite() {
 
 func (s *TestAuthzSuite) TestFailsIfNoTokenInContext() {
 	ctx := context.Background()
-	_, err := s.authzService.Authorize(ctx, "", uuid.NewV4().String())
+	_, err := s.authzService.Authorize(ctx, uuid.NewV4().String())
 	require.Error(s.T(), err)
 	require.IsType(s.T(), errors.UnauthorizedError{}, err)
 }

--- a/test/error.go
+++ b/test/error.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func AssertError(t require.TestingT, actualError error, expectedType interface{}, expectedMsgAndArgs ...interface{}) {
+	require.Error(t, actualError)
+	assert.IsType(t, expectedType, errors.Cause(actualError))
+	assert.Equal(t, messageFromMsgAndArgs(expectedMsgAndArgs...), actualError.Error())
+}
+
+func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
+	if len(msgAndArgs) == 0 || msgAndArgs == nil {
+		return ""
+	}
+	if len(msgAndArgs) == 1 {
+		return msgAndArgs[0].(string)
+	}
+	if len(msgAndArgs) > 1 {
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+	return ""
+}

--- a/test/http.go
+++ b/test/http.go
@@ -1,0 +1,49 @@
+package test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-wit/rest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type DummyHttpClient struct {
+	Response      *http.Response
+	Error         error
+	AssertRequest func(req *http.Request)
+}
+
+type DummyHttpDoer struct {
+	*rest.HttpClientDoer
+	Client *DummyHttpClient
+}
+
+func (c *DummyHttpClient) Do(req *http.Request) (*http.Response, error) {
+	if c.AssertRequest != nil {
+		c.AssertRequest(req)
+	}
+	return c.Response, c.Error
+}
+
+func NewDummyHttpDoer() *DummyHttpDoer {
+	client := &DummyHttpClient{}
+	doer := &rest.HttpClientDoer{HttpClient: client}
+	return &DummyHttpDoer{HttpClientDoer: doer, Client: client}
+}
+
+func EqualURLs(t *testing.T, expected string, actual string) {
+	expectedURL, err := url.Parse(expected)
+	require.Nil(t, err)
+	actualURL, err := url.Parse(actual)
+	require.Nil(t, err)
+	assert.Equal(t, expectedURL.Scheme, actualURL.Scheme)
+	assert.Equal(t, expectedURL.Host, actualURL.Host)
+	assert.Equal(t, len(expectedURL.Query()), len(actualURL.Query()))
+	for name, value := range expectedURL.Query() {
+		assert.Equal(t, value, actualURL.Query()[name])
+	}
+}

--- a/test/login.go
+++ b/test/login.go
@@ -94,13 +94,13 @@ func ServiceAsServiceAccountUser(serviceName string, u account.Identity) *goa.Se
 // ServiceAsUser creates a new service and fill the context with input Identity
 func ServiceAsUser(serviceName string, u account.Identity) *goa.Service {
 	svc := service(serviceName, nil, u, nil)
-	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeycloakAuthzServiceManager{Service: &dummySpaceAuthzService{}})
+	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.AuthzServiceManagerWrapper{Service: &dummySpaceAuthzService{}})
 	return svc
 }
 
 // ServiceAsSpaceUser creates a new service and fill the context with input Identity and space authz service
 func ServiceAsSpaceUser(serviceName string, u account.Identity, authzSrv authz.AuthzService) *goa.Service {
 	svc := service(serviceName, nil, u, nil)
-	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeycloakAuthzServiceManager{Service: authzSrv})
+	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.AuthzServiceManagerWrapper{Service: authzSrv})
 	return svc
 }

--- a/test/login.go
+++ b/test/login.go
@@ -2,16 +2,16 @@ package test
 
 import (
 	"context"
+	"time"
 
 	"github.com/fabric8-services/fabric8-wit/account"
-	tokencontext "github.com/fabric8-services/fabric8-wit/login/tokencontext"
+	"github.com/fabric8-services/fabric8-wit/auth"
+	"github.com/fabric8-services/fabric8-wit/login/tokencontext"
 	"github.com/fabric8-services/fabric8-wit/space/authz"
 	testtoken "github.com/fabric8-services/fabric8-wit/test/token"
 	"github.com/fabric8-services/fabric8-wit/token"
 
-	"time"
-
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 )
@@ -19,11 +19,11 @@ import (
 type dummySpaceAuthzService struct {
 }
 
-func (s *dummySpaceAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (bool, error) {
+func (s *dummySpaceAuthzService) Authorize(ctx context.Context, spaceID string) (bool, error) {
 	return true, nil
 }
 
-func (s *dummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
+func (s *dummySpaceAuthzService) Configuration() auth.ServiceConfiguration {
 	return nil
 }
 
@@ -80,13 +80,6 @@ func service(serviceName string, key interface{}, u account.Identity, authz *tok
 		svc.Context = WithAuthz(svc.Context, key, u, *authz)
 	}
 	svc.Context = tokencontext.ContextWithTokenManager(svc.Context, testtoken.TokenManager)
-	return svc
-}
-
-// ServiceAsUserWithAuthz creates a new service and fill the context with input Identity and resource authorization information
-func ServiceAsUserWithAuthz(serviceName string, key interface{}, u account.Identity, authorizationPayload token.AuthorizationPayload) *goa.Service {
-	svc := service(serviceName, key, u, &authorizationPayload)
-	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeycloakAuthzServiceManager{Service: &dummySpaceAuthzService{}})
 	return svc
 }
 

--- a/test/suite/unit_test_suite.go
+++ b/test/suite/unit_test_suite.go
@@ -1,0 +1,35 @@
+package suite
+
+import (
+	"fmt"
+
+	"github.com/fabric8-services/fabric8-wit/configuration"
+	"github.com/fabric8-services/fabric8-wit/resource"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// UnitTestSuite is a base for unit tests
+type UnitTestSuite struct {
+	suite.Suite
+	Config *configuration.Registry
+}
+
+// SetupSuite implements suite.SetupAllSuite
+func (s *UnitTestSuite) SetupSuite() {
+	resource.Require(s.T(), resource.UnitTest)
+	s.setupConfig()
+}
+
+func (s *UnitTestSuite) setupConfig() {
+	config, err := configuration.Get()
+	if err != nil {
+		panic(fmt.Errorf("failed to setup the configuration: %s", err.Error()))
+	}
+	s.Config = config
+}
+
+// TearDownSuite implements suite.TearDownAllSuite
+func (s *UnitTestSuite) TearDownSuite() {
+	s.Config = nil // Summon the GC!
+}


### PR DESCRIPTION
This PR is a temporal solution for native authorization via Auth service.
Instead of fetching an entitlement token for the resource (space) from Keycloak it loads the list of identity-roles (users with assigned roles) for the space from Auth service.

If the current user is not among the space admins or contributors then access is not granted.

This PR eliminates Keycloak from AuthZ flow.

The next step will be an implementation of new AuthZ flow based on Auth RPT tokens.

fixes https://github.com/fabric8-services/fabric8-auth/issues/493