### PR TITLE
 Use git hash in the build container name

### DIFF
--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -75,7 +75,7 @@ clean-docker-build-dir:
 ## by prefixing them with "docker-". For example to execute "make deps"
 ## inside the build container, just run "make docker-deps".
 ## To remove the container when no longer needed, call "make docker-rm".
-docker-start: docker-build-dir docker-image-builder
+docker-start: docker-rm docker-build-dir docker-image-builder
 ifneq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)
 	@echo "Docker container \"$(DOCKER_CONTAINER_NAME)\" already exists. To recreate, run \"make docker-rm\"."
 else


### PR DESCRIPTION
Right now the build container has fixed container name
'fabric8-wit-local-build' and this caused problem 😕 in the test CI
infrastructure where when the clean up 🚮 of environment is ❌ done
properly, this conflict in the name of containers caused the CI
tests to fail intermittently for no reason 😒.

This commit fixes 😌 this issue by adding the short git hash to the build
container name.

Fixes https://github.com/openshiftio/openshift.io/issues/3838