### PR TITLE
Use container images from quay.io instead of docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ MINISHIFT_URL = http://$(MINISHIFT_IP)
 MINISHIFT_HOSTS_ENTRY = http://minishift.local
 
 # Setup AUTH image URL, use default image path and default tag if not provided
-AUTH_IMAGE_DEFAULT=docker.io/fabric8/fabric8-auth
+AUTH_IMAGE_DEFAULT=quay.io/openshiftio/fabric8-services-fabric8-auth
 AUTH_IMAGE_TAG ?= latest
 AUTH_IMAGE_URL=$(AUTH_IMAGE_DEFAULT):$(AUTH_IMAGE_TAG)
 

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -8,7 +8,7 @@ services:
     environment:
       POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
   core:
-    image: docker.io/fabric8/fabric8-wit:latest
+    image: quay.io/openshiftio/fabric8-services-fabric8-wit:latest
 #    command: -config /usr/local/wit/etc/config.yaml
     environment:
       F8_AUTH_URL: "http://localhost:8089"
@@ -26,7 +26,7 @@ services:
     environment:
       POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
   auth:
-    image: docker.io/fabric8/fabric8-auth:latest
+    image: quay.io/openshiftio/fabric8-services-fabric8-auth:latest
 #    command: -config /usr/local/auth/etc/config.yaml
     environment:
       AUTH_WIT_URL: "http://docker.for.mac.localhost:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
   core:
-    image: docker.io/fabric8/fabric8-wit:latest
+    image: quay.io/openshiftio/fabric8-services-fabric8-wit:latest
 #    command: -config /usr/local/wit/etc/config.yaml
     environment:
       F8_AUTH_URL: "http://localhost:8089"
@@ -25,7 +25,7 @@ services:
     environment:
       POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
   auth:
-    image: docker.io/fabric8/fabric8-auth:latest
+    image: quay.io/openshiftio/fabric8-services-fabric8-auth:latest
 #    command: -config /usr/local/auth/etc/config.yaml
     environment:
       AUTH_WIT_URL: "http://localhost:8080"

--- a/minishift/Makefile
+++ b/minishift/Makefile
@@ -1,10 +1,10 @@
 # Setup WIT image URL, use default image path and default tag if not provided
-WIT_IMAGE_DEFAULT=fabric8/fabric8-wit
+WIT_IMAGE_DEFAULT=quay.io/openshiftio/fabric8-services-fabric8-wit
 WIT_IMAGE_TAG ?= latest
 WIT_IMAGE_URL=$(WIT_IMAGE_DEFAULT):$(WIT_IMAGE_TAG)
 
 # Setup AUTH image URL, use default image path and default tag if not provided
-AUTH_IMAGE_DEFAULT=fabric8/fabric8-auth
+AUTH_IMAGE_DEFAULT=quay.io/openshiftio/fabric8-services-fabric8-auth
 AUTH_IMAGE_TAG ?= latest
 AUTH_IMAGE_URL=$(AUTH_IMAGE_DEFAULT):$(AUTH_IMAGE_TAG)
 


### PR DESCRIPTION
The docker-compose file and makefile reference container images from `docker hub` which we no longer use. We're using `quay.io`  as our container registry (see https://github.com/fabric8-services/fabric8-wit/pull/2116). This PR updates docker compose and makefile to use the correct container registry.
