### PR TITLE
Add object count quotas to environment stats

### DIFF
--- a/design/deployments.go
+++ b/design/deployments.go
@@ -99,32 +99,19 @@ var simpleEnvironmentAttributes = a.Type("SimpleEnvironmentAttributes", func() {
 
 var envStats = a.Type("EnvStats", func() {
 	a.Description("resource usage and quotas for an environment")
-	a.Attribute("cpucores", envStatCores)
-	a.Attribute("memory", envStatMemory)
-	a.Attribute("pods", envStatObjects)
-	a.Attribute("replication_controllers", envStatObjects)
-	a.Attribute("resource_quotas", envStatObjects)
-	a.Attribute("services", envStatObjects)
-	a.Attribute("secrets", envStatObjects)
-	a.Attribute("config_maps", envStatObjects)
-	a.Attribute("persistent_volume_claims", envStatObjects)
-	a.Attribute("image_streams", envStatObjects)
+	a.Attribute("cpucores", envStatQuota)
+	a.Attribute("memory", envStatQuota)
+	a.Attribute("pods", envStatQuota)
+	a.Attribute("replication_controllers", envStatQuota)
+	a.Attribute("resource_quotas", envStatQuota)
+	a.Attribute("services", envStatQuota)
+	a.Attribute("secrets", envStatQuota)
+	a.Attribute("config_maps", envStatQuota)
+	a.Attribute("persistent_volume_claims", envStatQuota)
+	a.Attribute("image_streams", envStatQuota)
 })
 
-var envStatCores = a.Type("EnvStatCores", func() {
-	a.Description(`CPU core stats`)
-	a.Attribute("used", d.Number)
-	a.Attribute("quota", d.Number)
-})
-
-var envStatMemory = a.Type("EnvStatMemory", func() {
-	a.Description(`memory stats`)
-	a.Attribute("used", d.Number)
-	a.Attribute("quota", d.Number)
-	a.Attribute("units", d.String)
-})
-
-var envStatObjects = a.Type("EnvStatObjects", func() {
+var envStatQuota = a.Type("EnvStatQuota", func() {
 	a.Description(`environment object counts`)
 	a.Attribute("used", d.Number)
 	a.Attribute("quota", d.Number)

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -101,6 +101,14 @@ var envStats = a.Type("EnvStats", func() {
 	a.Description("resource usage and quotas for an environment")
 	a.Attribute("cpucores", envStatCores)
 	a.Attribute("memory", envStatMemory)
+	a.Attribute("pods", envStatObjects)
+	a.Attribute("replication_controllers", envStatObjects)
+	a.Attribute("resource_quotas", envStatObjects)
+	a.Attribute("services", envStatObjects)
+	a.Attribute("secrets", envStatObjects)
+	a.Attribute("config_maps", envStatObjects)
+	a.Attribute("persistent_volume_claims", envStatObjects)
+	a.Attribute("image_streams", envStatObjects)
 })
 
 var envStatCores = a.Type("EnvStatCores", func() {
@@ -114,6 +122,12 @@ var envStatMemory = a.Type("EnvStatMemory", func() {
 	a.Attribute("used", d.Number)
 	a.Attribute("quota", d.Number)
 	a.Attribute("units", d.String)
+})
+
+var envStatObjects = a.Type("EnvStatObjects", func() {
+	a.Description(`environment object counts`)
+	a.Attribute("used", d.Number)
+	a.Attribute("quota", d.Number)
 })
 
 var timedNumberTuple = a.Type("TimedNumberTuple", func() {

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -375,6 +375,23 @@ func TestGetEnvironment(t *testing.T) {
 			},
 		},
 		{
+			testName:     "All Objects",
+			cassetteName: "getenvironment-all-objects",
+			envTestData: envTestData{
+				envName: "run",
+				cpu:     &quotaData{0.488, 2.0},
+				mem:     &quotaData{262144000.0, 1073741824.0},
+				pod:     &quotaData{31, 40},
+				rc:      &quotaData{19, 25},
+				quota:   &quotaData{2, 3},
+				svc:     &quotaData{4, 5},
+				secret:  &quotaData{17, 20},
+				cm:      &quotaData{9, 10},
+				pvc:     &quotaData{0, 1},
+				is:      &quotaData{14, 15},
+			},
+		},
+		{
 			testName:     "Bad Environment",
 			cassetteName: "getenvironments",
 			envTestData: envTestData{
@@ -385,6 +402,42 @@ func TestGetEnvironment(t *testing.T) {
 		{
 			testName:     "Kubernetes Error",
 			cassetteName: "getenvironments-rq-error",
+			envTestData: envTestData{
+				envName: "run",
+			},
+			shouldFail:   true,
+			errorChecker: errors.IsNotFoundError,
+		},
+		{
+			testName:     "Compute Resources Missing",
+			cassetteName: "getenvironment-no-compute",
+			envTestData: envTestData{
+				envName: "run",
+			},
+			shouldFail:   true,
+			errorChecker: errors.IsNotFoundError,
+		},
+		{
+			testName:     "Object Counts Missing",
+			cassetteName: "getenvironment-no-objects",
+			envTestData: envTestData{
+				envName: "run",
+			},
+			shouldFail:   true,
+			errorChecker: errors.IsNotFoundError,
+		},
+		{
+			testName:     "CPU Missing",
+			cassetteName: "getenvironment-no-cpu",
+			envTestData: envTestData{
+				envName: "run",
+			},
+			shouldFail:   true,
+			errorChecker: errors.IsNotFoundError,
+		},
+		{
+			testName:     "Memory Missing",
+			cassetteName: "getenvironment-no-mem",
 			envTestData: envTestData{
 				envName: "run",
 			},

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -251,10 +251,21 @@ func TestClose(t *testing.T) {
 
 type envTestData struct {
 	envName string
-	cpuUsed float64
-	cpuHard float64
-	memUsed float64
-	memHard float64
+	cpu     *quotaData
+	mem     *quotaData
+	pod     *quotaData
+	rc      *quotaData
+	quota   *quotaData
+	svc     *quotaData
+	secret  *quotaData
+	cm      *quotaData
+	pvc     *quotaData
+	is      *quotaData
+}
+
+type quotaData struct {
+	used  float64
+	limit float64
 }
 
 func TestGetEnvironments(t *testing.T) {
@@ -271,24 +282,30 @@ func TestGetEnvironments(t *testing.T) {
 			data: map[string]*envTestData{
 				"run": {
 					envName: "run",
-					cpuUsed: 0.488,
-					cpuHard: 2.0,
-					memUsed: 262144000.0,
-					memHard: 1073741824.0,
+					cpu:     &quotaData{0.488, 2.0},
+					mem:     &quotaData{262144000.0, 1073741824.0},
+					rc:      &quotaData{2, 20},
+					pvc:     &quotaData{1, 1},
+					secret:  &quotaData{11, 20},
+					svc:     &quotaData{2, 5},
 				},
 				"stage": {
 					envName: "stage",
-					cpuUsed: 1.488,
-					cpuHard: 2.0,
-					memUsed: 799014912.0,
-					memHard: 1073741824.0,
+					cpu:     &quotaData{1.488, 2.0},
+					mem:     &quotaData{799014912.0, 1073741824.0},
+					rc:      &quotaData{5, 20},
+					pvc:     &quotaData{0, 1},
+					secret:  &quotaData{9, 20},
+					svc:     &quotaData{2, 5},
 				},
 				"test": {
 					envName: "test",
-					cpuUsed: 0.0,
-					cpuHard: 2.0,
-					memUsed: 0.0,
-					memHard: 1073741824.0,
+					cpu:     &quotaData{0.0, 2.0},
+					mem:     &quotaData{0.0, 1073741824.0},
+					rc:      &quotaData{1, 20},
+					pvc:     &quotaData{0, 1},
+					secret:  &quotaData{12, 20},
+					svc:     &quotaData{1, 5},
 				},
 			},
 		},
@@ -349,10 +366,12 @@ func TestGetEnvironment(t *testing.T) {
 			cassetteName: "getenvironments",
 			envTestData: envTestData{
 				envName: "run",
-				cpuUsed: 0.488,
-				cpuHard: 2.0,
-				memUsed: 262144000.0,
-				memHard: 1073741824.0,
+				cpu:     &quotaData{0.488, 2.0},
+				mem:     &quotaData{262144000.0, 1073741824.0},
+				rc:      &quotaData{2, 20},
+				pvc:     &quotaData{1, 1},
+				secret:  &quotaData{11, 20},
+				svc:     &quotaData{2, 5},
 			},
 		},
 		{
@@ -406,13 +425,38 @@ func TestGetEnvironment(t *testing.T) {
 func verifyEnvironment(env *app.SimpleEnvironment, testCase *envTestData, t *testing.T) {
 	require.Equal(t, testCase.envName, *env.Attributes.Name, "Wrong environment name")
 
-	cpuQuota := env.Attributes.Quota.Cpucores
-	require.InDelta(t, testCase.cpuHard, *cpuQuota.Quota, fltDelta, "Incorrect CPU quota for %s", testCase.envName)
-	require.InDelta(t, testCase.cpuUsed, *cpuQuota.Used, fltDelta, "Incorrect CPU usage for %s", testCase.envName)
+	quotas := env.Attributes.Quota
+	require.NotNil(t, quotas, "Expected non-nil Quota attribute")
 
-	memQuota := env.Attributes.Quota.Memory
-	require.InDelta(t, testCase.memHard, *memQuota.Quota, fltDelta, "Incorrect memory quota for %s", testCase.envName)
-	require.InDelta(t, testCase.memUsed, *memQuota.Used, fltDelta, "Incorrect memory usage for %s", testCase.envName)
+	cpuQuota := quotas.Cpucores
+	require.NotNil(t, cpuQuota, "Expected CPU usage/limit in response")
+	require.InDelta(t, testCase.cpu.limit, *cpuQuota.Quota, fltDelta, "Incorrect CPU quota for %s", testCase.envName)
+	require.InDelta(t, testCase.cpu.used, *cpuQuota.Used, fltDelta, "Incorrect CPU usage for %s", testCase.envName)
+
+	memQuota := quotas.Memory
+	require.NotNil(t, cpuQuota, "Expected memory usage/limit in response")
+	require.InDelta(t, testCase.mem.limit, *memQuota.Quota, fltDelta, "Incorrect memory quota for %s", testCase.envName)
+	require.InDelta(t, testCase.mem.used, *memQuota.Used, fltDelta, "Incorrect memory usage for %s", testCase.envName)
+
+	verifyObjectQuota(quotas.Pods, testCase.pod, "pod", testCase.envName, t)
+	verifyObjectQuota(quotas.ReplicationControllers, testCase.rc, "replication controller", testCase.envName, t)
+	verifyObjectQuota(quotas.ResourceQuotas, testCase.quota, "resource quota", testCase.envName, t)
+	verifyObjectQuota(quotas.Services, testCase.svc, "service", testCase.envName, t)
+	verifyObjectQuota(quotas.Secrets, testCase.secret, "secret", testCase.envName, t)
+	verifyObjectQuota(quotas.ConfigMaps, testCase.cm, "config map", testCase.envName, t)
+	verifyObjectQuota(quotas.PersistentVolumeClaims, testCase.pvc, "persistent volume claim", testCase.envName, t)
+	verifyObjectQuota(quotas.ImageStreams, testCase.is, "image stream", testCase.envName, t)
+}
+
+func verifyObjectQuota(quota *app.EnvStatObjects, expected *quotaData, resourceName string,
+	envName string, t *testing.T) {
+	if expected == nil {
+		require.Nil(t, quota, "Unexpected %s usage/limit in response", resourceName)
+	} else {
+		require.NotNil(t, quota, "Expected %s usage/limit in response", resourceName)
+		require.InDelta(t, expected.limit, *quota.Quota, fltDelta, "Incorrect %s quota for %s", resourceName, envName)
+		require.InDelta(t, expected.used, *quota.Used, fltDelta, "Incorrect %s usage for %s", resourceName, envName)
+	}
 }
 
 type spaceTestData struct {

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -501,7 +501,7 @@ func verifyEnvironment(env *app.SimpleEnvironment, testCase *envTestData, t *tes
 	verifyObjectQuota(quotas.ImageStreams, testCase.is, "image stream", testCase.envName, t)
 }
 
-func verifyObjectQuota(quota *app.EnvStatObjects, expected *quotaData, resourceName string,
+func verifyObjectQuota(quota *app.EnvStatQuota, expected *quotaData, resourceName string,
 	envName string, t *testing.T) {
 	if expected == nil {
 		require.Nil(t, quota, "Unexpected %s usage/limit in response", resourceName)

--- a/test/kubernetes/getenvironment-all-objects.yaml
+++ b/test/kubernetes/getenvironment-all-objects.yaml
@@ -1,0 +1,105 @@
+---
+version: 1
+interactions:
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "name": "compute-resources",
+                        "namespace": "my-run",
+                        "resourceVersion": "1048952505",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
+                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "488m",
+                            "limits.memory": "250Mi"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-run",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
+                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                    },
+                    "spec": {
+                        "hard": {
+                            "pods": "40",
+                            "replicationcontrollers": "25",
+                            "resourcequotas": "3",
+                            "services": "5",
+                            "secrets": "20",
+                            "configmaps": "10",
+                            "persistentvolumeclaims": "1",
+                            "openshift.io/imagestreams": "15"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "pods": "40",
+                            "replicationcontrollers": "25",
+                            "resourcequotas": "3",
+                            "services": "5",
+                            "secrets": "20",
+                            "configmaps": "10",
+                            "persistentvolumeclaims": "1",
+                            "openshift.io/imagestreams": "15"
+                        },
+                        "used": {
+                            "pods": "31",
+                            "replicationcontrollers": "19",
+                            "resourcequotas": "2",
+                            "services": "4",
+                            "secrets": "17",
+                            "configmaps": "9",
+                            "persistentvolumeclaims": "0",
+                            "openshift.io/imagestreams": "14"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/getenvironment-no-compute.yaml
+++ b/test/kubernetes/getenvironment-no-compute.yaml
@@ -1,0 +1,62 @@
+---
+version: 1
+interactions:
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-run",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
+                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "2",
+                            "secrets": "11",
+                            "services": "2"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/getenvironment-no-cpu.yaml
+++ b/test/kubernetes/getenvironment-no-cpu.yaml
@@ -1,0 +1,90 @@
+---
+version: 1
+interactions:
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "name": "compute-resources",
+                        "namespace": "my-run",
+                        "resourceVersion": "1048952505",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
+                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.memory": "250Mi"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-run",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
+                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "2",
+                            "secrets": "11",
+                            "services": "2"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/getenvironment-no-mem.yaml
+++ b/test/kubernetes/getenvironment-no-mem.yaml
@@ -1,0 +1,90 @@
+---
+version: 1
+interactions:
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "name": "compute-resources",
+                        "namespace": "my-run",
+                        "resourceVersion": "1048952505",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
+                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2"
+                        },
+                        "used": {
+                            "limits.cpu": "488m"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-run",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
+                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "2",
+                            "secrets": "11",
+                            "services": "2"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/getenvironment-no-objects.yaml
+++ b/test/kubernetes/getenvironment-no-objects.yaml
@@ -1,0 +1,59 @@
+---
+version: 1
+interactions:
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "name": "compute-resources",
+                        "namespace": "my-run",
+                        "resourceVersion": "1048952505",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
+                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "488m",
+                            "limits.memory": "250Mi"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/getenvironments-rq-error.yaml
+++ b/test/kubernetes/getenvironments-rq-error.yaml
@@ -8,7 +8,7 @@ interactions:
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas/compute-resources
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
     method: GET
   response:
     body: |
@@ -17,12 +17,9 @@ interactions:
             "apiVersion": "v1",
             "metadata": {},
             "status": "Failure",
-            "message": "resourcequotas \"compute-resources\" not found",
+            "message": "the server doesn't have a resource type "resourcequota",
             "reason": "NotFound",
-            "details": {
-                "name": "compute-resources",
-                "kind": "resourcequotas"
-            },
+            "details": {},
             "code": 404
         }
     headers:
@@ -36,40 +33,83 @@ interactions:
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas/compute-resources
+    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas
     method: GET
   response:
     body: |
         {
             "apiVersion": "v1",
-            "kind": "ResourceQuota",
-            "metadata": {
-                "creationTimestamp": "2017-05-10T20:06:15Z",
-                "name": "compute-resources",
-                "namespace": "my-stage",
-                "resourceVersion": "1066766807",
-                "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
-                "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
-            },
-            "spec": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:15Z",
+                        "name": "compute-resources",
+                        "namespace": "my-stage",
+                        "resourceVersion": "1066766807",
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
+                        "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "1488m",
+                            "limits.memory": "762Mi"
+                        }
+                    }
                 },
-                "scopes": [
-                    "NotTerminating"
-                ]
-            },
-            "status": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
-                },
-                "used": {
-                    "limits.cpu": "1488m",
-                    "limits.memory": "762Mi"
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-stage",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/object-counts",
+                        "uid": "74ad59a6-3071-454b-a719-7c07a3a8e7df"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "5",
+                            "secrets": "9",
+                            "services": "2"
+                        }
+                    }
                 }
-            }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
         }
     headers:
       Content-Type:
@@ -82,40 +122,83 @@ interactions:
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas/compute-resources
+    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas
     method: GET
   response:
     body: |
         {
             "apiVersion": "v1",
-            "kind": "ResourceQuota",
-            "metadata": {
-                "creationTimestamp": "2017-05-10T20:06:06Z",
-                "name": "compute-resources",
-                "namespace": "myNamespace",
-                "resourceVersion": "682306837",
-                "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
-                "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
-            },
-            "spec": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "compute-resources",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "682306837",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
+                        "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "0",
+                            "limits.memory": "0"
+                        }
+                    }
                 },
-                "scopes": [
-                    "NotTerminating"
-                ]
-            },
-            "status": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
-                },
-                "used": {
-                    "limits.cpu": "0",
-                    "limits.memory": "0"
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/object-counts",
+                        "uid": "2928ac2c-d240-4582-a4fb-a0edf65c8069"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "1",
+                            "secrets": "12",
+                            "services": "1"
+                        }
+                    }
                 }
-            }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
         }
     headers:
       Content-Type:

--- a/test/kubernetes/getenvironments.yaml
+++ b/test/kubernetes/getenvironments.yaml
@@ -8,40 +8,83 @@ interactions:
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas/compute-resources
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
     method: GET
   response:
     body: |
         {
             "apiVersion": "v1",
-            "kind": "ResourceQuota",
-            "metadata": {
-                "creationTimestamp": "2017-05-10T20:06:14Z",
-                "name": "compute-resources",
-                "namespace": "my-run",
-                "resourceVersion": "1048952505",
-                "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
-                "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
-            },
-            "spec": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "name": "compute-resources",
+                        "namespace": "my-run",
+                        "resourceVersion": "1048952505",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
+                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "488m",
+                            "limits.memory": "250Mi"
+                        }
+                    }
                 },
-                "scopes": [
-                    "NotTerminating"
-                ]
-            },
-            "status": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
-                },
-                "used": {
-                    "limits.cpu": "488m",
-                    "limits.memory": "250Mi"
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-run",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
+                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "2",
+                            "secrets": "11",
+                            "services": "2"
+                        }
+                    }
                 }
-            }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
         }
     headers:
       Content-Type:
@@ -54,40 +97,83 @@ interactions:
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas/compute-resources
+    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas
     method: GET
   response:
     body: |
         {
             "apiVersion": "v1",
-            "kind": "ResourceQuota",
-            "metadata": {
-                "creationTimestamp": "2017-05-10T20:06:15Z",
-                "name": "compute-resources",
-                "namespace": "my-stage",
-                "resourceVersion": "1066766807",
-                "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
-                "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
-            },
-            "spec": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:15Z",
+                        "name": "compute-resources",
+                        "namespace": "my-stage",
+                        "resourceVersion": "1066766807",
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
+                        "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "1488m",
+                            "limits.memory": "762Mi"
+                        }
+                    }
                 },
-                "scopes": [
-                    "NotTerminating"
-                ]
-            },
-            "status": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
-                },
-                "used": {
-                    "limits.cpu": "1488m",
-                    "limits.memory": "762Mi"
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-stage",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/object-counts",
+                        "uid": "74ad59a6-3071-454b-a719-7c07a3a8e7df"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "5",
+                            "secrets": "9",
+                            "services": "2"
+                        }
+                    }
                 }
-            }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
         }
     headers:
       Content-Type:
@@ -100,40 +186,83 @@ interactions:
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas/compute-resources
+    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas
     method: GET
   response:
     body: |
         {
             "apiVersion": "v1",
-            "kind": "ResourceQuota",
-            "metadata": {
-                "creationTimestamp": "2017-05-10T20:06:06Z",
-                "name": "compute-resources",
-                "namespace": "myNamespace",
-                "resourceVersion": "682306837",
-                "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
-                "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
-            },
-            "spec": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "compute-resources",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "682306837",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
+                        "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "0",
+                            "limits.memory": "0"
+                        }
+                    }
                 },
-                "scopes": [
-                    "NotTerminating"
-                ]
-            },
-            "status": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
-                },
-                "used": {
-                    "limits.cpu": "0",
-                    "limits.memory": "0"
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/object-counts",
+                        "uid": "2928ac2c-d240-4582-a4fb-a0edf65c8069"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "1",
+                            "secrets": "12",
+                            "services": "1"
+                        }
+                    }
                 }
-            }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
         }
     headers:
       Content-Type:


### PR DESCRIPTION
Currently, the deployments page shows CPU and memory resource usage and limits for each environment. There are also quotas enforced for the number of certain types of objects in each namespace. Hitting these quotas can prevent further deployments to those environments, so this information is useful to show to the user.

This PR adds usage and limits, for each type of object that has an active quota, to the data returned by the ShowEnvironments API. After discussing the design with UX, we agreed to show only object types that have a quota set up. The possible object types are: pods, replication controllers, resource quotas, services, secrets, config maps, persistent volume claims, and image streams [1]. Currently, my OpenShift starter account has only quotas enabled for replication controllers, services, secrets and persistent volume claims.

Example response before changes:

`GET https://api.openshift.io/api/deployments/spaces/6d141162-f541-478d-ace9-509795057466/environments`
```json
{
  "data": [
    {
      "attributes": {
        "name": "run",
        "quota": {
          "cpucores": {
            "quota": 2,
            "used": 1.488
          },
          "memory": {
            "quota": 1073741824,
            "units": "bytes",
            "used": 799014912
          }
        }
      },
      "id": "",
      "type": "environment"
    },
    {
      "attributes": {
        "name": "stage",
        "quota": {
          "cpucores": {
            "quota": 2,
            "used": 1.488
          },
          "memory": {
            "quota": 1073741824,
            "units": "bytes",
            "used": 799014912
          }
        }
      },
      "id": "",
      "type": "environment"
    }
  ]
}
```

Example response after changes:

`GET https://api.openshift.io/api/deployments/spaces/6d141162-f541-478d-ace9-509795057466/environments`
```json
{
  "data": [
    {
      "attributes": {
        "name": "stage",
        "quota": {
          "cpucores": {
            "quota": 2,
            "used": 1.488
          },
          "memory": {
            "quota": 1073741824,
            "units": "bytes",
            "used": 799014912
          },
          "persistent_volume_claims": {
            "quota": 1,
            "used": 0
          },
          "replication_controllers": {
            "quota": 20,
            "used": 5
          },
          "secrets": {
            "quota": 20,
            "used": 9
          },
          "services": {
            "quota": 5,
            "used": 2
          }
        }
      },
      "id": "",
      "type": "environment"
    },
    {
      "attributes": {
        "name": "run",
        "quota": {
          "cpucores": {
            "quota": 2,
            "used": 1.488
          },
          "memory": {
            "quota": 1073741824,
            "units": "bytes",
            "used": 799014912
          },
          "persistent_volume_claims": {
            "quota": 1,
            "used": 0
          },
          "replication_controllers": {
            "quota": 20,
            "used": 5
          },
          "secrets": {
            "quota": 20,
            "used": 9
          },
          "services": {
            "quota": 5,
            "used": 2
          }
        }
      },
      "id": "",
      "type": "environment"
    }
  ]
}
```

Fixes: https://github.com/openshiftio/openshift.io/issues/2890

[1] https://docs.openshift.com/online/dev_guide/compute_resources.html#dev-managed-by-quota