### PR TITLE
Codebase can search git@github... type codebase URLs

### DIFF
--- a/controller/json_api_compliance_test.go
+++ b/controller/json_api_compliance_test.go
@@ -81,14 +81,14 @@ func (s *JSONComplianceTestSuite) TestSearchCodebases() {
 		fxt := tf.NewTestFixture(s.T(), s.DB,
 			tf.Identities(1, tf.SetIdentityUsernames("spaceowner")),
 			tf.Codebases(2, func(fxt *tf.TestFixture, idx int) error {
-				fxt.Codebases[idx].URL = fmt.Sprintf("http://foo.com/single/%d", idx)
+				fxt.Codebases[idx].URL = fmt.Sprintf("https://foo.com/single/%d", idx)
 				return nil
 			}),
 		)
 		svc := NewService(*fxt.Identities[0])
 		searchCtrl := NewSearchController(svc, s.GormDB, s.Configuration)
 		// when
-		_, codebaseList := test.CodebasesSearchOK(t, nil, svc, searchCtrl, nil, nil, "http://foo.com/single/0")
+		_, codebaseList := test.CodebasesSearchOK(t, nil, svc, searchCtrl, nil, nil, "https://foo.com/single/0")
 		// then
 		s.Validate(codebaseList)
 	})
@@ -99,15 +99,15 @@ func (s *JSONComplianceTestSuite) TestSearchCodebases() {
 			tf.Identities(1, tf.SetIdentityUsernames("spaceowner")),
 			tf.Spaces(2),
 			tf.Codebases(2, func(fxt *tf.TestFixture, idx int) error {
-				fxt.Codebases[idx].URL = fmt.Sprintf("http://foo.com/multi/0") // both codebases have the same URL...
-				fxt.Codebases[idx].SpaceID = fxt.Spaces[idx].ID                // ... but they belong to different spaces
+				fxt.Codebases[idx].URL = fmt.Sprintf("https://foo.com/multi/0") // both codebases have the same URL...
+				fxt.Codebases[idx].SpaceID = fxt.Spaces[idx].ID                 // ... but they belong to different spaces
 				return nil
 			}),
 		)
 		svc := NewService(*fxt.Identities[0])
 		searchCtrl := NewSearchController(svc, s.GormDB, s.Configuration)
 		// when
-		_, codebaseList := test.CodebasesSearchOK(t, nil, svc, searchCtrl, nil, nil, "http://foo.com/multi/0")
+		_, codebaseList := test.CodebasesSearchOK(t, nil, svc, searchCtrl, nil, nil, "https://foo.com/multi/0")
 		// then
 		// then
 		s.Validate(codebaseList)

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -1395,11 +1395,11 @@ func (s *searchControllerTestSuite) TestSearchCodebases() {
 		tf.NewTestFixture(s.T(), s.DB,
 			tf.Identities(1, tf.SetIdentityUsernames("spaceowner")),
 			tf.Codebases(2, func(fxt *tf.TestFixture, idx int) error {
-				fxt.Codebases[idx].URL = fmt.Sprintf("http://foo.com/single/%d", idx)
+				fxt.Codebases[idx].URL = fmt.Sprintf("https://foo.com/single/%d", idx)
 				return nil
 			}),
 		) // when
-		_, codebaseList := test.CodebasesSearchOK(t, nil, nil, s.controller, nil, nil, "http://foo.com/single/0")
+		_, codebaseList := test.CodebasesSearchOK(t, nil, nil, s.controller, nil, nil, "https://foo.com/single/0")
 		// then
 		require.NotNil(t, codebaseList)
 		require.NotNil(t, codebaseList.Data)
@@ -1414,12 +1414,12 @@ func (s *searchControllerTestSuite) TestSearchCodebases() {
 			tf.Identities(1, tf.SetIdentityUsernames("spaceowner")),
 			tf.Spaces(count),
 			tf.Codebases(count, func(fxt *tf.TestFixture, idx int) error {
-				fxt.Codebases[idx].URL = fmt.Sprintf("http://foo.com/multi/0") // both codebases have the same URL...
-				fxt.Codebases[idx].SpaceID = fxt.Spaces[idx].ID                // ... but they belong to different spaces
+				fxt.Codebases[idx].URL = fmt.Sprintf("https://foo.com/multi/0") // both codebases have the same URL...
+				fxt.Codebases[idx].SpaceID = fxt.Spaces[idx].ID                 // ... but they belong to different spaces
 				return nil
 			}),
 		) // when
-		_, codebaseList := test.CodebasesSearchOK(t, nil, nil, s.controller, nil, nil, "http://foo.com/multi/0")
+		_, codebaseList := test.CodebasesSearchOK(t, nil, nil, s.controller, nil, nil, "https://foo.com/multi/0")
 		// then
 		require.NotNil(t, codebaseList)
 		require.NotNil(t, codebaseList.Data)
@@ -1431,6 +1431,27 @@ func (s *searchControllerTestSuite) TestSearchCodebases() {
 		// for included spaces, we must sort the spaces by their ID
 		sort.Sort(SortableIncludedSpacesByID(codebaseList.Included))
 		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_multi_match.json"), codebaseList)
+	})
+
+	s.T().Run("codebase with git@github.com", func(t *testing.T) {
+		// this is saved in database
+		savedURL := "https://github.com/USERNAME/REPOSITORY.git"
+		tf.NewTestFixture(t, s.DB,
+			tf.Codebases(1, func(fxt *tf.TestFixture, idx int) error {
+				fxt.Codebases[idx].URL = savedURL
+				return nil
+			}),
+		)
+
+		// when this URL is queried we should get what is in database
+		queryURL := "git@github.com:USERNAME/REPOSITORY.git"
+		_, codebaseList := test.CodebasesSearchOK(t, nil, nil, s.controller, nil, nil, queryURL)
+		// then
+		require.NotNil(t, codebaseList)
+		require.NotNil(t, codebaseList.Data)
+		require.Len(t, codebaseList.Data, 1)
+		require.Equal(t, savedURL, *codebaseList.Data[0].Attributes.URL)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "search_codebase_git_url.json"), codebaseList)
 	})
 }
 

--- a/controller/search_test.go
+++ b/controller/search_test.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_convertGithubURL(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		arg     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid url with git",
+			arg:     "git@github.com:USERNAME/REPOSITORY.git",
+			want:    "https://github.com/USERNAME/REPOSITORY.git",
+			wantErr: false,
+		},
+		{
+			name:    "valid url with https",
+			arg:     "https://github.com/USERNAME/REPOSITORY.git",
+			want:    "https://github.com/USERNAME/REPOSITORY.git",
+			wantErr: false,
+		},
+		{
+			name:    "invalid url without git at the end",
+			arg:     "git@github.com:USERNAME/REPOSITORY",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertGithubURL(tt.arg)
+			if tt.wantErr {
+				require.Error(t, err)
+				t.Logf("convertGithubURL() failed with error = %v", err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/controller/test-files/search/search_codebase_git_url.json
+++ b/controller/test-files/search/search_codebase_git_url.json
@@ -7,7 +7,7 @@
         "last_used_workspace": "my-used-last-workspace",
         "stackId": "golang-default",
         "type": "git",
-        "url": "https://foo.com/single/0"
+        "url": "https://github.com/USERNAME/REPOSITORY.git"
       },
       "id": "00000000-0000-0000-0000-000000000001",
       "links": {
@@ -136,8 +136,8 @@
     }
   ],
   "links": {
-    "first": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=https://foo.com/single/0",
-    "last": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=https://foo.com/single/0"
+    "first": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=git@github.com:USERNAME/REPOSITORY.git",
+    "last": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=git@github.com:USERNAME/REPOSITORY.git"
   },
   "meta": {
     "totalCount": 1

--- a/controller/test-files/search/search_codebase_per_url_multi_match.json
+++ b/controller/test-files/search/search_codebase_per_url_multi_match.json
@@ -7,7 +7,7 @@
         "last_used_workspace": "my-used-last-workspace",
         "stackId": "golang-default",
         "type": "git",
-        "url": "http://foo.com/multi/0"
+        "url": "https://foo.com/multi/0"
       },
       "id": "00000000-0000-0000-0000-000000000001",
       "links": {
@@ -42,7 +42,7 @@
         "last_used_workspace": "my-used-last-workspace",
         "stackId": "golang-default",
         "type": "git",
-        "url": "http://foo.com/multi/0"
+        "url": "https://foo.com/multi/0"
       },
       "id": "00000000-0000-0000-0000-000000000003",
       "links": {
@@ -77,7 +77,7 @@
         "last_used_workspace": "my-used-last-workspace",
         "stackId": "golang-default",
         "type": "git",
-        "url": "http://foo.com/multi/0"
+        "url": "https://foo.com/multi/0"
       },
       "id": "00000000-0000-0000-0000-000000000005",
       "links": {
@@ -112,7 +112,7 @@
         "last_used_workspace": "my-used-last-workspace",
         "stackId": "golang-default",
         "type": "git",
-        "url": "http://foo.com/multi/0"
+        "url": "https://foo.com/multi/0"
       },
       "id": "00000000-0000-0000-0000-000000000007",
       "links": {
@@ -147,7 +147,7 @@
         "last_used_workspace": "my-used-last-workspace",
         "stackId": "golang-default",
         "type": "git",
-        "url": "http://foo.com/multi/0"
+        "url": "https://foo.com/multi/0"
       },
       "id": "00000000-0000-0000-0000-000000000009",
       "links": {
@@ -664,8 +664,8 @@
     }
   ],
   "links": {
-    "first": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=http://foo.com/multi/0",
-    "last": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=http://foo.com/multi/0"
+    "first": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=https://foo.com/multi/0",
+    "last": "http:///api/search/codebases?page[offset]=0\u0026page[limit]=20\u0026url=https://foo.com/multi/0"
   },
   "meta": {
     "totalCount": 5


### PR DESCRIPTION
All the URLs that have git@github.com:USERNAME/REPOSITORY.git
cannot be searched on wit because the URLs added to wit are of the
format https://github.com/USERNAME/REPOSITORY.git

While at build time the URL that is sent to the analytics service is of
the format 'git@github' and when this is plainly queried nothing is
found.

So this commit converts the URL of the format 'git@github...' to the
'https://github...', before search.
