### PR TITLE
Serve swagger under /api/swagger.json and swagger-ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,10 +321,10 @@ dev: prebuild-check deps generate $(FRESH_BIN) docker-compose-up
 docker-compose-up:
 ifeq ($(UNAME_S),Darwin)
 	@echo "Running docker-compose with macOS network settings"
-	docker-compose -f docker-compose.macos.yml up -d db auth
+	docker-compose -f docker-compose.macos.yml up -d db auth swagger_ui
 else
 	@echo "Running docker-compose with Linux network settings"
-	docker-compose up -d db auth
+	docker-compose up -d db auth swagger_ui
 endif
 
 MINISHIFT_IP = `minishift ip`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,9 @@ services:
     network_mode: "host"
     depends_on:
       - db-auth
+  swagger_ui:
+    image: swaggerapi/swagger-ui:latest
+    ports:
+      - "8081:8080"
+    environment:
+      API_URL: "http://localhost:8080/api/swagger.json"

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/account"
@@ -404,7 +405,7 @@ func main() {
 	featuresCtrl := controller.NewFeaturesController(service, config)
 	app.MountFeaturesController(service, featuresCtrl)
 
-	// serve the swagger.json
+	// serve the swagger.json modified to the current host
 	service.Mux.Handle("GET", "/api/swagger.json",
 		func(res http.ResponseWriter, req *http.Request, url url.Values) {
 			b, err := swagger.Asset("swagger.json")
@@ -412,9 +413,14 @@ func main() {
 				res.WriteHeader(404)
 				return
 			}
+
+			s := string(b)
+			s = strings.Replace(s, `"host":"openshift.io"`, `"host":"`+config.GetHTTPAddress()+`"`, -1)
+
 			res.Header().Set("Access-Control-Allow-Origin", "*")
 			res.Header().Set("Access-Control-Allow-Methods", "GET")
-			res.Write(b)
+
+			res.Write([]byte(s))
 		},
 	)
 


### PR DESCRIPTION
This serves the generated `swagger.json` under `/api/swagger.json` and replaces the host with the current setting from `config.GetHTTPAddress()`. This should make the swagger output compatible with whatever host it is running on (local, prod-preview, prod, ...).

I've also added a swagger-ui container that starts up on `make dev` and is served at [http://localhost:8081/](http://localhost:8081/) and looks like this:

![bildschirmfoto von 2018-08-06 17-33-28](https://user-images.githubusercontent.com/193408/43726345-3544b774-999f-11e8-8386-37248c7cd43d.png)


See also #165 for an old version of this.