### PR TITLE
Added cico_run_e2e_tests.sh

### DIFF
--- a/cico_run_e2e_tests.sh
+++ b/cico_run_e2e_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "The end to end tests check will be implemented in"
+echo "https://github.com/fabric8-services/fabric8-wit/pull/2197 "
+echo "but for the CI to execute the task in an individual job we need"
+echo "to have an \".sh\" file in place."
+
+exit 1


### PR DESCRIPTION
We want to have end to end tests checking our PRs and in https://github.com/fabric8-services/fabric8-wit/pull/2197 @rgarg1 is working on how this.

It makes sense to run the end to end tests as a standalone job because the tests can be slow and can output messages that we don't want to see inside of our unit or integration tests.

This change adds a `cico_run_e2e_tests.sh` file that fails all the time and outputs a message. Once the file https://github.com/openshiftio/openshiftio-cico-jobs/blob/master/devtools-ci-index.yaml is adjusted to pick up run the end to end tests using this file, then @rgarg1 can adjust his PR to execute the tests in this `.sh` file.