### PR TITLE
Don't use same container for all builds

### DIFF
--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -8,7 +8,7 @@ else
 endif
 
 # If running in Jenkins we don't allow for interactively running the container
-ifneq ($(BUILD_TAG),)
+ifneq ($(BUILD_NUMBER),)
 	DOCKER_RUN_INTERACTIVE_SWITCH :=
 else
 	DOCKER_RUN_INTERACTIVE_SWITCH := -i
@@ -18,10 +18,10 @@ endif
 WORKSPACE ?= /tmp
 DOCKER_BUILD_DIR := $(WORKSPACE)/$(PROJECT_NAME)-build
 
-# The BUILD_TAG environment variable will be set by jenkins
+# The BUILD_NUMBER environment variable will be set by jenkins
 # to reflect jenkins-${JOB_NAME}-${BUILD_NUMBER}
-BUILD_TAG ?= $(PROJECT_NAME)-local-build
-DOCKER_CONTAINER_NAME := $(BUILD_TAG)
+BUILD_NUMBER ?= local-build
+DOCKER_CONTAINER_NAME := $(PROJECT_NAME)-$(BUILD_NUMBER)
 
 # Where is the GOPATH inside the build container?
 GOPATH_IN_CONTAINER=/tmp/go

--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -8,7 +8,7 @@ else
 endif
 
 # If running in Jenkins we don't allow for interactively running the container
-ifneq ($(BUILD_NUMBER),)
+ifneq ($(BUILD_TAG),)
 	DOCKER_RUN_INTERACTIVE_SWITCH :=
 else
 	DOCKER_RUN_INTERACTIVE_SWITCH := -i
@@ -18,10 +18,10 @@ endif
 WORKSPACE ?= /tmp
 DOCKER_BUILD_DIR := $(WORKSPACE)/$(PROJECT_NAME)-build
 
-# The BUILD_NUMBER environment variable will be set by jenkins
+# The BUILD_TAG environment variable will be set by jenkins
 # to reflect jenkins-${JOB_NAME}-${BUILD_NUMBER}
-BUILD_NUMBER ?= local-build
-DOCKER_CONTAINER_NAME := $(PROJECT_NAME)-$(BUILD_NUMBER)
+BUILD_TAG ?= $(PROJECT_NAME)-local-build
+DOCKER_CONTAINER_NAME := $(BUILD_TAG)
 
 # Where is the GOPATH inside the build container?
 GOPATH_IN_CONTAINER=/tmp/go

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -21,6 +21,7 @@ function load_jenkins_vars() {
               GIT_BRANCH \
               GIT_COMMIT \
               BUILD_NUMBER \
+              BUILD_TAG \
               ghprbSourceBranch \
               ghprbActualCommit \
               BUILD_URL \


### PR DESCRIPTION
Use `BUILD_TAG` (available in Jenkins environment) for docker container name.
For jenkins job 123, container name would be `jenkins-devtools-fabric8-wit-123` and for local build it would be `fabric8-wit-local-build`

see - https://github.com/openshiftio/openshift.io/issues/3838