### PR TITLE
event cleanup (code)

### DIFF
--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -474,6 +474,21 @@ func getBranch(projects []che.WorkspaceProject, codebaseURL string) string {
 	return ""
 }
 
+// ConvertCodebaseSimple converts a simple codebase ID into a Generic Relationship
+func ConvertCodebaseSimple(request *http.Request, id interface{}) (*app.GenericData, *app.GenericLinks) {
+	i := fmt.Sprint(id)
+	data := &app.GenericData{
+		Type: ptr.String(APIStringTypeCodebase),
+		ID:   &i,
+	}
+	relatedURL := rest.AbsoluteURL(request, app.CodebaseHref(i))
+	links := &app.GenericLinks{
+		Self:    &relatedURL,
+		Related: &relatedURL,
+	}
+	return data, links
+}
+
 // ConvertCodebase converts between internal and external REST representation
 func ConvertCodebase(request *http.Request, codebase codebase.Codebase, options ...CodebaseConvertFunc) *app.Codebase {
 	relatedURL := rest.AbsoluteURL(request, app.CodebaseHref(codebase.ID))

--- a/controller/label.go
+++ b/controller/label.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/label"
 	"github.com/fabric8-services/fabric8-wit/login"
+	"github.com/fabric8-services/fabric8-wit/ptr"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/space"
 	"github.com/goadesign/goa"
@@ -164,10 +165,9 @@ func ConvertLabelsSimple(request *http.Request, labelIDs []interface{}) []*app.G
 
 // ConvertLabelSimple converts a Label ID into a Generic Relationship
 func ConvertLabelSimple(request *http.Request, labelID interface{}) *app.GenericData {
-	t := label.APIStringTypeLabels
 	i := fmt.Sprint(labelID)
 	return &app.GenericData{
-		Type: &t,
+		Type: ptr.String(label.APIStringTypeLabels),
 		ID:   &i,
 	}
 }

--- a/controller/test-files/event/list/ok-area.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-area.res.payload.golden.json
@@ -3,8 +3,6 @@
     {
       "attributes": {
         "name": "system.area",
-        "newValue": null,
-        "oldValue": null,
         "timestamp": "0001-01-01T00:00:00Z"
       },
       "id": "00000000-0000-0000-0000-000000000001",
@@ -27,13 +25,14 @@
             }
           ]
         },
-        "oldValue": {
-          "data": [
-            {
-              "id": "",
-              "type": "areas"
-            }
-          ]
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000004"
+          }
         }
       },
       "type": "events"

--- a/controller/test-files/event/list/ok-assignees.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-assignees.res.payload.golden.json
@@ -3,8 +3,6 @@
     {
       "attributes": {
         "name": "system.assignees",
-        "newValue": null,
-        "oldValue": null,
         "timestamp": "0001-01-01T00:00:00Z"
       },
       "id": "00000000-0000-0000-0000-000000000001",
@@ -27,7 +25,15 @@
             }
           ]
         },
-        "oldValue": {}
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
       },
       "type": "events"
     }

--- a/controller/test-files/event/list/ok-description.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-description.res.payload.golden.json
@@ -3,8 +3,10 @@
     {
       "attributes": {
         "name": "system.description",
-        "newValue": null,
-        "oldValue": null,
+        "newValue": {
+          "content": "# Description is modified1",
+          "markup": "Markdown"
+        },
         "timestamp": "0001-01-01T00:00:00Z"
       },
       "id": "00000000-0000-0000-0000-000000000001",
@@ -17,6 +19,15 @@
           "links": {
             "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
             "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
           }
         }
       },

--- a/controller/test-files/event/list/ok-iteration.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-iteration.res.payload.golden.json
@@ -3,8 +3,6 @@
     {
       "attributes": {
         "name": "system.iteration",
-        "newValue": null,
-        "oldValue": null,
         "timestamp": "0001-01-01T00:00:00Z"
       },
       "id": "00000000-0000-0000-0000-000000000001",
@@ -27,13 +25,14 @@
             }
           ]
         },
-        "oldValue": {
-          "data": [
-            {
-              "id": "",
-              "type": "iterations"
-            }
-          ]
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000004"
+          }
         }
       },
       "type": "events"

--- a/controller/test-files/event/list/ok-kindFloat.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-kindFloat.res.payload.golden.json
@@ -3,8 +3,8 @@
     {
       "attributes": {
         "name": "myFloatType",
-        "newValue": "2.99",
-        "oldValue": "1.99",
+        "newValue": 2.99,
+        "oldValue": 1.99,
         "timestamp": "0001-01-01T00:00:00Z"
       },
       "id": "00000000-0000-0000-0000-000000000001",
@@ -17,6 +17,15 @@
           "links": {
             "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
             "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
           }
         }
       },

--- a/controller/test-files/event/list/ok-kindInt.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-kindInt.res.payload.golden.json
@@ -3,8 +3,8 @@
     {
       "attributes": {
         "name": "myIntType",
-        "newValue": "4235",
-        "oldValue": "200",
+        "newValue": 4235,
+        "oldValue": 200,
         "timestamp": "0001-01-01T00:00:00Z"
       },
       "id": "00000000-0000-0000-0000-000000000001",
@@ -17,6 +17,15 @@
           "links": {
             "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
             "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
           }
         }
       },

--- a/controller/test-files/event/list/ok-labels.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-labels.res.payload.golden.json
@@ -3,8 +3,6 @@
     {
       "attributes": {
         "name": "system.labels",
-        "newValue": null,
-        "oldValue": null,
         "timestamp": "0001-01-01T00:00:00Z"
       },
       "id": "00000000-0000-0000-0000-000000000001",
@@ -31,7 +29,15 @@
             }
           ]
         },
-        "oldValue": {}
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000005",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000005"
+          }
+        }
       },
       "type": "events"
     }

--- a/controller/test-files/event/list/ok-state.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-state.res.payload.golden.json
@@ -18,6 +18,15 @@
             "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
             "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
           }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
         }
       },
       "type": "events"

--- a/controller/test-files/event/list/ok-title.res.payload.golden.json
+++ b/controller/test-files/event/list/ok-title.res.payload.golden.json
@@ -18,6 +18,15 @@
             "related": "http:///api/users/00000000-0000-0000-0000-000000000003",
             "self": "http:///api/users/00000000-0000-0000-0000-000000000003"
           }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000004"
+          }
         }
       },
       "type": "events"

--- a/controller/test-files/event/list/ok.bool_list.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.bool_list.res.payload.golden.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "bool_list",
+        "newValue": [
+          true,
+          false
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "bool_list",
+        "newValue": [
+          false,
+          true
+        ],
+        "oldValue": [
+          true,
+          false
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.bool_single.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.bool_single.res.payload.golden.json
@@ -1,0 +1,65 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "bool_single",
+        "newValue": true,
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "bool_single",
+        "newValue": false,
+        "oldValue": true,
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.float_list.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.float_list.res.payload.golden.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "float_list",
+        "newValue": [
+          0.1,
+          -1111.1
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "float_list",
+        "newValue": [
+          -1111.1,
+          0.1
+        ],
+        "oldValue": [
+          0.1,
+          -1111.1
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.float_single.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.float_single.res.payload.golden.json
@@ -1,0 +1,65 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "float_single",
+        "newValue": 0.1,
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "float_single",
+        "newValue": -1111.1,
+        "oldValue": 0.1,
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.integer_list.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.integer_list.res.payload.golden.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "integer_list",
+        "newValue": [
+          0,
+          333
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "integer_list",
+        "newValue": [
+          333,
+          0
+        ],
+        "oldValue": [
+          0,
+          333
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.integer_single.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.integer_single.res.payload.golden.json
@@ -1,0 +1,65 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "integer_single",
+        "newValue": 0,
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "integer_single",
+        "newValue": 333,
+        "oldValue": 0,
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.markup_list.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.markup_list.res.payload.golden.json
@@ -1,0 +1,92 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "markup_list",
+        "newValue": [
+          {
+            "content": "plain text",
+            "markup": "PlainText"
+          },
+          {
+            "content": "default",
+            "markup": "PlainText"
+          }
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "markup_list",
+        "newValue": [
+          {
+            "content": "default",
+            "markup": "PlainText"
+          },
+          {
+            "content": "plain text",
+            "markup": "PlainText"
+          }
+        ],
+        "oldValue": [
+          {
+            "content": "plain text",
+            "markup": "PlainText"
+          },
+          {
+            "content": "default",
+            "markup": "PlainText"
+          }
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.markup_single.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.markup_single.res.payload.golden.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "markup_single",
+        "newValue": {
+          "content": "plain text",
+          "markup": "PlainText"
+        },
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "markup_single",
+        "newValue": {
+          "content": "default",
+          "markup": "PlainText"
+        },
+        "oldValue": {
+          "content": "plain text",
+          "markup": "PlainText"
+        },
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.string_list.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.string_list.res.payload.golden.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "string_list",
+        "newValue": [
+          "foo",
+          "bar"
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "string_list",
+        "newValue": [
+          "bar",
+          "foo"
+        ],
+        "oldValue": [
+          "foo",
+          "bar"
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.string_single.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.string_single.res.payload.golden.json
@@ -1,0 +1,65 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "string_single",
+        "newValue": "foo",
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "string_single",
+        "newValue": "bar",
+        "oldValue": "foo",
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.url_list.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.url_list.res.payload.golden.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "url_list",
+        "newValue": [
+          "127.0.0.1",
+          "http://www.openshift.io"
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "url_list",
+        "newValue": [
+          "http://www.openshift.io",
+          "127.0.0.1"
+        ],
+        "oldValue": [
+          "127.0.0.1",
+          "http://www.openshift.io"
+        ],
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/test-files/event/list/ok.url_single.res.payload.golden.json
+++ b/controller/test-files/event/list/ok.url_single.res.payload.golden.json
@@ -1,0 +1,65 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "url_single",
+        "newValue": "127.0.0.1",
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000001",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    },
+    {
+      "attributes": {
+        "name": "url_single",
+        "newValue": "http://www.openshift.io",
+        "oldValue": "127.0.0.1",
+        "timestamp": "0001-01-01T00:00:00Z"
+      },
+      "id": "00000000-0000-0000-0000-000000000004",
+      "relationships": {
+        "modifier": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "users"
+          },
+          "links": {
+            "related": "http:///api/users/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/users/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "workItemType": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "workitemtypes"
+          },
+          "links": {
+            "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+          }
+        }
+      },
+      "type": "events"
+    }
+  ]
+}

--- a/controller/work_item_events.go
+++ b/controller/work_item_events.go
@@ -187,7 +187,7 @@ func ConvertEvent(ctx context.Context, appl application.Application, req *http.R
 	}
 	arrNew, ok := wiEvent.New.([]interface{})
 	if !ok {
-		return nil, errs.Errorf("failed to convert old value of field \"%s\" to []interface{}: %+v", fieldName, wiEvent.Old)
+		return nil, errs.Errorf("failed to convert new value of field \"%s\" to []interface{}: %+v", fieldName, wiEvent.New)
 	}
 
 	for i, v := range arrOld {

--- a/controller/work_item_events.go
+++ b/controller/work_item_events.go
@@ -99,9 +99,9 @@ func ConvertEvent(ctx context.Context, appl application.Application, req *http.R
 					Self: ptr.String(rest.AbsoluteURL(req, app.WorkitemtypeHref(wit.ID))),
 				},
 				Data: &app.GenericData{
-					ID: ptr.String(wit.ID.String()),
+					ID:   ptr.String(wit.ID.String()),
 					Type: ptr.String(APIStringTypeWorkItemType),
-				}
+				},
 			},
 		},
 	}
@@ -151,7 +151,7 @@ func ConvertEvent(ctx context.Context, appl application.Application, req *http.R
 	// handle all single value fields (including enums)
 	if kind != workitem.KindList {
 		oldVal, useRel := convertVal(kind, wiEvent.Old)
-		newVal, _ := convertVal(kind, wiEvent.New)		
+		newVal, _ := convertVal(kind, wiEvent.New)
 		if useRel {
 			e.Relationships.OldValue = &app.RelationGenericList{
 				Data: []*app.GenericData{

--- a/controller/work_item_events.go
+++ b/controller/work_item_events.go
@@ -168,8 +168,12 @@ func ConvertEvent(ctx context.Context, appl application.Application, req *http.R
 				e.Relationships.NewValue = &app.RelationGenericList{Data: []*app.GenericData{newVal.(*app.GenericData)}}
 			}
 		} else {
-			e.Attributes.OldValue = &oldVal
-			e.Attributes.NewValue = &newVal
+			if oldVal != nil {
+				e.Attributes.OldValue = &oldVal
+			}
+			if newVal != nil {
+				e.Attributes.NewValue = &newVal
+			}
 		}
 		return &e, nil
 	}
@@ -223,5 +227,6 @@ func ConvertEvent(ctx context.Context, appl application.Application, req *http.R
 			(*e.Attributes.NewValue).([]interface{})[i] = newVal
 		}
 	}
+
 	return &e, nil
 }

--- a/controller/work_item_events.go
+++ b/controller/work_item_events.go
@@ -153,15 +153,11 @@ func ConvertEvent(ctx context.Context, appl application.Application, req *http.R
 		oldVal, useRel := convertVal(kind, wiEvent.Old)
 		newVal, _ := convertVal(kind, wiEvent.New)
 		if useRel {
-			e.Relationships.OldValue = &app.RelationGenericList{
-				Data: []*app.GenericData{
-					oldVal.(*app.GenericData),
-				},
+			if wiEvent.Old != nil {
+				e.Relationships.OldValue = &app.RelationGenericList{Data: []*app.GenericData{oldVal.(*app.GenericData)}}
 			}
-			e.Relationships.NewValue = &app.RelationGenericList{
-				Data: []*app.GenericData{
-					newVal.(*app.GenericData),
-				},
+			if wiEvent.New != nil {
+				e.Relationships.NewValue = &app.RelationGenericList{Data: []*app.GenericData{newVal.(*app.GenericData)}}
 			}
 		} else {
 			e.Attributes.OldValue = &oldVal

--- a/controller/work_item_events.go
+++ b/controller/work_item_events.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/application"
+	"github.com/fabric8-services/fabric8-wit/jsonapi"
 	"github.com/fabric8-services/fabric8-wit/ptr"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/workitem"
@@ -44,11 +45,15 @@ func (c *EventsController) List(ctx *app.ListWorkItemEventsContext) error {
 		return errs.Wrap(err, "list events model failed")
 	})
 
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
 	var convertedEvents []*app.Event
 	return ctx.ConditionalEntities(eventList, c.config.GetCacheControlEvents, func() error {
 		convertedEvents, err = ConvertEvents(ctx, c.db, ctx.Request, eventList, ctx.WiID)
 		if err != nil {
-			return errs.Wrapf(err, "failed to convert events")
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "failed to convert events"))
 		}
 		return ctx.OK(&app.EventList{
 			Data: convertedEvents,

--- a/controller/work_item_events.go
+++ b/controller/work_item_events.go
@@ -111,6 +111,9 @@ func ConvertEvent(ctx context.Context, appl application.Application, req *http.R
 		},
 	}
 
+	// convertVal returns the given value converted from storage space to
+	// JSONAPI space. If the given value is supposed to be stored as a
+	// relationship in JSONAPI, the second return value will be true.
 	convertVal := func(kind workitem.Kind, val interface{}) (interface{}, bool) {
 		switch kind {
 		case workitem.KindString,

--- a/controller/work_item_events_test.go
+++ b/controller/work_item_events_test.go
@@ -511,11 +511,17 @@ func (s *TestEvent) TestListEvent() {
 						},
 					},
 				}
+				// update work item once
 				test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[0].ID, &payload)
+				// update it twice
+				payload.Data.Attributes[workitem.SystemVersion] = fxt.WorkItems[0].Version + 1
+				payload.Data.Attributes[fieldNameSingle] = testData[kind].Valid[1]
+				test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[0].ID, &payload)
+
 				res, eventList := test.ListWorkItemEventsOK(t, svc.Context, svc, EventCtrl, fxt.WorkItems[0].ID, nil, nil)
 				safeOverriteHeader(t, res, app.ETag, "1GmclFDDPcLR1ZWPZnykWw==")
 				require.NotEmpty(t, eventList)
-				require.Len(t, eventList.Data, 1)
+				require.Len(t, eventList.Data, 2)
 				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameSingle+".res.payload.golden.json"), eventList)
 				// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameSingle+".res.headers.golden.json"), res.Header())
 			})
@@ -540,11 +546,16 @@ func (s *TestEvent) TestListEvent() {
 						},
 					},
 				}
+				// update work item once
+				test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[1].ID, &payload)
+				// update it twice
+				payload.Data.Attributes[workitem.SystemVersion] = fxt.WorkItems[1].Version + 1
+				payload.Data.Attributes[fieldNameList] = []interface{}{testData[kind].Valid[1], testData[kind].Valid[0]}
 				test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[1].ID, &payload)
 				res, eventList := test.ListWorkItemEventsOK(t, svc.Context, svc, EventCtrl, fxt.WorkItems[1].ID, nil, nil)
 				safeOverriteHeader(t, res, app.ETag, "1GmclFDDPcLR1ZWPZnykWw==")
 				require.NotEmpty(t, eventList)
-				require.Len(t, eventList.Data, 1)
+				require.Len(t, eventList.Data, 2)
 				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameList+".res.payload.golden.json"), eventList)
 				// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameList+".res.headers.golden.json"), res.Header())
 			})
@@ -576,11 +587,16 @@ func (s *TestEvent) TestListEvent() {
 			// 			},
 			// 		},
 			// 	}
-			// 	test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[2].ID, &payload)
+			// // update work item once
+			// test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[2].ID, &payload)
+			// // update it twice
+			// payload.Data.Attributes[workitem.SystemVersion] = fxt.WorkItems[2].Version + 1
+			// payload.Data.Attributes[fieldNameEnum] = testData[kind].Valid[1]
+			// test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[2].ID, &payload)
 			// 	res, eventList := test.ListWorkItemEventsOK(t, svc.Context, svc, EventCtrl, fxt.WorkItems[2].ID, nil, nil)
 			// 	safeOverriteHeader(t, res, app.ETag, "1GmclFDDPcLR1ZWPZnykWw==")
 			// 	require.NotEmpty(t, eventList)
-			// 	require.Len(t, eventList.Data, 1)
+			// 	require.Len(t, eventList.Data, 2)
 			// 	compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameEnum+".res.payload.golden.json"), eventList)
 			// 	// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameEnum+".res.headers.golden.json"), res.Header())
 			// })

--- a/controller/work_item_events_test.go
+++ b/controller/work_item_events_test.go
@@ -443,6 +443,7 @@ func (s *TestEvent) TestListEvent() {
 
 			fieldNameSingle := kind.String() + "_single"
 			fieldNameList := kind.String() + "_list"
+			// NOTE(kwk): Leave this commented out until we have proper test data
 			// fieldNameEnum := kind.String() + "_enum"
 
 			fxt := tf.NewTestFixture(t, s.DB,
@@ -464,6 +465,7 @@ func (s *TestEvent) TestListEvent() {
 								ComponentType: workitem.SimpleType{Kind: kind},
 							},
 						}
+						// NOTE(kwk): Leave this commented out until we have proper test data
 						// case 3:
 						// fxt.WorkItemTypes[idx].Fields[fieldNameEnum] = workitem.FieldDefinition{
 						// 	Label:       fieldNameEnum,
@@ -521,7 +523,6 @@ func (s *TestEvent) TestListEvent() {
 				require.NotEmpty(t, eventList)
 				require.Len(t, eventList.Data, 2)
 				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameSingle+".res.payload.golden.json"), eventList)
-				// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameSingle+".res.headers.golden.json"), res.Header())
 			})
 			t.Run(fieldNameList, func(t *testing.T) {
 				// NOTE(kwk): Leave this commented out until we have proper test data
@@ -555,9 +556,8 @@ func (s *TestEvent) TestListEvent() {
 				require.NotEmpty(t, eventList)
 				require.Len(t, eventList.Data, 2)
 				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameList+".res.payload.golden.json"), eventList)
-				// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameList+".res.headers.golden.json"), res.Header())
 			})
-
+			// NOTE(kwk): Leave this commented out until we have proper test data
 			// TODO(kwk): Once the new type system enhancements are in, also
 			// test for enum fields here.
 

--- a/controller/work_item_events_test.go
+++ b/controller/work_item_events_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/fabric8-services/fabric8-wit/controller"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/label"
+	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/rest"
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
@@ -38,7 +39,7 @@ func (s *TestEvent) SetupTest() {
 func (s *TestEvent) TestListEvent() {
 
 	s.T().Run("event list ok - state", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		workitemCtrl := NewWorkitemController(svc, s.GormDB, s.Configuration)
@@ -66,7 +67,7 @@ func (s *TestEvent) TestListEvent() {
 	})
 
 	s.T().Run("event list ok - title", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		workitemCtrl := NewWorkitemController(svc, s.GormDB, s.Configuration)
@@ -186,18 +187,25 @@ func (s *TestEvent) TestListEvent() {
 	})
 
 	s.T().Run("event list ok - description", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		workitemCtrl := NewWorkitemController(svc, s.GormDB, s.Configuration)
 		spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(fxt.Spaces[0].ID.String()))
+
+		modifiedDescription := "# Description is modified1"
+		modifiedRenderedDescription := "<h1>Description is modified1</h1>\n"
+		modifiedMarkup := rendering.SystemMarkupMarkdown
+
 		payload := app.UpdateWorkitemPayload{
 			Data: &app.WorkItem{
 				Type: APIStringTypeWorkItem,
 				ID:   &fxt.WorkItems[0].ID,
 				Attributes: map[string]interface{}{
-					workitem.SystemDescription: "New Description",
-					workitem.SystemVersion:     fxt.WorkItems[0].Version,
+					workitem.SystemDescription:         modifiedDescription,
+					workitem.SystemDescriptionRendered: modifiedRenderedDescription,
+					workitem.SystemDescriptionMarkup:   modifiedMarkup,
+					workitem.SystemVersion:             fxt.WorkItems[0].Version,
 				},
 				Relationships: &app.WorkItemRelationships{
 					Space: app.NewSpaceRelation(fxt.Spaces[0].ID, spaceSelfURL),
@@ -214,7 +222,7 @@ func (s *TestEvent) TestListEvent() {
 	})
 
 	s.T().Run("event list ok - assigned", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		assignee := []string{fxt.Identities[0].ID.String()}
@@ -288,7 +296,7 @@ func (s *TestEvent) TestListEvent() {
 	})
 
 	s.T().Run("event list ok - iteration", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		workitemCtrl := NewWorkitemController(svc, s.GormDB, s.Configuration)
@@ -316,7 +324,7 @@ func (s *TestEvent) TestListEvent() {
 	})
 
 	s.T().Run("event list ok - area", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		workitemCtrl := NewWorkitemController(svc, s.GormDB, s.Configuration)
@@ -344,7 +352,7 @@ func (s *TestEvent) TestListEvent() {
 	})
 
 	s.T().Run("event list - empty", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		res, eventList := test.ListWorkItemEventsOK(t, svc.Context, svc, EventCtrl, fxt.WorkItems[0].ID, nil, nil)
@@ -354,7 +362,7 @@ func (s *TestEvent) TestListEvent() {
 	})
 
 	s.T().Run("many events", func(t *testing.T) {
-		fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1), tf.Iterations(2))
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1), tf.Iterations(2))
 		svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
 		EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
 		workitemCtrl := NewWorkitemController(svc, s.GormDB, s.Configuration)
@@ -415,5 +423,159 @@ func (s *TestEvent) TestListEvent() {
 		safeOverriteHeader(t, res, app.ETag, "1GmclFDDPcLR1ZWPZnykWw==")
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList.Data, 3)
+	})
+
+	s.T().Run("non-relational field kinds", func(t *testing.T) {
+		testData := workitem.GetFieldTypeTestData(t)
+		for _, kind := range testData.GetKinds() {
+			if !kind.IsSimpleType() || kind.IsRelational() {
+				continue
+			}
+
+			// TODO(kwk): Once we got rid of the duration kind remove this skip
+			if kind == workitem.KindDuration {
+				continue
+			}
+
+			// TODO(kwk): Once the new type system enhancements are in, also
+			// test instant fields
+			if kind == workitem.KindInstant {
+				continue
+			}
+
+			fieldNameSingle := kind.String() + "_single"
+			fieldNameList := kind.String() + "_list"
+			// fieldNameEnum := kind.String() + "_enum"
+
+			fxt := tf.NewTestFixture(t, s.DB,
+				tf.CreateWorkItemEnvironment(),
+				tf.WorkItems(1),
+				tf.WorkItemTypes(1, func(fxt *tf.TestFixture, idx int) error {
+					fxt.WorkItemTypes[idx].Fields[fieldNameSingle] = workitem.FieldDefinition{
+						Label:       fieldNameSingle,
+						Description: "A single value of a " + kind.String() + " object",
+						Type:        workitem.SimpleType{Kind: kind},
+					}
+					fxt.WorkItemTypes[idx].Fields[fieldNameList] = workitem.FieldDefinition{
+						Label:       fieldNameList,
+						Description: "An array of " + kind.String() + " objects",
+						Type: workitem.ListType{
+							SimpleType:    workitem.SimpleType{Kind: workitem.KindList},
+							ComponentType: workitem.SimpleType{Kind: kind},
+						},
+					}
+					// fxt.WorkItemTypes[idx].Fields[fieldNameEnum] = workitem.FieldDefinition{
+					// 	Label:       fieldNameEnum,
+					// 	Description: "An enum value of a " + kind.String() + " object",
+					// 	Type: workitem.EnumType{
+					// 		SimpleType: workitem.SimpleType{Kind: workitem.KindEnum},
+					// 		BaseType:   workitem.SimpleType{Kind: kind},
+					// 		Values: []interface{}{
+					// 			testData[kind].Valid[0],
+					// 			testData[kind].Valid[1],
+					// 		},
+					// 	},
+					// }
+					return nil
+				}),
+			)
+			svc := testsupport.ServiceAsSpaceUser("Event-Service", *fxt.Identities[0], &TestSpaceAuthzService{*fxt.Identities[0], ""})
+			EventCtrl := NewEventsController(svc, s.GormDB, s.Configuration)
+			workitemCtrl := NewWorkitemController(svc, s.GormDB, s.Configuration)
+			spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(fxt.Spaces[0].ID.String()))
+
+			t.Run(fieldNameSingle, func(t *testing.T) {
+				// NOTE(kwk): Leave this commented out until we have proper test data
+				// fieldDef := fxt.WorkItemTypes[0].Fields[fieldNameSingle]
+				// val, err := fieldDef.ConvertFromModel(fieldNameSingle, testData[kind].Valid[0])
+				// require.NoError(t, err)
+				newValue := testData[kind].Valid[0]
+				payload := app.UpdateWorkitemPayload{
+					Data: &app.WorkItem{
+						Type: APIStringTypeWorkItem,
+						ID:   &fxt.WorkItems[0].ID,
+						Attributes: map[string]interface{}{
+							fieldNameSingle:        newValue,
+							workitem.SystemVersion: fxt.WorkItems[0].Version,
+						},
+						Relationships: &app.WorkItemRelationships{
+							Space: app.NewSpaceRelation(fxt.Spaces[0].ID, spaceSelfURL),
+						},
+					},
+				}
+				test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[0].ID, &payload)
+				res, eventList := test.ListWorkItemEventsOK(t, svc.Context, svc, EventCtrl, fxt.WorkItems[0].ID, nil, nil)
+				safeOverriteHeader(t, res, app.ETag, "1GmclFDDPcLR1ZWPZnykWw==")
+				require.NotEmpty(t, eventList)
+				require.Len(t, eventList.Data, 1)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameSingle+".res.payload.golden.json"), eventList)
+				// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameSingle+".res.headers.golden.json"), res.Header())
+			})
+			t.Run(fieldNameList, func(t *testing.T) {
+				// NOTE(kwk): Leave this commented out until we have proper test data
+				// listDef := fxt.WorkItemTypes[0].Fields[fieldNameList]
+				// fieldDef, ok := listDef.Type.(workitem.ListType)
+				// require.True(t, ok, "failed to cast %+v (%[1]T) to workitem.ListType", listDef)
+				// vals, err := fieldDef.ConvertFromModel([]interface{}{testData[kind].Valid[0], testData[kind].Valid[1]})
+				// require.NoError(t, err)
+				newValue := []interface{}{testData[kind].Valid[0], testData[kind].Valid[1]}
+				payload := app.UpdateWorkitemPayload{
+					Data: &app.WorkItem{
+						Type: APIStringTypeWorkItem,
+						ID:   &fxt.WorkItems[0].ID,
+						Attributes: map[string]interface{}{
+							fieldNameList:          newValue,
+							workitem.SystemVersion: fxt.WorkItems[0].Version + 1,
+						},
+						Relationships: &app.WorkItemRelationships{
+							Space: app.NewSpaceRelation(fxt.Spaces[0].ID, spaceSelfURL),
+						},
+					},
+				}
+				test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[0].ID, &payload)
+				res, eventList := test.ListWorkItemEventsOK(t, svc.Context, svc, EventCtrl, fxt.WorkItems[0].ID, nil, nil)
+				safeOverriteHeader(t, res, app.ETag, "1GmclFDDPcLR1ZWPZnykWw==")
+				require.NotEmpty(t, eventList)
+				require.Len(t, eventList.Data, 2)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameList+".res.payload.golden.json"), eventList)
+				// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameList+".res.headers.golden.json"), res.Header())
+			})
+
+			// TODO(kwk): Once the new type system enhancements are in, also
+			// test for enum fields here.
+
+			// t.Run(fieldNameEnum, func(t *testing.T) {
+			// 	// NOTE(kwk): Leave this commented out until we have proper test data
+			// 	// listDef := fxt.WorkItemTypes[0].Fields[fieldNameEnum]
+			// 	// fieldDef, ok := listDef.Type.(workitem.EnumType)
+			// 	// require.True(t, ok, "failed to cast %+v (%[1]T) to workitem.EnumType", listDef)
+			// 	// val, err := fieldDef.ConvertFromModel(testData[kind].Valid[0])
+			// 	// require.NoError(t, err)
+
+			// 	// we have to use the second value because we default to the
+			// 	// first one upon creation of the work item.
+			// 	newValue := testData[kind].Valid[1]
+			// 	payload := app.UpdateWorkitemPayload{
+			// 		Data: &app.WorkItem{
+			// 			Type: APIStringTypeWorkItem,
+			// 			ID:   &fxt.WorkItems[0].ID,
+			// 			Attributes: map[string]interface{}{
+			// 				fieldNameEnum:          newValue,
+			// 				workitem.SystemVersion: fxt.WorkItems[0].Version + 2,
+			// 			},
+			// 			Relationships: &app.WorkItemRelationships{
+			// 				Space: app.NewSpaceRelation(fxt.Spaces[0].ID, spaceSelfURL),
+			// 			},
+			// 		},
+			// 	}
+			// 	test.UpdateWorkitemOK(t, svc.Context, svc, workitemCtrl, fxt.WorkItems[0].ID, &payload)
+			// 	res, eventList := test.ListWorkItemEventsOK(t, svc.Context, svc, EventCtrl, fxt.WorkItems[0].ID, nil, nil)
+			// 	safeOverriteHeader(t, res, app.ETag, "1GmclFDDPcLR1ZWPZnykWw==")
+			// 	require.NotEmpty(t, eventList)
+			// 	require.Len(t, eventList.Data, 3)
+			// 	compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameEnum+".res.payload.golden.json"), eventList)
+			// 	// compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok."+fieldNameEnum+".res.headers.golden.json"), res.Header())
+			// })
+		}
 	})
 }

--- a/controller/work_item_events_test.go
+++ b/controller/work_item_events_test.go
@@ -194,7 +194,6 @@ func (s *TestEvent) TestListEvent() {
 		spaceSelfURL := rest.AbsoluteURL(&http.Request{Host: "api.service.domain.org"}, app.SpaceHref(fxt.Spaces[0].ID.String()))
 
 		modifiedDescription := "# Description is modified1"
-		modifiedRenderedDescription := "<h1>Description is modified1</h1>\n"
 		modifiedMarkup := rendering.SystemMarkupMarkdown
 
 		payload := app.UpdateWorkitemPayload{
@@ -202,10 +201,9 @@ func (s *TestEvent) TestListEvent() {
 				Type: APIStringTypeWorkItem,
 				ID:   &fxt.WorkItems[0].ID,
 				Attributes: map[string]interface{}{
-					workitem.SystemDescription:         modifiedDescription,
-					workitem.SystemDescriptionRendered: modifiedRenderedDescription,
-					workitem.SystemDescriptionMarkup:   modifiedMarkup,
-					workitem.SystemVersion:             fxt.WorkItems[0].Version,
+					workitem.SystemDescription:       modifiedDescription,
+					workitem.SystemDescriptionMarkup: modifiedMarkup,
+					workitem.SystemVersion:           fxt.WorkItems[0].Version,
 				},
 				Relationships: &app.WorkItemRelationships{
 					Space: app.NewSpaceRelation(fxt.Spaces[0].ID, spaceSelfURL),

--- a/design/work_item_event.go
+++ b/design/work_item_event.go
@@ -13,12 +13,10 @@ var event = a.Type("Event", func() {
 	a.Attribute("id", d.UUID, "ID of event", func() {
 		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
 	})
-	a.Attribute("attributes", a.HashOf(d.String, d.Any), func() {
-		a.Example(map[string]interface{}{"version": "1", "system.state": "new", "system.title": "Example story"})
-	})
+	a.Attribute("attributes", eventAttributes)
 	a.Attribute("relationships", eventRelationships)
 	a.Attribute("links", genericLinks)
-	a.Required("type")
+	a.Required("type", "relationships", "attributes", "id")
 })
 
 var eventAttributes = a.Type("EventAttributes", func() {
@@ -27,12 +25,12 @@ var eventAttributes = a.Type("EventAttributes", func() {
 		a.Example("2016-11-29T23:18:14Z")
 	})
 	a.Attribute("name", d.String, "The name of the event occured", func() {
-		a.Example("closed")
+		a.Example("system.title")
 	})
-	a.Attribute("oldValue", d.String, "The user who was assigned to (or unassigned from). Only for 'assigned' and 'unassigned' events.", func() {
+	a.Attribute("oldValue", d.Any, "The user who was assigned to (or unassigned from). Only for 'assigned' and 'unassigned' events.", func() {
 		a.Example("813a456e-1c8a-48df-ac15-84065ee039f7")
 	})
-	a.Attribute("newValue", d.String, "The user who performed the assignment (or unassignment). Only for 'assigned' and 'unassigned' events..", func() {
+	a.Attribute("newValue", d.Any, "The user who performed the assignment (or unassignment). Only for 'assigned' and 'unassigned' events..", func() {
 		a.Example("813a456e-1c8a-48df-ac15-84065ee039f7")
 	})
 	a.Required("timestamp", "name")
@@ -42,6 +40,9 @@ var eventRelationships = a.Type("EventRelations", func() {
 	a.Attribute("modifier", relationGeneric, "This defines the modifier of the event")
 	a.Attribute("oldValue", relationGenericList)
 	a.Attribute("newValue", relationGenericList)
+	a.Attribute("workItemType", relationGeneric, "The type of the work item at the event's point in time")
+
+	a.Required("workItemType", "modifier")
 })
 
 var eventList = JSONList(

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -63,7 +63,7 @@ func (t EnumType) ConvertToModel(value interface{}) (interface{}, error) {
 	}
 
 	if !contains(t.Values, converted) {
-		return nil, fmt.Errorf("not an enum value: %v", value)
+		return nil, fmt.Errorf("value: %+v (%[1]T) is not part of allowed enum values: %+v", value, t.Values)
 	}
 	return converted, nil
 }

--- a/workitem/event/event.go
+++ b/workitem/event/event.go
@@ -8,12 +8,13 @@ import (
 
 // Event represents work item event
 type Event struct {
-	ID        uuid.UUID
-	Name      string
-	Timestamp time.Time
-	Modifier  uuid.UUID
-	Old       interface{}
-	New       interface{}
+	ID             uuid.UUID
+	Name           string
+	WorkItemTypeID uuid.UUID
+	Timestamp      time.Time
+	Modifier       uuid.UUID
+	Old            interface{}
+	New            interface{}
 }
 
 // GetETagData returns the field values to use to generate the ETag

--- a/workitem/event/event_repository.go
+++ b/workitem/event/event_repository.go
@@ -2,7 +2,6 @@ package event
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/jinzhu/gorm"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/errors"
-	"github.com/fabric8-services/fabric8-wit/rendering"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 )
 
@@ -48,181 +46,124 @@ type GormEventRepository struct {
 func (r *GormEventRepository) List(ctx context.Context, wiID uuid.UUID) ([]Event, error) {
 	revisionList, err := r.wiRevisionRepo.List(ctx, wiID)
 	if err != nil {
-		return nil, errs.Wrapf(err, "error during fetching event list")
+		return nil, errs.Wrapf(err, "failed to list revisions for work item: %s", wiID)
 	}
 	if revisionList == nil {
 		return []Event{}, nil
 	}
-	wi, err := r.workItemRepo.LoadByID(ctx, wiID)
-	if err != nil {
-		return nil, errs.Wrapf(err, "error during fetching event list")
-	}
-	wiType, err := r.workItemTypeRepo.Load(ctx, wi.Type)
-	if err != nil {
-		return nil, errs.Wrapf(err, "error during fetching event list")
+	if err = r.workItemRepo.CheckExists(ctx, wiID); err != nil {
+		return nil, errs.Wrapf(err, "failed to find work item: %s", wiID)
 	}
 
 	eventList := []Event{}
 	for k := 1; k < len(revisionList); k++ {
-		modifierID, err := r.identityRepo.Load(ctx, revisionList[k].ModifierIdentity)
-		if err != nil {
-			return nil, errs.Wrapf(err, "error during fetching event list")
+
+		oldRev := revisionList[k-1]
+		newRev := revisionList[k]
+
+		// If the new and old work item type are different, we're skipping this
+		// revision because it denotes the change of a work item type.
+		//
+		// TODO(kwk): make sure we have a proper "changed work item type"
+		// revision entry in one way or another.
+		if oldRev.WorkItemTypeID != newRev.WorkItemTypeID {
+			continue
 		}
-		for fieldName, field := range wiType.Fields {
-			switch fieldType := field.Type.(type) {
+
+		wit, err := r.workItemTypeRepo.Load(ctx, oldRev.WorkItemTypeID)
+		if err != nil {
+			return nil, errs.Wrapf(err, "failed to load old work item type: %s", oldRev.WorkItemTypeID)
+		}
+
+		modifierID, err := r.identityRepo.Load(ctx, newRev.ModifierIdentity)
+		if err != nil {
+			return nil, errs.Wrapf(err, "failed to load modifier identity %s", newRev.ModifierIdentity)
+		}
+
+		for fieldName, fieldDef := range wit.Fields {
+
+			oldVal := oldRev.WorkItemFields[fieldName]
+			newVal := newRev.WorkItemFields[fieldName]
+
+			event := Event{
+				ID:             newRev.ID,
+				Name:           fieldName,
+				WorkItemTypeID: newRev.WorkItemTypeID,
+				Timestamp:      newRev.Time,
+				Modifier:       modifierID.ID,
+				Old:            oldVal,
+				New:            newVal,
+			}
+
+			// The enum type can be handled by the simple type since it's just a
+			// single value after all.
+			ft := fieldDef.Type
+			enumType, isEnumType := ft.(workitem.EnumType)
+			if isEnumType {
+				ft = enumType.BaseType
+			}
+
+			switch fieldType := ft.(type) {
 			case workitem.ListType:
-				switch fieldType.ComponentType.Kind {
-				case workitem.KindLabel, workitem.KindUser, workitem.KindBoardColumn:
-					var p []interface{}
-					var n []interface{}
+				var p, n []interface{}
+				var ok bool
 
-					previousValues := revisionList[k-1].WorkItemFields[fieldName]
-					newValues := revisionList[k].WorkItemFields[fieldName]
-					switch previousValues.(type) {
-					case nil:
-						p = []interface{}{}
-					case []interface{}:
-						for _, v := range previousValues.([]interface{}) {
-							p = append(p, v)
-						}
-					}
-
-					switch newValues.(type) {
-					case nil:
-						n = []interface{}{}
-					case []interface{}:
-						for _, v := range newValues.([]interface{}) {
-							n = append(n, v)
-						}
-
-					}
-
-					// Avoid duplicate entries for empty labels or assignees
-					if reflect.DeepEqual(p, n) == false {
-						wie := Event{
-							ID:        revisionList[k].ID,
-							Name:      fieldName,
-							Timestamp: revisionList[k].Time,
-							Modifier:  modifierID.ID,
-							Old:       p,
-							New:       n,
-						}
-						eventList = append(eventList, wie)
-					}
-				default:
-					return nil, errors.NewNotFoundError("Unknown field:", fieldName)
-				}
-			case workitem.EnumType:
-				var p string
-				var n string
-
-				previousValue := revisionList[k-1].WorkItemFields[fieldName]
-				newValue := revisionList[k].WorkItemFields[fieldName]
-
-				switch previousValue.(type) {
+				switch t := oldVal.(type) {
 				case nil:
-					p = ""
-				case interface{}:
-					p, _ = previousValue.(string)
-				}
-
-				switch newValue.(type) {
-				case nil:
-					n = ""
-				case interface{}:
-					n, _ = newValue.(string)
-
-				}
-				if p != n {
-					wie := Event{
-						ID:        revisionList[k].ID,
-						Name:      fieldName,
-						Timestamp: revisionList[k].Time,
-						Modifier:  modifierID.ID,
-						Old:       p,
-						New:       n,
+					p = []interface{}{}
+				case []interface{}:
+					converted, err := fieldType.ConvertFromModel(t)
+					if err != nil {
+						return nil, errs.Wrapf(err, "failed to convert old value for field %s from storage representation: %+v", fieldName, t)
 					}
-					eventList = append(eventList, wie)
+					p, ok = converted.([]interface{})
+					if !ok {
+						return nil, errs.Errorf("failed to convert old value for field %s from to []interface{}: %+v", fieldName, t)
+					}
+				}
+
+				switch t := newVal.(type) {
+				case nil:
+					n = []interface{}{}
+				case []interface{}:
+					converted, err := fieldType.ConvertFromModel(t)
+					if err != nil {
+						return nil, errs.Wrapf(err, "failed to convert new value for field %s from storage representation: %+v", fieldName, t)
+					}
+					n, ok = converted.([]interface{})
+					if !ok {
+						return nil, errs.Errorf("failed to convert new value for field %s from to []interface{}: %+v", fieldName, t)
+					}
+				}
+
+				// Avoid duplicate entries for empty labels or assignees, etc.
+				if !reflect.DeepEqual(p, n) {
+					event.Old = p
+					event.New = n
+					eventList = append(eventList, event)
 				}
 			case workitem.SimpleType:
-				switch fieldType.Kind {
-				case workitem.KindMarkup:
-					var p string
-					var n string
+				// compensate conversion from storage if this really was an enum field
+				converter := fieldType.ConvertFromModel
+				if isEnumType {
+					converter = enumType.ConvertFromModel
+				}
 
-					previousValue := revisionList[k-1].WorkItemFields[fieldName]
-					newValue := revisionList[k].WorkItemFields[fieldName]
-
-					switch previousValue.(type) {
-					case nil:
-						p = ""
-					case map[string]interface{}:
-						pv := rendering.NewMarkupContentFromMap(previousValue.(map[string]interface{}))
-						p = pv.Content
-					}
-
-					switch newValue.(type) {
-					case nil:
-						n = ""
-					case map[string]interface{}:
-						nv := rendering.NewMarkupContentFromMap(newValue.(map[string]interface{}))
-						n = nv.Content
-
-					}
-
-					if p != n {
-						wie := Event{
-							ID:        revisionList[k].ID,
-							Name:      fieldName,
-							Timestamp: revisionList[k].Time,
-							Modifier:  modifierID.ID,
-							Old:       p,
-							New:       n,
-						}
-						eventList = append(eventList, wie)
-					}
-				case workitem.KindString, workitem.KindIteration, workitem.KindArea, workitem.KindFloat, workitem.KindInteger:
-					var p string
-					var n string
-
-					previousValue := revisionList[k-1].WorkItemFields[fieldName]
-					newValue := revisionList[k].WorkItemFields[fieldName]
-
-					switch v := previousValue.(type) {
-					case nil:
-						p = ""
-					case float32, float64, int:
-						p = fmt.Sprintf("%g", previousValue)
-					case string:
-						p = v
-					default:
-						return nil, errors.NewConversionError("Failed to convert")
-					}
-
-					switch v := newValue.(type) {
-					case nil:
-						n = ""
-					case float32, float64, int:
-						n = fmt.Sprintf("%g", newValue)
-					case string:
-						n = v
-					default:
-						return nil, errors.NewConversionError("Failed to convert")
-					}
-					if p != n {
-						wie := Event{
-							ID:        revisionList[k].ID,
-							Name:      fieldName,
-							Timestamp: revisionList[k].Time,
-							Modifier:  modifierID.ID,
-							Old:       p,
-							New:       n,
-						}
-						eventList = append(eventList, wie)
-					}
+				p, err := converter(oldVal)
+				if err != nil {
+					return nil, errs.Wrapf(err, "failed to convert old value for field %s from storage representation: %+v", fieldName, oldVal)
+				}
+				n, err := converter(newVal)
+				if err != nil {
+					return nil, errs.Wrapf(err, "failed to convert new value for field %s from storage representation: %+v", fieldName, newVal)
+				}
+				if !reflect.DeepEqual(p, n) {
+					event.Old = p
+					event.New = n
+					eventList = append(eventList, event)
 				}
 			default:
-				return nil, errors.NewNotFoundError("Unknown field:", fieldName)
+				return nil, errors.NewNotFoundError("unknown field type", fieldType.GetKind().String())
 			}
 		}
 	}

--- a/workitem/event/event_repository_blackbox_test.go
+++ b/workitem/event/event_repository_blackbox_test.go
@@ -1,7 +1,6 @@
 package event_test
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
@@ -10,6 +9,7 @@ import (
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/fabric8-services/fabric8-wit/workitem/event"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -59,7 +59,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemAssignees)
+		assert.Equal(t, workitem.SystemAssignees, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
 		assert.Equal(t, fxt.Identities[0].ID.String(), eventList[0].New.([]interface{})[0])
 
@@ -72,7 +72,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		eventList, err = s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 2)
-		assert.Equal(t, eventList[1].Name, workitem.SystemAssignees)
+		assert.Equal(t, workitem.SystemAssignees, eventList[1].Name)
 		assert.NotEmpty(t, eventList[1].Old)
 		assert.NotEmpty(t, eventList[1].New)
 		assert.Equal(t, fxt.Identities[0].ID.String(), eventList[0].New.([]interface{})[0])
@@ -93,7 +93,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemAssignees)
+		assert.Equal(t, workitem.SystemAssignees, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
 		assert.Equal(t, fxt.Identities[0].ID.String(), eventList[0].New.([]interface{})[0])
 	})
@@ -112,9 +112,9 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		require.Equal(t, "description1", eventList[0].Old)
-		require.Equal(t, "description2", eventList[0].New)
-		require.Equal(t, wiNew.Fields[workitem.SystemDescription], newDescription)
+		require.Equal(t, oldDescription, eventList[0].Old)
+		require.Equal(t, newDescription, eventList[0].New)
+		require.Equal(t, newDescription, wiNew.Fields[workitem.SystemDescription])
 	})
 
 	s.T().Run("event assignee - new assignee nil", func(t *testing.T) {
@@ -130,7 +130,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemAssignees)
+		assert.Equal(t, workitem.SystemAssignees, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
 		assert.Equal(t, fxt.Identities[0].ID.String(), eventList[0].New.([]interface{})[0])
 
@@ -142,7 +142,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		eventList, err = s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 2)
-		assert.Equal(t, eventList[1].Name, workitem.SystemAssignees)
+		assert.Equal(t, workitem.SystemAssignees, eventList[1].Name)
 		assert.Empty(t, eventList[1].New)
 	})
 
@@ -159,7 +159,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemAssignees)
+		assert.Equal(t, workitem.SystemAssignees, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
 		assert.Equal(t, fxt.Identities[0].ID.String(), eventList[0].New.([]interface{})[0])
 
@@ -171,7 +171,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		eventList, err = s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 2)
-		assert.Equal(t, eventList[1].Name, workitem.SystemAssignees)
+		assert.Equal(t, workitem.SystemAssignees, eventList[1].Name)
 		assert.Equal(t, fxt.Identities[1].ID.String(), eventList[1].New.([]interface{})[0])
 	})
 
@@ -185,7 +185,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemState)
+		assert.Equal(t, workitem.SystemState, eventList[0].Name)
 		assert.Equal(t, workitem.SystemStateResolved, eventList[0].New)
 	})
 
@@ -193,9 +193,10 @@ func (s *eventRepoBlackBoxTest) TestList() {
 
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItems(1))
 
-		label := []string{"label1"}
+		labelID1 := uuid.NewV4()
+		labels := []string{labelID1.String()}
 
-		fxt.WorkItems[0].Fields[workitem.SystemLabels] = label
+		fxt.WorkItems[0].Fields[workitem.SystemLabels] = labels
 		wiNew, err := s.wiRepo.Save(s.Ctx, fxt.WorkItems[0].SpaceID, *fxt.WorkItems[0], fxt.Identities[0].ID)
 		require.NoError(t, err)
 		require.Len(t, wiNew.Fields[workitem.SystemLabels].([]interface{}), 1)
@@ -203,12 +204,13 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemLabels)
+		assert.Equal(t, workitem.SystemLabels, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
-		assert.Equal(t, "label1", eventList[0].New.([]interface{})[0])
+		assert.Equal(t, labelID1.String(), eventList[0].New.([]interface{})[0])
 
-		label = []string{"label2"}
-		wiNew.Fields[workitem.SystemLabels] = label
+		labelID2 := uuid.NewV4()
+		labels = []string{labelID2.String()}
+		wiNew.Fields[workitem.SystemLabels] = labels
 		wiNew.Version = fxt.WorkItems[0].Version + 1
 		wiNew, err = s.wiRepo.Save(s.Ctx, fxt.WorkItems[0].SpaceID, *wiNew, fxt.Identities[0].ID)
 		require.NoError(t, err)
@@ -216,20 +218,21 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		eventList, err = s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 2)
-		assert.Equal(t, eventList[1].Name, workitem.SystemLabels)
+		assert.Equal(t, workitem.SystemLabels, eventList[1].Name)
 		assert.NotEmpty(t, eventList[1].Old)
 		assert.NotEmpty(t, eventList[1].New)
-		assert.Equal(t, "label1", eventList[0].New.([]interface{})[0])
-		assert.Equal(t, "label2", eventList[1].New.([]interface{})[0])
+		assert.Equal(t, labelID1.String(), eventList[0].New.([]interface{})[0])
+		assert.Equal(t, labelID2.String(), eventList[1].New.([]interface{})[0])
 	})
 
 	s.T().Run("event label - previous label nil", func(t *testing.T) {
 
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItems(1))
 
-		label := []string{"label1"}
+		labelID1 := uuid.NewV4()
+		labels := []string{labelID1.String()}
 
-		fxt.WorkItems[0].Fields[workitem.SystemLabels] = label
+		fxt.WorkItems[0].Fields[workitem.SystemLabels] = labels
 		wiNew, err := s.wiRepo.Save(s.Ctx, fxt.WorkItems[0].SpaceID, *fxt.WorkItems[0], fxt.Identities[0].ID)
 		require.NoError(t, err)
 		require.Len(t, wiNew.Fields[workitem.SystemLabels].([]interface{}), 1)
@@ -237,7 +240,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemLabels)
+		assert.Equal(t, workitem.SystemLabels, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
 	})
 
@@ -245,9 +248,10 @@ func (s *eventRepoBlackBoxTest) TestList() {
 
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItems(1))
 
-		label := []string{"label1"}
+		labelID1 := uuid.NewV4()
+		labels := []string{labelID1.String()}
 
-		fxt.WorkItems[0].Fields[workitem.SystemLabels] = label
+		fxt.WorkItems[0].Fields[workitem.SystemLabels] = labels
 		wiNew, err := s.wiRepo.Save(s.Ctx, fxt.WorkItems[0].SpaceID, *fxt.WorkItems[0], fxt.Identities[0].ID)
 		require.NoError(t, err)
 		require.Len(t, wiNew.Fields[workitem.SystemLabels].([]interface{}), 1)
@@ -255,7 +259,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemLabels)
+		assert.Equal(t, workitem.SystemLabels, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
 
 		wiNew.Fields[workitem.SystemLabels] = []string{}
@@ -266,7 +270,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		eventList, err = s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 2)
-		assert.Equal(t, eventList[1].Name, workitem.SystemLabels)
+		assert.Equal(t, workitem.SystemLabels, eventList[1].Name)
 		assert.Empty(t, eventList[1].New)
 	})
 
@@ -280,7 +284,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		assert.Equal(t, eventList[0].Name, workitem.SystemIteration)
+		assert.Equal(t, workitem.SystemIteration, eventList[0].Name)
 		assert.Empty(t, eventList[0].Old)
 
 		wiNew.Fields[workitem.SystemIteration] = fxt.Iterations[1].ID.String()
@@ -289,7 +293,7 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		eventList, err = s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 		require.Len(t, eventList, 2)
-		assert.Equal(t, eventList[1].Name, workitem.SystemIteration)
+		assert.Equal(t, workitem.SystemIteration, eventList[1].Name)
 	})
 
 	s.T().Run("Field with Kind", func(t *testing.T) {
@@ -317,13 +321,9 @@ func (s *eventRepoBlackBoxTest) TestList() {
 			require.NoError(t, err)
 			eventList, err := s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 			require.Len(t, eventList, 1)
-			assert.Equal(t, eventList[0].Name, fieldName)
-			oldStr, _ := eventList[0].Old.(string)
-			old, _ := strconv.ParseFloat(oldStr, 64)
-			assert.Equal(t, old, initialValue)
-			newStr, _ := eventList[0].New.(string)
-			new, _ := strconv.ParseFloat(newStr, 64)
-			assert.Equal(t, new, updatedValue)
+			assert.Equal(t, fieldName, eventList[0].Name)
+			assert.Equal(t, initialValue, eventList[0].Old)
+			assert.Equal(t, updatedValue, eventList[0].New)
 		})
 
 		t.Run("Int", func(t *testing.T) {
@@ -350,21 +350,16 @@ func (s *eventRepoBlackBoxTest) TestList() {
 			require.NoError(t, err)
 			eventList, err := s.wiEventRepo.List(s.Ctx, fxt.WorkItems[0].ID)
 			require.Len(t, eventList, 1)
-			assert.Equal(t, eventList[0].Name, fieldName)
-			oldStr, _ := eventList[0].Old.(string)
-			old, _ := strconv.ParseInt(oldStr, 10, 0)
-			assert.EqualValues(t, old, initialValue)
-			newStr, _ := eventList[0].New.(string)
-			new, _ := strconv.ParseInt(newStr, 10, 0)
-			assert.EqualValues(t, new, updatedValue)
+			assert.Equal(t, fieldName, eventList[0].Name)
+			assert.EqualValues(t, initialValue, eventList[0].Old)
+			assert.EqualValues(t, updatedValue, eventList[0].New)
 		})
 
 	})
 
 	s.T().Run("multiple events", func(t *testing.T) {
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItems(1))
-		label := []string{"label1"}
-		fxt.WorkItems[0].Fields[workitem.SystemLabels] = label
+		fxt.WorkItems[0].Fields[workitem.SystemLabels] = []string{uuid.NewV4().String()}
 		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateResolved
 		_, err := s.wiRepo.Save(s.Ctx, fxt.WorkItems[0].SpaceID, *fxt.WorkItems[0], fxt.Identities[0].ID)
 		require.NoError(t, err)

--- a/workitem/field_definition.go
+++ b/workitem/field_definition.go
@@ -13,22 +13,25 @@ import (
 
 // constants for describing possible field types
 const (
-	KindString      Kind = "string"
-	KindInteger     Kind = "integer"
-	KindFloat       Kind = "float"
-	KindBoolean     Kind = "bool"
-	KindInstant     Kind = "instant"
-	KindDuration    Kind = "duration"
-	KindURL         Kind = "url"
+	// non-relational
+	KindString   Kind = "string"
+	KindInteger  Kind = "integer"
+	KindFloat    Kind = "float"
+	KindBoolean  Kind = "bool"
+	KindInstant  Kind = "instant"
+	KindDuration Kind = "duration"
+	KindURL      Kind = "url"
+	KindMarkup   Kind = "markup"
+	// relational
 	KindIteration   Kind = "iteration"
 	KindUser        Kind = "user"
 	KindLabel       Kind = "label"
 	KindBoardColumn Kind = "boardcolumn"
-	KindEnum        Kind = "enum"
-	KindList        Kind = "list"
-	KindMarkup      Kind = "markup"
 	KindArea        Kind = "area"
 	KindCodebase    Kind = "codebase"
+	// composite
+	KindEnum Kind = "enum"
+	KindList Kind = "list"
 )
 
 // Kind is the kind of field type
@@ -37,6 +40,21 @@ type Kind string
 // IsSimpleType returns 'true' if the kind is simple, i.e., not a list nor an enum
 func (k Kind) IsSimpleType() bool {
 	return k != KindEnum && k != KindList
+}
+
+// IsRelational returns 'true' if the kind must be represented with a
+// relationship.
+func (k Kind) IsRelational() bool {
+	switch k {
+	case KindIteration,
+		KindUser,
+		KindLabel,
+		KindBoardColumn,
+		KindArea,
+		KindCodebase:
+		return true
+	}
+	return false
 }
 
 // String implements the Stringer interface and returns the kind as a string

--- a/workitem/field_definition_blackbox_test.go
+++ b/workitem/field_definition_blackbox_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/fabric8-services/fabric8-wit/workitem"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func testFieldDefinitionMarshalUnmarshal(t *testing.T, def workitem.FieldDefinition) {
@@ -73,4 +75,25 @@ func TestFieldDefinition_Marshalling(t *testing.T) {
 		}
 		testFieldDefinitionMarshalUnmarshal(t, def)
 	})
+}
+
+func TestFieldDefinition_IsRelational(t *testing.T) {
+	// relational kinds
+	require.True(t, workitem.KindLabel.IsRelational())
+	require.True(t, workitem.KindArea.IsRelational())
+	require.True(t, workitem.KindIteration.IsRelational())
+	require.True(t, workitem.KindBoardColumn.IsRelational())
+	require.True(t, workitem.KindUser.IsRelational())
+	require.True(t, workitem.KindCodebase.IsRelational())
+	// composite kinds
+	require.False(t, workitem.KindList.IsRelational())
+	require.False(t, workitem.KindEnum.IsRelational())
+	// non-relational kinds
+	require.False(t, workitem.KindString.IsRelational())
+	require.False(t, workitem.KindInteger.IsRelational())
+	require.False(t, workitem.KindInstant.IsRelational())
+	require.False(t, workitem.KindFloat.IsRelational())
+	require.False(t, workitem.KindBoolean.IsRelational())
+	// random
+	require.False(t, workitem.Kind(uuid.NewV4().String()).IsRelational())
 }

--- a/workitem/field_test_data.go
+++ b/workitem/field_test_data.go
@@ -161,7 +161,7 @@ func GetFieldTypeTestData(t *testing.T) FieldTypeTestDataMap {
 				return int(v)
 			},
 			Valid: []interface{}{
-				0,
+				int(0),
 				333,
 				-100,
 			},


### PR DESCRIPTION
See https://github.com/fabric8-services/fabric8-wit/pull/2213 for golden files changed. https://github.com/fabric8-services/fabric8-wit/pull/2213 Is also the PR that contains the code of this PR and it should pass tests, while this PR (#2212) will not pass tests because of missing golden files.

---

There were places inside of the event system that dealt with work item fields by name and not by their type. Here's what's done by this change.

1. We only distinguish between single-value (`workitem.SimpleType` and `workitem.EnumType`) and multi-value (`workitem.ListType`) fields in the work item repository.
2. We use the existing `workitem.FieldType.ConvertFromModel` function to convert stored values from the DB into the model space. Previously this was done manually and everything was converted to a string.
3. The events JSONAPI no longer expects old and new values to be strings all the time. Instead values can be of any type. Have a look at the `controller/test-files/event/list/ok-kindFloat.res.payload.golden.json` and `controller/test-files/event/list/ok-kindInt.res.payload.golden.json` files to see that effect.
4. Added event system tests for simple values (those that are not relationships) in a list or a single field.