### PR TITLE
WIP: Rework JWT with scopes in GOA design

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -5,6 +5,18 @@ import (
 	a "github.com/goadesign/goa/design/apidsl"
 )
 
+// JWT defines a security scheme using JWT.  The scheme uses the "Authorization"
+// header to lookup the token.  It also defines then scopes "view",
+// "collaborate" and "manage".
+var JWT = a.JWTSecurity("jwt", func() {
+	a.Description("JWT Token Auth")
+	a.TokenURL("/api/login/authorize")
+	a.Header("Authorization")
+	a.Scope("view", "view a resource")
+	a.Scope("collaborate", "collaborate on a resource (includes view scope)")
+	a.Scope("manage", "manage the resource (includes view and collaborate scope)")
+})
+
 var _ = a.API("wit", func() {
 	a.Title("Fabric8-wit: One to rule them all")
 	a.Description("The next big thing")
@@ -41,12 +53,6 @@ var _ = a.API("wit", func() {
 			a.Header("If-Modified-Since", d.String)
 			a.Header("If-None-Match", d.String)
 		})
-	})
-
-	a.JWTSecurity("jwt", func() {
-		a.Description("JWT Token Auth")
-		a.TokenURL("/api/login/authorize")
-		a.Header("Authorization")
 	})
 
 	a.ResponseTemplate(d.OK, func() {

--- a/design/labels.go
+++ b/design/labels.go
@@ -62,6 +62,9 @@ var _ = a.Resource("label", func() {
 	a.BasePath("/labels")
 
 	a.Action("show", func() {
+		a.Security(JWT, func() { // Use JWT to auth requests to this endpoint
+			a.Scope("view") // Enforce presence of "view" scope in JWT claims.
+		})
 		a.Routing(
 			a.GET("/:labelID"),
 		)
@@ -78,6 +81,9 @@ var _ = a.Resource("label", func() {
 	})
 
 	a.Action("list", func() {
+		a.Security(JWT, func() { // Use JWT to auth requests to this endpoint
+			a.Scope("view") // Enforce presence of "view" scope in JWT claims.
+		})
 		a.Routing(
 			a.GET(""),
 		)
@@ -90,6 +96,9 @@ var _ = a.Resource("label", func() {
 	})
 
 	a.Action("create", func() {
+		a.Security(JWT, func() { // Use JWT to auth requests to this endpoint
+			a.Scope("manage") // Enforce presence of "manage" scope in JWT claims.
+		})
 		a.Security("jwt")
 		a.Routing(
 			a.POST(""),
@@ -108,6 +117,9 @@ var _ = a.Resource("label", func() {
 	})
 
 	a.Action("update", func() {
+		a.Security(JWT, func() { // Use JWT to auth requests to this endpoint
+			a.Scope("collaborate") // Enforce presence of "collaborate" scope in JWT claims.
+		})
 		a.Security("jwt")
 		a.Routing(
 			a.PATCH("/:labelID"),


### PR DESCRIPTION
Hey, I've looked at some swagger with @tinakurian and we found out about scopes in JWT and GOA. This PR exists to show how we might want to integrate scopes as presented by @alexeykazakov and @sbose78 into our endpoints. 

The PR was inspired by this example usage of JWT: https://github.com/goadesign/examples/blob/master/security/design/jwt.go#L10

Notice that we were not using the newly created `JWT` global variable anywhere but just defined.

As you can see the scopes can be placed on each action of a resource which is close to what we want, no? What's missing in the generated swagger are information about the `Authorization` header that should be provided in requests. The required scopes for each action are appended to the description of each action.

I have no idea what effect the changes will have on our endpoints. Do the reject a request if a scope is missing now?