### PR TITLE
Replace swagger host with request host and adjust scheme

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/models"
 	"github.com/fabric8-services/fabric8-wit/notification"
 	"github.com/fabric8-services/fabric8-wit/remoteworkitem"
+	"github.com/fabric8-services/fabric8-wit/rest"
 	"github.com/fabric8-services/fabric8-wit/sentry"
 	"github.com/fabric8-services/fabric8-wit/space/authz"
 	"github.com/fabric8-services/fabric8-wit/swagger"
@@ -415,14 +416,10 @@ func main() {
 			}
 
 			s := string(b)
-			// if set, use the deployments service URL for a proper host URL
-			// and fallback to the configured HTTP Address
-			serviceURL := config.GetDeploymentsServiceURL()
+			// replace swagger host with host from request
+			serviceURL := rest.AbsoluteURL(req, "")
 			serviceURL = strings.Replace(serviceURL, "http://", "", -1)
 			serviceURL = strings.Replace(serviceURL, "https://", "", -1)
-			if serviceURL == "" {
-				serviceURL = config.GetHTTPAddress()
-			}
 			s = strings.Replace(s, `"host":"openshift.io"`, `"host":"`+serviceURL+`"`, -1)
 
 			res.Header().Set("Access-Control-Allow-Origin", "*")

--- a/main.go
+++ b/main.go
@@ -417,10 +417,10 @@ func main() {
 
 			s := string(b)
 			// replace swagger host with host from request
-			serviceURL := rest.AbsoluteURL(req, "")
-			serviceURL = strings.Replace(serviceURL, "http://", "", -1)
-			serviceURL = strings.Replace(serviceURL, "https://", "", -1)
-			s = strings.Replace(s, `"host":"openshift.io"`, `"host":"`+serviceURL+`"`, -1)
+			newHost := rest.AbsoluteURL(req, "")
+			newHost = strings.Replace(newHost, "http://", "", -1)
+			newHost = strings.Replace(newHost, "https://", "", -1)
+			s = strings.Replace(s, `"host":"openshift.io"`, `"host":"`+newHost+`"`, -1)
 
 			res.Header().Set("Access-Control-Allow-Origin", "*")
 			res.Header().Set("Access-Control-Allow-Methods", "GET")

--- a/main.go
+++ b/main.go
@@ -417,7 +417,7 @@ func main() {
 			s := string(b)
 			// if set, use the deployments service URL for a proper host URL
 			// and fallback to the configured HTTP Address
-			serviceURL := os.Getenv("F8_DEPLOYMENTS_SERVICEURL")
+			serviceURL := config.GetDeploymentsServiceURL()
 			serviceURL = strings.Replace(serviceURL, "http://", "", -1)
 			serviceURL = strings.Replace(serviceURL, "https://", "", -1)
 			if serviceURL == "" {

--- a/main.go
+++ b/main.go
@@ -422,6 +422,11 @@ func main() {
 			newHost = strings.Replace(newHost, "https://", "", -1)
 			s = strings.Replace(s, `"host":"openshift.io"`, `"host":"`+newHost+`"`, -1)
 
+			// replace schemes in swagger with the current URL scheme
+			if req.URL != nil && strings.ToLower(req.URL.Scheme) == "https" {
+				s = strings.Replace(s, `"schemes":["http"]`, `"schemes":["https"]`, -1)
+			}
+
 			res.Header().Set("Access-Control-Allow-Origin", "*")
 			res.Header().Set("Access-Control-Allow-Methods", "GET")
 

--- a/main.go
+++ b/main.go
@@ -415,7 +415,15 @@ func main() {
 			}
 
 			s := string(b)
-			s = strings.Replace(s, `"host":"openshift.io"`, `"host":"`+config.GetHTTPAddress()+`"`, -1)
+			// if set, use the deployments service URL for a proper host URL
+			// and fallback to the configured HTTP Address
+			serviceURL := os.Getenv("F8_DEPLOYMENTS_SERVICEURL")
+			serviceURL = strings.Replace(serviceURL, "http://", "", -1)
+			serviceURL = strings.Replace(serviceURL, "https://", "", -1)
+			if serviceURL == "" {
+				serviceURL = config.GetHTTPAddress()
+			}
+			s = strings.Replace(s, `"host":"openshift.io"`, `"host":"`+serviceURL+`"`, -1)
 
 			res.Header().Set("Access-Control-Allow-Origin", "*")
 			res.Header().Set("Access-Control-Allow-Methods", "GET")


### PR DESCRIPTION
As a follow up for #2217 this change will properly replace the host (currently always `host: "0.0.0.0:8080",`) in the [generated swagger file](https://api.prod-preview.openshift.io/api/swagger.json) with the host of the request that tries to access the swagger file. We strip off the `http://` or `https://` prefix because that's handled in the swagger `schemes` section.

We also set the scheme to `https` if the current request was made using `https://`.