### PR TITLE
Serve endpoints API under /api and fix missing URL schema for relationship links of endpoints

### DIFF
--- a/controller/endpoints.go
+++ b/controller/endpoints.go
@@ -81,28 +81,28 @@ func getEndpoints(ctx *app.ListEndpointsContext, fileHandler asseter) (*app.Endp
 	var result map[string]interface{}
 	err = json.Unmarshal(swaggerJSON, &result)
 	if err != nil {
-		return nil, errs.Wrapf(err, "unable to unmarshal the file with id "+"'"+embeddedSwaggerSpecFile+"'")
+		return nil, errs.Wrapf(err, `unable to unmarshal the file with id "%s"`, embeddedSwaggerSpecFile)
 	}
 
 	// Get and iterate over paths from swagger specification.
 	swaggerPaths, ok := result["paths"]
 	if !ok {
-		return nil, errors.NewInternalErrorFromString("field `paths` could be found in swagger specification")
+		return nil, errors.NewInternalErrorFromString(`failed to find field "paths" in swagger specification`)
 	}
 
 	swaggerPathz, ok := swaggerPaths.(map[string]interface{})
 	if !ok {
-		return nil, errors.NewInternalErrorFromString("unable to assert concrete type map for field `paths` in swagger specification")
+		return nil, errors.NewInternalErrorFromString(`unable to assert concrete type map for field "paths" in swagger specification`)
 	}
 
 	basePathObj, ok := result["basePath"]
 	if !ok {
-		return nil, errors.NewInternalErrorFromString("field `basePath` could be found in swagger specification")
+		return nil, errors.NewInternalErrorFromString(`failed to find field "basePath" in swagger specification`)
 	}
 
 	basePath, ok := basePathObj.(string)
 	if !ok {
-		return nil, errors.NewInternalErrorFromString("unable to assert concrete type string for field `basePath` in swagger specification")
+		return nil, errors.NewInternalErrorFromString(`unable to assert concrete type string for field "basePath" in swagger specification`)
 	}
 
 	absoluteBasePath := rest.AbsoluteURL(ctx.Request, basePath)

--- a/controller/endpoints.go
+++ b/controller/endpoints.go
@@ -135,10 +135,12 @@ func getEndpoints(ctx *app.ListEndpointsContext, fileHandler asseter) (*app.Endp
 			key = jsonapi.FormatMemberName(key)
 
 			// Set the related field and link objects for each name.
-			namedPaths[key] = map[string]interface{}{
-				"links": map[string]string{
-					"related": absoluteBasePath + path,
-				},
+			if key != "" {
+				namedPaths[key] = map[string]interface{}{
+					"links": map[string]string{
+						"related": absoluteBasePath + path,
+					},
+				}
 			}
 		}
 	}

--- a/controller/test-files/endpoints/list/ok.res.payload.golden.json
+++ b/controller/test-files/endpoints/list/ok.res.payload.golden.json
@@ -7,132 +7,132 @@
     "relationships": {
       "codebases_che_start": {
         "links": {
-          "related": "/codebases/che/start"
+          "related": "http:///api/codebases/che/start"
         }
       },
       "codebases_che_state": {
         "links": {
-          "related": "/codebases/che/state"
+          "related": "http:///api/codebases/che/state"
         }
       },
       "current_user": {
         "links": {
-          "related": "/user"
+          "related": "http:///api/user"
         }
       },
       "deployments_environments": {
         "links": {
-          "related": "/deployments/environments"
+          "related": "http:///api/deployments/environments"
         }
       },
       "endpoints": {
         "links": {
-          "related": "/endpoints"
+          "related": "http:///api/endpoints"
         }
       },
       "features": {
         "links": {
-          "related": "/features"
+          "related": "http:///api/features"
         }
       },
       "filters": {
         "links": {
-          "related": "/filters"
+          "related": "http:///api/filters"
         }
       },
       "login_authorize": {
         "links": {
-          "related": "/login/authorize"
+          "related": "http:///api/login/authorize"
         }
       },
       "login_generate": {
         "links": {
-          "related": "/login/generate"
+          "related": "http:///api/login/generate"
         }
       },
       "login_refresh": {
         "links": {
-          "related": "/login/refresh"
+          "related": "http:///api/login/refresh"
         }
       },
       "logout": {
         "links": {
-          "related": "/logout"
+          "related": "http:///api/logout"
         }
       },
       "render": {
         "links": {
-          "related": "/render"
+          "related": "http:///api/render"
         }
       },
       "search": {
         "links": {
-          "related": "/search"
+          "related": "http:///api/search"
         }
       },
       "search_codebases": {
         "links": {
-          "related": "/search/codebases"
+          "related": "http:///api/search/codebases"
         }
       },
       "search_spaces": {
         "links": {
-          "related": "/search/spaces"
+          "related": "http:///api/search/spaces"
         }
       },
       "search_users": {
         "links": {
-          "related": "/search/users"
+          "related": "http:///api/search/users"
         }
       },
       "spaces": {
         "links": {
-          "related": "/spaces"
+          "related": "http:///api/spaces"
         }
       },
       "spacetemplates": {
         "links": {
-          "related": "/spacetemplates"
+          "related": "http:///api/spacetemplates"
         }
       },
       "status": {
         "links": {
-          "related": "/status"
+          "related": "http:///api/status"
         }
       },
       "trackerqueries": {
         "links": {
-          "related": "/trackerqueries"
+          "related": "http:///api/trackerqueries"
         }
       },
       "trackers": {
         "links": {
-          "related": "/trackers"
+          "related": "http:///api/trackers"
         }
       },
       "user_services": {
         "links": {
-          "related": "/user/services"
+          "related": "http:///api/user/services"
         }
       },
       "users": {
         "links": {
-          "related": "/users"
+          "related": "http:///api/users"
         }
       },
       "userspace": {
         "links": {
-          "related": "/userspace/*"
+          "related": "http:///api/userspace/*"
         }
       },
       "workitemlinkcategories": {
         "links": {
-          "related": "/workitemlinkcategories"
+          "related": "http:///api/workitemlinkcategories"
         }
       },
       "workitemlinks": {
         "links": {
-          "related": "/workitemlinks"
+          "related": "http:///api/workitemlinks"
         }
       }
     },

--- a/design/endpoints.go
+++ b/design/endpoints.go
@@ -27,7 +27,7 @@ var _ = a.Resource("endpoints", func() {
 		a.Routing(
 			a.GET(""),
 		)
-		a.Description("List all endpoints. ")
+		a.Description("List all endpoints.")
 		a.Response(d.OK, endpointsSingle)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)

--- a/main.go
+++ b/main.go
@@ -414,6 +414,9 @@ func main() {
 	log.Logger().Infoln("GOMAXPROCS:     ", runtime.GOMAXPROCS(-1))
 	log.Logger().Infoln("NumCPU:         ", runtime.NumCPU())
 
+	// Make the endpoints available under /api as well
+	http.Handle("/api", http.RedirectHandler("/api/endpoints", http.StatusTemporaryRedirect))
+
 	http.Handle("/api/", service.Mux)
 	http.Handle("/favicon.ico", http.NotFoundHandler())
 


### PR DESCRIPTION
With this PR the endpoints (see #521) are served under `/api` and each endpoint relationship link has a proper URL-schema prefix.

The `/api` temporarily redirects to `/api/endpoints`.

Co-authored-by: Konrad Kleine 193408+kwk@users.noreply.github.com