### PR TITLE
Clean test entites created by space_areas_blackbox_test.go

### DIFF
--- a/controller/space_areas_blackbox_test.go
+++ b/controller/space_areas_blackbox_test.go
@@ -31,6 +31,7 @@ func TestRunSpaceAreaREST(t *testing.T) {
 }
 
 func (rest *TestSpaceAreaREST) SetupTest() {
+	rest.DBTestSuite.SetupTest()
 	rest.svcSpaceAreas, rest.ctrlSpaceAreas = rest.SecuredController()
 }
 


### PR DESCRIPTION
Fixes issue similar to https://github.com/fabric8-services/fabric8-wit/issues/2155