### PR TITLE
Remove flow-heater container if it already exists

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -55,7 +55,9 @@ function prepare() {
   # Start "flow-heater" container to build in and run tests in.
   # Every make target that begins with "docker-" will be executed
   # in the resulting container.
+  make docker-rm
   make docker-start
+  
   make docker-check-go-format
   # Download Go dependencies
   make docker-deps


### PR DESCRIPTION
This prevents error messages like this one:

```
docker run \
    --detach=true \
    -t \
    -i \
    --name="fabric8-wit-local-build" \
    -v /root/payload:/tmp/go/src/github.com/fabric8-services/fabric8-wit:Z \
    -u 0:0 \
    -e GOPATH=/tmp/go \
    -w /tmp/go/src/github.com/fabric8-services/fabric8-wit \
    fabric8-wit
/usr/bin/docker-current: Error response from daemon: Conflict. The container name "/fabric8-wit-local-build" is already in use by container aef0c5eb4f38e45d2fb41df5d660da1057acf0bda90ccd35ec1ff938bf85a79d. You have to remove (or rename) that container to be able to reuse that name..
```

The `docker-rm` make target removes containers with the name `fabric8-wit-local-build` (if any) so that `docker-start` can run through without problems.