### PR TITLE
Add description in work item type group

### DIFF
--- a/controller/test-files/work_item_type_group/list/ok_legacy_template.payload.golden.json
+++ b/controller/test-files/work_item_type_group/list/ok_legacy_template.payload.golden.json
@@ -4,6 +4,7 @@
       "attributes": {
         "bucket": "portfolio",
         "created-at": "0001-01-01T00:00:00Z",
+        "description": "Work item type group that focuses on the planning-oriented work item types, such as scenario, fundamental, and papercuts.\n",
         "icon": "fa fa-bullseye",
         "name": "Scenarios",
         "show-in-sidebar": true,

--- a/controller/work_item_type_group.go
+++ b/controller/work_item_type_group.go
@@ -70,6 +70,7 @@ func ConvertTypeGroup(request *http.Request, tg workitem.WorkItemTypeGroup) *app
 		Attributes: &app.WorkItemTypeGroupAttributes{
 			Bucket:        tg.Bucket.String(),
 			Name:          tg.Name,
+			Description:   tg.Description,
 			Icon:          tg.Icon,
 			CreatedAt:     &createdAt,
 			UpdatedAt:     &updatedAt,

--- a/design/work_item_type_group.go
+++ b/design/work_item_type_group.go
@@ -44,6 +44,7 @@ var workItemTypeGroupData = a.Type("WorkItemTypeGroupData", func() {
 var workItemTypeGroupAttributes = a.Type("WorkItemTypeGroupAttributes", func() {
 	a.Attribute("bucket", d.String, "Name of the bucket this group belongs to")
 	a.Attribute("name", d.String)
+	a.Attribute("description", d.String)
 	a.Attribute("show-in-sidebar", d.Boolean, "Whether or not to render a link for this type group in the sidebar")
 	a.Attribute("icon", d.String, "CSS property value for icon of the group")
 	a.Attribute("created-at", d.DateTime, "timestamp of entity creation")

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -448,6 +448,9 @@ func GetMigrations() Migrations {
 		},
 	})
 
+	// Version 101
+	m = append(m, steps{ExecuteSQLFile("101-add-description-to-witg.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -149,6 +149,8 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration97", testMigration97RemoveResolutionFieldFromImpediment)
 	t.Run("TestMigration98", testMigration98Boards)
 	t.Run("TestMigration99", testMigration99CodebaseCVEScanDefaultFalse)
+	t.Run("TestMigration100", testDropUserspacedataTable)
+	t.Run("TestMigration101", testTypeGroupHasDescriptionField)
 
 	// Perform the migration
 	err = migration.Migrate(sqlDB, databaseName)
@@ -1242,7 +1244,14 @@ func testMigration95Boards(t *testing.T) {
 // used as a temporary solution to get data from tenant jenkins
 func testDropUserspacedataTable(t *testing.T) {
 	migrateToVersion(t, sqlDB, migrations[:100], 100)
-	assert.False(t, dialect.HasTable("userspace_data"))
+	require.False(t, dialect.HasTable("userspace_data"))
+}
+
+// testTypeGroupHasDescriptionField checks that the work item type groups table
+// has a description after updating to DB version 101.
+func testTypeGroupHasDescriptionField(t *testing.T) {
+	migrateToVersion(t, sqlDB, migrations[:101], 101)
+	require.False(t, dialect.HasColumn("work_item_type_groups", "description"))
 }
 
 // migrateToVersion runs the migration of all the scripts to a certain version

--- a/migration/sql-files/101-add-description-to-witg.sql
+++ b/migration/sql-files/101-add-description-to-witg.sql
@@ -1,0 +1,1 @@
+ALTER TABLE work_item_type_groups ADD COLUMN description text;

--- a/spacetemplate/assets/legacy.yaml
+++ b/spacetemplate/assets/legacy.yaml
@@ -206,6 +206,9 @@ work_item_type_groups:
 
 - name: Scenarios
   id: "679a563c-ac9b-4478-9f3e-4187f708dd30"
+  description: >
+    Work item type group that focuses on the planning-oriented work item types,
+    such as scenario, fundamental, and papercuts.
   type_list:
   - *scenarioID
   - *fundamentalID

--- a/spacetemplate/importer/importer_blackbox_test.go
+++ b/spacetemplate/importer/importer_blackbox_test.go
@@ -315,6 +315,7 @@ work_item_link_types:
 work_item_type_groups:
 - name: Scenarios
   id: "` + witgID.String() + `"
+  description: "description for scenarios"
   type_list:
     - "` + witID.String() + `"
   bucket: portfolio
@@ -417,6 +418,7 @@ func getValidTestTemplateParsed(t *testing.T, spaceTemplateID, witID, wiltID uui
 			{
 				ID:              witgID,
 				Name:            "Scenarios",
+				Description:     ptr.String("description for scenarios"),
 				Bucket:          workitem.BucketPortfolio,
 				Icon:            "fa fa-suitcase",
 				SpaceTemplateID: spaceTemplateID,

--- a/workitem/typegroup.go
+++ b/workitem/typegroup.go
@@ -2,6 +2,7 @@ package workitem
 
 import (
 	"database/sql/driver"
+	"reflect"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/convert"
@@ -39,6 +40,7 @@ type WorkItemTypeGroup struct {
 	SpaceTemplateID       uuid.UUID   `sql:"type:uuid" json:"space_template_id"`
 	Bucket                TypeBucket  `json:"bucket,omitempty"`
 	Name                  string      `json:"name,omitempty"` // the name to be displayed to user (is unique)
+	Description           *string     `json:"description,omitempty"`
 	Icon                  string      `json:"icon,omitempty"`
 	Position              int         `json:"-"`
 	TypeList              []uuid.UUID `gorm:"-" json:"type_list,omitempty"`
@@ -69,6 +71,9 @@ func (witg WorkItemTypeGroup) Equal(u convert.Equaler) bool {
 		return false
 	}
 	if witg.Name != other.Name {
+		return false
+	}
+	if !reflect.DeepEqual(witg.Description, other.Description) {
 		return false
 	}
 	if witg.Bucket != other.Bucket {

--- a/workitem/typegroup_repository_blackbox_test.go
+++ b/workitem/typegroup_repository_blackbox_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
+	"github.com/fabric8-services/fabric8-wit/ptr"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	"github.com/fabric8-services/fabric8-wit/workitem"
@@ -71,6 +72,7 @@ func (s *workItemTypeGroupRepoTest) TestCreate() {
 		SpaceTemplateID: fxt.SpaceTemplates[0].ID,
 		Bucket:          workitem.BucketIteration,
 		Name:            "work item type group " + ID.String(),
+		Description:     ptr.String("description for type group"),
 		Icon:            "a world on the back of a turtle",
 		Position:        42,
 		TypeList: []uuid.UUID{
@@ -160,6 +162,7 @@ func TestWorkItemTypeGroup_Equal(t *testing.T) {
 		ID:              uuid.NewV4(),
 		SpaceTemplateID: uuid.NewV4(),
 		Name:            "foo",
+		Description:     ptr.String("Description for foo"),
 		Bucket:          workitem.BucketRequirement,
 		Position:        42,
 		Icon:            "bar",
@@ -189,6 +192,12 @@ func TestWorkItemTypeGroup_Equal(t *testing.T) {
 		t.Parallel()
 		b := a
 		b.Name = "bar"
+		assert.False(t, a.Equal(b))
+	})
+	t.Run("Description", func(t *testing.T) {
+		t.Parallel()
+		b := a
+		b.Description = ptr.String("bar")
 		assert.False(t, a.Equal(b))
 	})
 	t.Run("SpaceTemplateID", func(t *testing.T) {


### PR DESCRIPTION
To support #2222 where @Preeticp wants to add info tips texts to work item type groups. Here I've added just one description (as pointed out here: https://github.com/fabric8-services/fabric8-wit/pull/2222#issuecomment-411048527) to see that it works. @Preeticp can do the rest in her PR.
