### PR TITLE
Revert "Remove flow-heater container if it already exists"

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -55,9 +55,7 @@ function prepare() {
   # Start "flow-heater" container to build in and run tests in.
   # Every make target that begins with "docker-" will be executed
   # in the resulting container.
-  make docker-rm
   make docker-start
-  
   make docker-check-go-format
   # Download Go dependencies
   make docker-deps


### PR DESCRIPTION
Reverts fabric8-services/fabric8-wit#2188

Because the root cause as described here might be two jobs assigned to the same container. https://github.com/openshiftio/openshift.io/issues/3838#issuecomment-399006019