### PR TITLE
Actions infra

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -44,7 +44,7 @@ import (
 // ExecuteActionsByOldNew executes all actions given in the actionConfigList
 // using the mapped configuration strings and returns the new context entity.
 // It takes the old version and the new version of the context entity, comparing them.
-func ExecuteActionsByOldNew(ctx context.Context, db application.DB, userID uuid.UUID, oldContext change.Detector, newContext change.Detector, actionConfigList map[string]string) (change.Detector, []change.Change, error) {
+func ExecuteActionsByOldNew(ctx context.Context, db application.DB, userID uuid.UUID, oldContext change.Detector, newContext change.Detector, actionConfigList map[string]string) (change.Detector, change.Set, error) {
 	if oldContext == nil || newContext == nil {
 		return nil, nil, errs.New("execute actions called with nil entities")
 	}
@@ -58,8 +58,8 @@ func ExecuteActionsByOldNew(ctx context.Context, db application.DB, userID uuid.
 // ExecuteActionsByChangeset executes all actions given in the actionConfigs
 // using the mapped configuration strings and returns the new context entity.
 // It takes a []Change that describes the differences between the old and the new context.
-func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uuid.UUID, newContext change.Detector, contextChanges []change.Change, actionConfigs map[string]string) (change.Detector, []change.Change, error) {
-	var actionChanges []change.Change
+func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uuid.UUID, newContext change.Detector, contextChanges []change.Change, actionConfigs map[string]string) (change.Detector, change.Set, error) {
+	var actionChanges change.Set
 	for actionKey := range actionConfigs {
 		var err error
 		actionConfig := actionConfigs[actionKey]
@@ -93,7 +93,7 @@ func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uu
 // executeAction executes the action given. The actionChanges contain the changes made by
 // prior action executions. The execution is expected to add/update their changes on this
 // change set.
-func executeAction(act rules.Action, configuration string, newContext change.Detector, contextChanges []change.Change, actionChanges *[]change.Change) (change.Detector, []change.Change, error) {
+func executeAction(act rules.Action, configuration string, newContext change.Detector, contextChanges change.Set, actionChanges *change.Set) (change.Detector, change.Set, error) {
 	if act == nil {
 		return nil, nil, errs.New("rule can not be nil")
 	}

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -37,14 +37,14 @@ import (
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/fabric8-services/fabric8-wit/actions/rules"
+	"github.com/fabric8-services/fabric8-wit/actions/change"
 	"github.com/fabric8-services/fabric8-wit/application"
-	"github.com/fabric8-services/fabric8-wit/convert"
 )
 
 // ExecuteActionsByOldNew executes all actions given in the actionConfigList
 // using the mapped configuration strings and returns the new context entity.
 // It takes the old version and the new version of the context entity, comparing them.
-func ExecuteActionsByOldNew(ctx context.Context, db application.DB, userID uuid.UUID, oldContext convert.ChangeDetector, newContext convert.ChangeDetector, actionConfigList map[string]string) (convert.ChangeDetector, []convert.Change, error) {
+func ExecuteActionsByOldNew(ctx context.Context, db application.DB, userID uuid.UUID, oldContext change.Detector, newContext change.Detector, actionConfigList map[string]string) (change.Detector, []change.Change, error) {
 	if oldContext == nil || newContext == nil {
 		return nil, nil, errs.New("execute actions called with nil entities")
 	}
@@ -58,8 +58,8 @@ func ExecuteActionsByOldNew(ctx context.Context, db application.DB, userID uuid.
 // ExecuteActionsByChangeset executes all actions given in the actionConfigs
 // using the mapped configuration strings and returns the new context entity.
 // It takes a []Change that describes the differences between the old and the new context.
-func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uuid.UUID, newContext convert.ChangeDetector, contextChanges []convert.Change, actionConfigs map[string]string) (convert.ChangeDetector, []convert.Change, error) {
-	var actionChanges []convert.Change
+func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uuid.UUID, newContext change.Detector, contextChanges []change.Change, actionConfigs map[string]string) (change.Detector, []change.Change, error) {
+	var actionChanges []change.Change
 	for actionKey := range actionConfigs {
 		var err error
 		actionConfig := actionConfigs[actionKey]
@@ -93,7 +93,7 @@ func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uu
 // executeAction executes the action given. The actionChanges contain the changes made by
 // prior action executions. The execution is expected to add/update their changes on this
 // change set.
-func executeAction(act rules.Action, configuration string, newContext convert.ChangeDetector, contextChanges []convert.Change, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error) {
+func executeAction(act rules.Action, configuration string, newContext change.Detector, contextChanges []change.Change, actionChanges *[]change.Change) (change.Detector, []change.Change, error) {
 	if act == nil {
 		return nil, nil, errs.New("rule can not be nil")
 	}

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -36,8 +36,8 @@ import (
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
-	"github.com/fabric8-services/fabric8-wit/actions/rules"
 	"github.com/fabric8-services/fabric8-wit/actions/change"
+	"github.com/fabric8-services/fabric8-wit/actions/rules"
 	"github.com/fabric8-services/fabric8-wit/application"
 )
 

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -72,12 +72,14 @@ func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uu
 				Ctx:    ctx,
 				UserID: &userID,
 			}, actionConfig, newContext, contextChanges, &actionChanges)
+		/* commented out for now until this rule is added
 		case rules.ActionKeyStateToMetastate:
 			newContext, actionChanges, err = executeAction(rules.ActionStateToMetaState{
 				Db:     db,
 				Ctx:    ctx,
 				UserID: &userID,
 			}, actionConfig, newContext, contextChanges, &actionChanges)
+		*/
 		default:
 			return nil, nil, errs.New("action key " + actionKey + " is unknown")
 		}

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,0 +1,99 @@
+package actions
+
+/*
+	 The actions system is a key component for process automation in WIT. It provides
+	 a way of executing user-configurable, dynamic process steps depending on user
+	 settings, schema settings and events in the WIT.
+
+	 The idea here is to provide a simple, yet powerful "publish-subscribe" system that
+	 can connect any "event" in the system to any "action" with a clear decoupling
+	 of events and actions with the goal of making the associations later dynamic and
+	 configurable by the user ("user connects this event to this action"). Think
+	 of a "IFTTT for WIT" (https://en.wikipedia.org/wiki/IFTTT).
+
+	 Actions are generic and atomic execution steps that do exactly one task and
+	 are configurable. The actions system around the actions provide a key-based
+	 execution of the actions.
+
+	 Some examples for an application of this system would be:
+		- closing all children of a parent WI that is being closed (the user connects the
+		"close" attribute change event of a WI to an action that closes all WIs of
+		a matching query).
+		- sending out notifications for mentions on markdown (the system executes an
+		action "send notification" for every mention found in markdown values).
+		- moving all WIs from one iteration to the next in the time sequence when
+		the original iteration is closed.
+
+		For all these automations, the actions system provides a re-usable, flexible
+		and later user configurable way of doing that without creating lots of
+		custom code and/or custom process implementations that are hardcoded in the
+		WIT.
+*/
+
+import (
+	"context"
+
+	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/fabric8-services/fabric8-wit/actions/rules"
+	"github.com/fabric8-services/fabric8-wit/application"
+	"github.com/fabric8-services/fabric8-wit/convert"
+)
+
+// ExecuteActionsByOldNew executes all actions given in the actionConfigList
+// using the mapped configuration strings and returns the new context entity.
+// It takes the old version and the new version of the context entity, comparing them.
+func ExecuteActionsByOldNew(ctx context.Context, db application.DB, userID uuid.UUID, oldContext convert.ChangeDetector, newContext convert.ChangeDetector, actionConfigList map[string]string) (convert.ChangeDetector, []convert.Change, error) {
+	if oldContext == nil || newContext == nil {
+		return nil, nil, errs.New("execute actions called with nil entities")
+	}
+	contextChanges, err := oldContext.ChangeSet(newContext)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ExecuteActionsByChangeset(ctx, db, userID, newContext, contextChanges, actionConfigList)
+}
+
+// ExecuteActionsByChangeset executes all actions given in the actionConfigs
+// using the mapped configuration strings and returns the new context entity.
+// It takes a []Change that describes the differences between the old and the new context.
+func ExecuteActionsByChangeset(ctx context.Context, db application.DB, userID uuid.UUID, newContext convert.ChangeDetector, contextChanges []convert.Change, actionConfigs map[string]string) (convert.ChangeDetector, []convert.Change, error) {
+	var actionChanges []convert.Change
+	for actionKey := range actionConfigs {
+		var err error
+		actionConfig := actionConfigs[actionKey]
+		switch actionKey {
+		case rules.ActionKeyNil:
+			newContext, actionChanges, err = executeAction(rules.ActionNil{}, actionConfig, newContext, contextChanges, &actionChanges)
+		case rules.ActionKeyFieldSet:
+			newContext, actionChanges, err = executeAction(rules.ActionFieldSet{
+				Db:     db,
+				Ctx:    ctx,
+				UserID: &userID,
+			}, actionConfig, newContext, contextChanges, &actionChanges)
+		case rules.ActionKeyStateToMetastate:
+			newContext, actionChanges, err = executeAction(rules.ActionStateToMetaState{
+				Db:     db,
+				Ctx:    ctx,
+				UserID: &userID,
+			}, actionConfig, newContext, contextChanges, &actionChanges)
+		default:
+			return nil, nil, errs.New("action key " + actionKey + " is unknown")
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return newContext, actionChanges, nil
+}
+
+// executeAction executes the action given. The actionChanges contain the changes made by
+// prior action executions. The execution is expected to add/update their changes on this
+// change set.
+func executeAction(act rules.Action, configuration string, newContext convert.ChangeDetector, contextChanges []convert.Change, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error) {
+	if act == nil {
+		return nil, nil, errs.New("rule can not be nil")
+	}
+	return act.OnChange(newContext, contextChanges, configuration, actionChanges)
+}

--- a/actions/actions_whitebox_test.go
+++ b/actions/actions_whitebox_test.go
@@ -1,0 +1,180 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
+	"github.com/fabric8-services/fabric8-wit/resource"
+	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
+	"github.com/fabric8-services/fabric8-wit/workitem"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestSuiteAction(t *testing.T) {
+	resource.Require(t, resource.Database)
+	suite.Run(t, &ActionSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+type ActionSuite struct {
+	gormtestsupport.DBTestSuite
+}
+
+func createWICopy(wi workitem.WorkItem, state string, boardcolumns []interface{}) workitem.WorkItem {
+	var wiCopy workitem.WorkItem
+	wiCopy.ID = wi.ID
+	wiCopy.SpaceID = wi.SpaceID
+	wiCopy.Type = wi.Type
+	wiCopy.Number = wi.Number
+	wiCopy.Fields = map[string]interface{}{}
+	for k := range wi.Fields {
+		wiCopy.Fields[k] = wi.Fields[k]
+	}
+	wiCopy.Fields[workitem.SystemState] = state
+	wiCopy.Fields[workitem.SystemBoardcolumns] = boardcolumns
+	return wiCopy
+}
+
+func (s *ActionSuite) TestChangeSet() {
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2))
+
+	s.T().Run("different ID", func(t *testing.T) {
+		_, err := fxt.WorkItems[0].ChangeSet(*fxt.WorkItems[1])
+		require.Error(t, err)
+	})
+
+	s.T().Run("same instance", func(t *testing.T) {
+		changes, err := fxt.WorkItems[0].ChangeSet(*fxt.WorkItems[0])
+		require.NoError(t, err)
+		require.Empty(t, changes)
+	})
+
+	s.T().Run("no changes, same column order", func(t *testing.T) {
+		wiCopy := createWICopy(*fxt.WorkItems[0], workitem.SystemStateNew, []interface{}{"bcid0", "bcid1"})
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		changes, err := fxt.WorkItems[0].ChangeSet(wiCopy)
+		require.NoError(t, err)
+		require.Empty(t, changes)
+	})
+
+	s.T().Run("no changes, mixed column order", func(t *testing.T) {
+		wiCopy := createWICopy(*fxt.WorkItems[0], workitem.SystemStateNew, []interface{}{"bcid1", "bcid0"})
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		changes, err := fxt.WorkItems[0].ChangeSet(wiCopy)
+		require.NoError(t, err)
+		require.Empty(t, changes)
+	})
+
+	s.T().Run("state changes", func(t *testing.T) {
+		wiCopy := createWICopy(*fxt.WorkItems[0], workitem.SystemStateNew, []interface{}{"bcid0", "bcid1"})
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateOpen
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		changes, err := fxt.WorkItems[0].ChangeSet(wiCopy)
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		require.Equal(t, workitem.SystemState, changes[0].AttributeName)
+		require.Equal(t, workitem.SystemStateOpen, changes[0].NewValue)
+		require.Equal(t, workitem.SystemStateNew, changes[0].OldValue)
+	})
+
+	s.T().Run("column changes", func(t *testing.T) {
+		wiCopy := createWICopy(*fxt.WorkItems[0], workitem.SystemStateNew, []interface{}{"bcid0"})
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		changes, err := fxt.WorkItems[0].ChangeSet(wiCopy)
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		require.Equal(t, workitem.SystemBoardcolumns, changes[0].AttributeName)
+		require.Equal(t, wiCopy.Fields[workitem.SystemBoardcolumns], changes[0].OldValue)
+		require.Equal(t, fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns], changes[0].NewValue)
+	})
+
+	s.T().Run("multiple changes", func(t *testing.T) {
+		wiCopy := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0"})
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		changes, err := fxt.WorkItems[0].ChangeSet(wiCopy)
+		require.NoError(t, err)
+		require.Len(t, changes, 2)
+		// we intentionally test the order here as the code under test needs
+		// to be expanded later, supporting more changes and this is an
+		// integrity test on the current impl.
+		require.Equal(t, workitem.SystemState, changes[0].AttributeName)
+		require.Equal(t, workitem.SystemStateNew, changes[0].NewValue)
+		require.Equal(t, workitem.SystemStateOpen, changes[0].OldValue)
+		require.Equal(t, workitem.SystemBoardcolumns, changes[1].AttributeName)
+		require.Equal(t, fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns], changes[1].NewValue)
+		require.Equal(t, wiCopy.Fields[workitem.SystemBoardcolumns], changes[1].OldValue)
+	})
+
+	s.T().Run("new instance", func(t *testing.T) {
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{}
+		changes, err := fxt.WorkItems[0].ChangeSet(nil)
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		require.Equal(t, workitem.SystemState, changes[0].AttributeName)
+		require.Equal(t, workitem.SystemStateNew, changes[0].NewValue)
+		require.Nil(t, changes[0].OldValue)
+	})
+}
+
+func (s *ActionSuite) TestActionExecution() {
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2))
+	userID := fxt.Identities[0].ID
+
+	s.T().Run("by Old New", func(t *testing.T) {
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		_, changes, err := ExecuteActionsByOldNew(s.Ctx, s.GormDB, userID, fxt.WorkItems[0], newVersion, map[string]string{
+			"Nil": "{ noConfig: 'none' }",
+		})
+		require.NoError(t, err)
+		require.Len(t, changes, 0)
+	})
+
+	s.T().Run("by ChangeSet", func(t *testing.T) {
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		contextChanges, err := fxt.WorkItems[0].ChangeSet(newVersion)
+		require.NoError(t, err)
+		afterActionWI, changes, err := ExecuteActionsByChangeset(s.Ctx, s.GormDB, userID, newVersion, contextChanges, map[string]string{
+			"Nil": "{ noConfig: 'none' }",
+		})
+		require.NoError(t, err)
+		require.Len(t, changes, 0)
+		require.Equal(t, workitem.SystemStateOpen, afterActionWI.(workitem.WorkItem).Fields["system.state"])
+	})
+
+	s.T().Run("unknown rule", func(t *testing.T) {
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		contextChanges, err := fxt.WorkItems[0].ChangeSet(newVersion)
+		require.NoError(t, err)
+		_, _, err = ExecuteActionsByChangeset(s.Ctx, s.GormDB, userID, newVersion, contextChanges, map[string]string{
+			"unknownRule": "{ noConfig: 'none' }",
+		})
+		require.NotNil(t, err)
+	})
+
+	s.T().Run("sideffects", func(t *testing.T) {
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		contextChanges, err := fxt.WorkItems[0].ChangeSet(newVersion)
+		require.NoError(t, err)
+		// Intentionally not using a constant here!
+		afterActionWI, changes, err := ExecuteActionsByChangeset(s.Ctx, s.GormDB, userID, newVersion, contextChanges, map[string]string{
+			"FieldSet": "{ \"system.state\": \"resolved\" }",
+		})
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		require.Equal(t, workitem.SystemStateResolved, afterActionWI.(workitem.WorkItem).Fields[workitem.SystemState])
+	})
+}

--- a/actions/change/changeset.go
+++ b/actions/change/changeset.go
@@ -1,10 +1,10 @@
-package convert
+package change
 
 // ChangeDetector defines funcs for getting a changeset from two
 // instances of a class. This interface has to be implemented by
 // all entities that should trigger action rule runs.
-type ChangeDetector interface {
-	ChangeSet(older ChangeDetector) ([]Change, error)
+type Detector interface {
+	ChangeSet(older Detector) ([]Change, error)
 }
 
 // Change defines a set of changed values in an entity. It holds

--- a/actions/change/changeset.go
+++ b/actions/change/changeset.go
@@ -1,10 +1,13 @@
 package change
 
+// Set is a set of changes to an entitiy.
+type Set []Change
+
 // ChangeDetector defines funcs for getting a changeset from two
 // instances of a class. This interface has to be implemented by
 // all entities that should trigger action rule runs.
 type Detector interface {
-	ChangeSet(older Detector) ([]Change, error)
+	ChangeSet(older Detector) (Set, error)
 }
 
 // Change defines a set of changed values in an entity. It holds

--- a/actions/change/changeset.go
+++ b/actions/change/changeset.go
@@ -3,7 +3,7 @@ package change
 // Set is a set of changes to an entitiy.
 type Set []Change
 
-// ChangeDetector defines funcs for getting a changeset from two
+// Detector defines funcs for getting a changeset from two
 // instances of a class. This interface has to be implemented by
 // all entities that should trigger action rule runs.
 type Detector interface {

--- a/actions/doc.go
+++ b/actions/doc.go
@@ -1,0 +1,40 @@
+/* 
+Package actions system is a key component for process automation in WIT. It provides a 
+way of executing user-configurable, dynamic process steps depending on user 
+settings, schema settings and events in the WIT.
+
+The idea here is to provide a simple, yet powerful "signal-slot" system that 
+can connect any "event" in the system to any "action" with a clear decoupling of 
+events and actions with the goal of making the associations later dynamic and 
+configurable by the user ("user connects this event to this action"). Think 
+of a "IFTTT for WIT".
+
+Actions are generic and atomic execution steps that do exactly one task and are 
+configurable. The actions system around the actions provide a key-based 
+execution of the actions.
+
+Some examples for an application of this system would be:
+  * closing all childs of a parent that is being closed (the user connects the 
+    "close" attribute change event of a WI to an action that closes all 
+    WIs of a matching query).
+  * sending out notifications for mentions on markdown (the system executes 
+	  an action "send notification" for every mention found in markdown values).
+  * moving all WIs from one iteration to the next in the time sequence when 
+    the original iteration is closed.
+
+For all these automations, the actions system provides a re-usable, flexible and 
+later user configurable way of doing that without creating lots of custom code 
+and/or custom process implementations that are hardcoded in the WIT.
+
+The current PR provides the basic actions infrastructure and an implementation of 
+an example action rules for testing.
+
+This package provides two methods ExecuteActionsByOldNew() and ExecuteActionsByChangeset()
+that can be called by a client (for example the controller on a request) with an entity
+that is the context of the action run and a configuration for the context. The
+configuration consists of a list of rule keys (identifying the rules that apply) and 
+respective configuration for the rules. The actions system will run the rules
+sequentially and return the new context entity and a set of changes done while running
+the rules. Note that executing actions may have sideffects on data beyond the context.
+*/
+package actions

--- a/actions/doc.go
+++ b/actions/doc.go
@@ -1,38 +1,38 @@
-/* 
-Package actions system is a key component for process automation in WIT. It provides a 
-way of executing user-configurable, dynamic process steps depending on user 
+/*
+Package actions system is a key component for process automation in WIT. It provides a
+way of executing user-configurable, dynamic process steps depending on user
 settings, schema settings and events in the WIT.
 
-The idea here is to provide a simple, yet powerful "signal-slot" system that 
-can connect any "event" in the system to any "action" with a clear decoupling of 
-events and actions with the goal of making the associations later dynamic and 
-configurable by the user ("user connects this event to this action"). Think 
+The idea here is to provide a simple, yet powerful "signal-slot" system that
+can connect any "event" in the system to any "action" with a clear decoupling of
+events and actions with the goal of making the associations later dynamic and
+configurable by the user ("user connects this event to this action"). Think
 of a "IFTTT for WIT".
 
-Actions are generic and atomic execution steps that do exactly one task and are 
-configurable. The actions system around the actions provide a key-based 
+Actions are generic and atomic execution steps that do exactly one task and are
+configurable. The actions system around the actions provide a key-based
 execution of the actions.
 
 Some examples for an application of this system would be:
-  * closing all childs of a parent that is being closed (the user connects the 
-    "close" attribute change event of a WI to an action that closes all 
+  * closing all childs of a parent that is being closed (the user connects the
+    "close" attribute change event of a WI to an action that closes all
     WIs of a matching query).
-  * sending out notifications for mentions on markdown (the system executes 
+  * sending out notifications for mentions on markdown (the system executes
 	  an action "send notification" for every mention found in markdown values).
-  * moving all WIs from one iteration to the next in the time sequence when 
+  * moving all WIs from one iteration to the next in the time sequence when
     the original iteration is closed.
 
-For all these automations, the actions system provides a re-usable, flexible and 
-later user configurable way of doing that without creating lots of custom code 
+For all these automations, the actions system provides a re-usable, flexible and
+later user configurable way of doing that without creating lots of custom code
 and/or custom process implementations that are hardcoded in the WIT.
 
-The current PR provides the basic actions infrastructure and an implementation of 
+The current PR provides the basic actions infrastructure and an implementation of
 an example action rules for testing.
 
 This package provides two methods ExecuteActionsByOldNew() and ExecuteActionsByChangeset()
 that can be called by a client (for example the controller on a request) with an entity
 that is the context of the action run and a configuration for the context. The
-configuration consists of a list of rule keys (identifying the rules that apply) and 
+configuration consists of a list of rule keys (identifying the rules that apply) and
 respective configuration for the rules. The actions system will run the rules
 sequentially and return the new context entity and a set of changes done while running
 the rules. Note that executing actions may have sideffects on data beyond the context.

--- a/actions/rules/action.go
+++ b/actions/rules/action.go
@@ -1,6 +1,6 @@
 package rules
 
-import "github.com/fabric8-services/fabric8-wit/convert"
+import "github.com/fabric8-services/fabric8-wit/actions/change"
 
 const (
 	// ActionKeyNil is the key for the ActionKeyNil action rule.
@@ -24,5 +24,5 @@ type Action interface {
 	// updated attributes. It returns the new context. Note that this
 	// needs the new (after change) context and the old value(s) as
 	// part of the changeset.
-	OnChange(newContext convert.ChangeDetector, contextChanges []convert.Change, configuration string, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error)
+	OnChange(newContext change.Detector, contextChanges []change.Change, configuration string, actionChanges *[]change.Change) (change.Detector, []change.Change, error)
 }

--- a/actions/rules/action.go
+++ b/actions/rules/action.go
@@ -1,0 +1,28 @@
+package rules
+
+import "github.com/fabric8-services/fabric8-wit/convert"
+
+const (
+	// ActionKeyNil is the key for the ActionKeyNil action rule.
+	ActionKeyNil = "Nil"
+	// ActionKeyFieldSet is the key for the ActionKeyFieldSet action rule.
+	ActionKeyFieldSet = "FieldSet"
+	// ActionKeyStateToMetastate is the key for the ActionKeyStateToMetastate action rule.
+	ActionKeyStateToMetastate = "BidirectionalStateToColumn"
+
+	// ActionKeyStateToMetastateConfigMetastate is the key for the ActionKeyStateToMetastateConfigMetastate config parameter.
+	ActionKeyStateToMetastateConfigMetastate = "metaState"
+)
+
+// Action defines an action on change of an entity. Executing an
+// Action might have sideffects, but will always return the original
+// given context with all changes of the Action to this context. Note
+// that the execution may have sideeffects on other entities beyond the
+// context.
+type Action interface {
+	// OnChange executes this action by looking at a change set of
+	// updated attributes. It returns the new context. Note that this
+	// needs the new (after change) context and the old value(s) as
+	// part of the changeset.
+	OnChange(newContext convert.ChangeDetector, contextChanges []convert.Change, configuration string, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error)
+}

--- a/actions/rules/action.go
+++ b/actions/rules/action.go
@@ -24,5 +24,5 @@ type Action interface {
 	// updated attributes. It returns the new context. Note that this
 	// needs the new (after change) context and the old value(s) as
 	// part of the changeset.
-	OnChange(newContext change.Detector, contextChanges []change.Change, configuration string, actionChanges *[]change.Change) (change.Detector, []change.Change, error)
+	OnChange(newContext change.Detector, contextChanges change.Set, configuration string, actionChanges *change.Set) (change.Detector, change.Set, error)
 }

--- a/actions/rules/action_field_set.go
+++ b/actions/rules/action_field_set.go
@@ -8,8 +8,8 @@ import (
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
-	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/actions/change"
+	"github.com/fabric8-services/fabric8-wit/application"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 )
 

--- a/actions/rules/action_field_set.go
+++ b/actions/rules/action_field_set.go
@@ -9,7 +9,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/fabric8-services/fabric8-wit/application"
-	"github.com/fabric8-services/fabric8-wit/convert"
+	"github.com/fabric8-services/fabric8-wit/actions/change"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 )
 
@@ -52,7 +52,7 @@ func (act ActionFieldSet) storeWorkItem(wi *workitem.WorkItem) (*workitem.WorkIt
 }
 
 // OnChange executes the action rule.
-func (act ActionFieldSet) OnChange(newContext convert.ChangeDetector, contextChanges []convert.Change, configuration string, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error) {
+func (act ActionFieldSet) OnChange(newContext change.Detector, contextChanges []change.Change, configuration string, actionChanges *[]change.Change) (change.Detector, []change.Change, error) {
 	// check if the newContext is a WorkItem, fail otherwise.
 	wiContext, ok := newContext.(workitem.WorkItem)
 	if !ok {
@@ -76,7 +76,7 @@ func (act ActionFieldSet) OnChange(newContext convert.ChangeDetector, contextCha
 			if !ok {
 				return nil, nil, errs.New("unknown field name: " + k)
 			}
-			*actionChanges = append(*actionChanges, convert.Change{
+			*actionChanges = append(*actionChanges, change.Change{
 				AttributeName: k,
 				NewValue:      v,
 				OldValue:      wiContext.Fields[k],

--- a/actions/rules/action_field_set.go
+++ b/actions/rules/action_field_set.go
@@ -1,0 +1,104 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/fabric8-services/fabric8-wit/application"
+	"github.com/fabric8-services/fabric8-wit/convert"
+	"github.com/fabric8-services/fabric8-wit/workitem"
+)
+
+// ActionFieldSet takes a configuration JSON object that has field
+// names as the keys and a value as the argument. It updates the
+// given ChangeDetector and sets the Field[key] value to the
+// values given. Note that this only works on WorkItems.
+type ActionFieldSet struct {
+	Db     application.DB
+	Ctx    context.Context
+	UserID *uuid.UUID
+}
+
+// make sure the rule is implementing the interface.
+var _ Action = ActionFieldSet{}
+
+func (act ActionFieldSet) storeWorkItem(wi *workitem.WorkItem) (*workitem.WorkItem, error) {
+	if act.Ctx == nil {
+		return nil, errs.New("context is nil")
+	}
+	if act.Db == nil {
+		return nil, errs.New("database is nil")
+	}
+	if act.UserID == nil {
+		return nil, errs.New("userID is nil")
+	}
+	var storeResultWorkItem *workitem.WorkItem
+	err := application.Transactional(act.Db, func(appl application.Application) error {
+		var err error
+		storeResultWorkItem, err = appl.WorkItems().Save(act.Ctx, wi.SpaceID, *wi, *act.UserID)
+		if err != nil {
+			return errs.Wrap(err, "error updating work item")
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return storeResultWorkItem, nil
+}
+
+// OnChange executes the action rule.
+func (act ActionFieldSet) OnChange(newContext convert.ChangeDetector, contextChanges []convert.Change, configuration string, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error) {
+	// check if the newContext is a WorkItem, fail otherwise.
+	wiContext, ok := newContext.(workitem.WorkItem)
+	if !ok {
+		return nil, nil, errs.New("given context is not a WorkItem: " + reflect.TypeOf(newContext).String())
+	}
+	// deserialize the config JSON.
+	var rawType map[string]interface{}
+	err := json.Unmarshal([]byte(configuration), &rawType)
+	if err != nil {
+		return nil, nil, errs.Wrap(err, "failed to unmarshall from action configuration to a map: "+configuration)
+	}
+	// load WIT.
+	wit, err := act.Db.WorkItemTypes().Load(act.Ctx, wiContext.Type)
+	if err != nil {
+		return nil, nil, errs.Wrap(err, "error loading work item type: "+err.Error())
+	}
+	// iterate over the fields.
+	for k, v := range rawType {
+		if wiContext.Fields[k] != v {
+			fieldType, ok := wit.Fields[k]
+			if !ok {
+				return nil, nil, errs.New("unknown field name: " + k)
+			}
+			*actionChanges = append(*actionChanges, convert.Change{
+				AttributeName: k,
+				NewValue:      v,
+				OldValue:      wiContext.Fields[k],
+			})
+			newValue, err := fieldType.Type.ConvertToModel(v)
+			if err != nil {
+				return nil, nil, errs.Wrap(err, "error converting new value to model")
+			}
+			wiContext.Fields[k] = newValue
+		}
+	}
+	// store the WorkItem.
+	actionResultContext, err := act.storeWorkItem(&wiContext)
+	if err != nil {
+		return nil, nil, err
+	}
+	// iterate over the resulting wi, see if all keys are there.
+	// if not, the key was an unknown key.
+	for k := range rawType {
+		if _, ok := actionResultContext.Fields[k]; !ok {
+			return nil, nil, errs.New("field attribute unknown: " + k)
+		}
+	}
+	return *actionResultContext, *actionChanges, nil
+}

--- a/actions/rules/action_field_set.go
+++ b/actions/rules/action_field_set.go
@@ -52,7 +52,7 @@ func (act ActionFieldSet) storeWorkItem(wi *workitem.WorkItem) (*workitem.WorkIt
 }
 
 // OnChange executes the action rule.
-func (act ActionFieldSet) OnChange(newContext change.Detector, contextChanges []change.Change, configuration string, actionChanges *[]change.Change) (change.Detector, []change.Change, error) {
+func (act ActionFieldSet) OnChange(newContext change.Detector, contextChanges change.Set, configuration string, actionChanges *change.Set) (change.Detector, change.Set, error) {
 	// check if the newContext is a WorkItem, fail otherwise.
 	wiContext, ok := newContext.(workitem.WorkItem)
 	if !ok {

--- a/actions/rules/action_field_set_test.go
+++ b/actions/rules/action_field_set_test.go
@@ -1,0 +1,135 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/fabric8-services/fabric8-wit/convert"
+	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
+	"github.com/fabric8-services/fabric8-wit/resource"
+	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
+	"github.com/fabric8-services/fabric8-wit/workitem"
+)
+
+func TestSuiteActionFieldSet(t *testing.T) {
+	resource.Require(t, resource.Database)
+	suite.Run(t, &ActionFieldSetSuite{DBTestSuite: gormtestsupport.NewDBTestSuite()})
+}
+
+type ActionFieldSetSuite struct {
+	gormtestsupport.DBTestSuite
+}
+
+func createWICopy(wi workitem.WorkItem, state string, boardcolumns []interface{}) workitem.WorkItem {
+	var wiCopy workitem.WorkItem
+	wiCopy.ID = wi.ID
+	wiCopy.SpaceID = wi.SpaceID
+	wiCopy.Type = wi.Type
+	wiCopy.Number = wi.Number
+	wiCopy.Fields = map[string]interface{}{}
+	for k := range wi.Fields {
+		wiCopy.Fields[k] = wi.Fields[k]
+	}
+	wiCopy.Fields[workitem.SystemState] = state
+	wiCopy.Fields[workitem.SystemBoardcolumns] = boardcolumns
+	return wiCopy
+}
+
+func (s *ActionFieldSetSuite) TestActionExecution() {
+	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2))
+	require.NotNil(s.T(), fxt)
+	require.Len(s.T(), fxt.WorkItems, 2)
+
+	s.T().Run("sideffects", func(t *testing.T) {
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2))
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		contextChanges, err := fxt.WorkItems[0].ChangeSet(newVersion)
+		require.NoError(t, err)
+		action := ActionFieldSet{
+			Db:     s.GormDB,
+			Ctx:    s.Ctx,
+			UserID: &fxt.Identities[0].ID,
+		}
+		var convertChanges []convert.Change
+		// Not using constants here intentionally.
+		afterActionWI, convertChanges, err := action.OnChange(newVersion, contextChanges, "{ \"system.state\": \"resolved\" }", &convertChanges)
+		require.NoError(t, err)
+		require.Len(t, convertChanges, 1)
+		require.Equal(t, workitem.SystemState, convertChanges[0].AttributeName)
+		require.Equal(t, workitem.SystemStateOpen, convertChanges[0].OldValue)
+		require.Equal(t, workitem.SystemStateResolved, convertChanges[0].NewValue)
+		require.Equal(t, workitem.SystemStateResolved, afterActionWI.(workitem.WorkItem).Fields[workitem.SystemState])
+	})
+
+	s.T().Run("stacking", func(t *testing.T) {
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2))
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		contextChanges, err := fxt.WorkItems[0].ChangeSet(newVersion)
+		require.NoError(t, err)
+		action := ActionFieldSet{
+			Db:     s.GormDB,
+			Ctx:    s.Ctx,
+			UserID: &fxt.Identities[0].ID,
+		}
+		var convertChanges []convert.Change
+		// Not using constants here intentionally.
+		afterActionWI, convertChanges, err := action.OnChange(newVersion, contextChanges, "{ \"system.state\": \"resolved\" }", &convertChanges)
+		require.NoError(t, err)
+		require.Len(t, convertChanges, 1)
+		require.Equal(t, workitem.SystemState, convertChanges[0].AttributeName)
+		require.Equal(t, workitem.SystemStateOpen, convertChanges[0].OldValue)
+		require.Equal(t, workitem.SystemStateResolved, convertChanges[0].NewValue)
+		require.Equal(t, workitem.SystemStateResolved, afterActionWI.(workitem.WorkItem).Fields[workitem.SystemState])
+		// doing another change, the convertChange needs to stack.
+		afterActionWI, convertChanges, err = action.OnChange(afterActionWI, []convert.Change{}, "{ \"system.state\": \"new\" }", &convertChanges)
+		require.NoError(t, err)
+		require.Len(t, convertChanges, 2)
+		require.Equal(t, workitem.SystemState, convertChanges[0].AttributeName)
+		require.Equal(t, workitem.SystemStateOpen, convertChanges[0].OldValue)
+		require.Equal(t, workitem.SystemStateResolved, convertChanges[0].NewValue)
+		require.Equal(t, workitem.SystemState, convertChanges[1].AttributeName)
+		require.Equal(t, workitem.SystemStateResolved, convertChanges[1].OldValue)
+		require.Equal(t, workitem.SystemStateNew, convertChanges[1].NewValue)
+		require.Equal(t, workitem.SystemStateNew, afterActionWI.(workitem.WorkItem).Fields[workitem.SystemState])
+	})
+
+	s.T().Run("unknown field", func(t *testing.T) {
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2))
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		contextChanges, err := fxt.WorkItems[0].ChangeSet(newVersion)
+		require.NoError(t, err)
+		action := ActionFieldSet{
+			Db:     s.GormDB,
+			Ctx:    s.Ctx,
+			UserID: &fxt.Identities[0].ID,
+		}
+		var convertChanges []convert.Change
+		_, _, err = action.OnChange(newVersion, contextChanges, "{ \"system.notavailable\": \"updatedState\" }", &convertChanges)
+		require.NotNil(t, err)
+	})
+
+	s.T().Run("non-json configuration", func(t *testing.T) {
+		fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(2))
+		fxt.WorkItems[0].Fields[workitem.SystemState] = workitem.SystemStateNew
+		fxt.WorkItems[0].Fields[workitem.SystemBoardcolumns] = []interface{}{"bcid0", "bcid1"}
+		newVersion := createWICopy(*fxt.WorkItems[0], workitem.SystemStateOpen, []interface{}{"bcid0", "bcid1"})
+		contextChanges, err := fxt.WorkItems[0].ChangeSet(newVersion)
+		require.NoError(t, err)
+		action := ActionFieldSet{
+			Db:     s.GormDB,
+			Ctx:    s.Ctx,
+			UserID: &fxt.Identities[0].ID,
+		}
+		var convertChanges []convert.Change
+		_, convertChanges, err = action.OnChange(newVersion, contextChanges, "someNonJSON", &convertChanges)
+		require.NotNil(t, err)
+	})
+}

--- a/actions/rules/action_field_set_test.go
+++ b/actions/rules/action_field_set_test.go
@@ -54,7 +54,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []change.Change
+		var convertChanges change.Set
 		// Not using constants here intentionally.
 		afterActionWI, convertChanges, err := action.OnChange(newVersion, contextChanges, "{ \"system.state\": \"resolved\" }", &convertChanges)
 		require.NoError(t, err)
@@ -77,7 +77,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []change.Change
+		var convertChanges change.Set
 		// Not using constants here intentionally.
 		afterActionWI, convertChanges, err := action.OnChange(newVersion, contextChanges, "{ \"system.state\": \"resolved\" }", &convertChanges)
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 		require.Equal(t, workitem.SystemStateResolved, convertChanges[0].NewValue)
 		require.Equal(t, workitem.SystemStateResolved, afterActionWI.(workitem.WorkItem).Fields[workitem.SystemState])
 		// doing another change, the convertChange needs to stack.
-		afterActionWI, convertChanges, err = action.OnChange(afterActionWI, []change.Change{}, "{ \"system.state\": \"new\" }", &convertChanges)
+		afterActionWI, convertChanges, err = action.OnChange(afterActionWI, change.Set{}, "{ \"system.state\": \"new\" }", &convertChanges)
 		require.NoError(t, err)
 		require.Len(t, convertChanges, 2)
 		require.Equal(t, workitem.SystemState, convertChanges[0].AttributeName)
@@ -111,7 +111,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []change.Change
+		var convertChanges change.Set
 		_, _, err = action.OnChange(newVersion, contextChanges, "{ \"system.notavailable\": \"updatedState\" }", &convertChanges)
 		require.NotNil(t, err)
 	})
@@ -128,7 +128,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []change.Change
+		var convertChanges change.Set
 		_, convertChanges, err = action.OnChange(newVersion, contextChanges, "someNonJSON", &convertChanges)
 		require.NotNil(t, err)
 	})

--- a/actions/rules/action_field_set_test.go
+++ b/actions/rules/action_field_set_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/fabric8-services/fabric8-wit/convert"
+	"github.com/fabric8-services/fabric8-wit/actions/change"
 	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
@@ -54,7 +54,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []convert.Change
+		var convertChanges []change.Change
 		// Not using constants here intentionally.
 		afterActionWI, convertChanges, err := action.OnChange(newVersion, contextChanges, "{ \"system.state\": \"resolved\" }", &convertChanges)
 		require.NoError(t, err)
@@ -77,7 +77,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []convert.Change
+		var convertChanges []change.Change
 		// Not using constants here intentionally.
 		afterActionWI, convertChanges, err := action.OnChange(newVersion, contextChanges, "{ \"system.state\": \"resolved\" }", &convertChanges)
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 		require.Equal(t, workitem.SystemStateResolved, convertChanges[0].NewValue)
 		require.Equal(t, workitem.SystemStateResolved, afterActionWI.(workitem.WorkItem).Fields[workitem.SystemState])
 		// doing another change, the convertChange needs to stack.
-		afterActionWI, convertChanges, err = action.OnChange(afterActionWI, []convert.Change{}, "{ \"system.state\": \"new\" }", &convertChanges)
+		afterActionWI, convertChanges, err = action.OnChange(afterActionWI, []change.Change{}, "{ \"system.state\": \"new\" }", &convertChanges)
 		require.NoError(t, err)
 		require.Len(t, convertChanges, 2)
 		require.Equal(t, workitem.SystemState, convertChanges[0].AttributeName)
@@ -111,7 +111,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []convert.Change
+		var convertChanges []change.Change
 		_, _, err = action.OnChange(newVersion, contextChanges, "{ \"system.notavailable\": \"updatedState\" }", &convertChanges)
 		require.NotNil(t, err)
 	})
@@ -128,7 +128,7 @@ func (s *ActionFieldSetSuite) TestActionExecution() {
 			Ctx:    s.Ctx,
 			UserID: &fxt.Identities[0].ID,
 		}
-		var convertChanges []convert.Change
+		var convertChanges []change.Change
 		_, convertChanges, err = action.OnChange(newVersion, contextChanges, "someNonJSON", &convertChanges)
 		require.NotNil(t, err)
 	})

--- a/actions/rules/action_nil.go
+++ b/actions/rules/action_nil.go
@@ -12,6 +12,6 @@ type ActionNil struct {
 var _ Action = ActionNil{}
 
 // OnChange executes the action rule.
-func (act ActionNil) OnChange(newContext change.Detector, contextChanges []change.Change, configuration string, actionChanges *[]change.Change) (change.Detector, []change.Change, error) {
+func (act ActionNil) OnChange(newContext change.Detector, contextChanges change.Set, configuration string, actionChanges *change.Set) (change.Detector, change.Set, error) {
 	return newContext, nil, nil
 }

--- a/actions/rules/action_nil.go
+++ b/actions/rules/action_nil.go
@@ -1,0 +1,17 @@
+package rules
+
+import (
+	"github.com/fabric8-services/fabric8-wit/convert"
+)
+
+// ActionNil is a dummy action rule that does nothing and has no sideffects.
+type ActionNil struct {
+}
+
+// make sure the rule is implementing the interface.
+var _ Action = ActionNil{}
+
+// OnChange executes the action rule.
+func (act ActionNil) OnChange(newContext convert.ChangeDetector, contextChanges []convert.Change, configuration string, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error) {
+	return newContext, nil, nil
+}

--- a/actions/rules/action_nil.go
+++ b/actions/rules/action_nil.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"github.com/fabric8-services/fabric8-wit/convert"
+	"github.com/fabric8-services/fabric8-wit/actions/change"
 )
 
 // ActionNil is a dummy action rule that does nothing and has no sideffects.
@@ -12,6 +12,6 @@ type ActionNil struct {
 var _ Action = ActionNil{}
 
 // OnChange executes the action rule.
-func (act ActionNil) OnChange(newContext convert.ChangeDetector, contextChanges []convert.Change, configuration string, actionChanges *[]convert.Change) (convert.ChangeDetector, []convert.Change, error) {
+func (act ActionNil) OnChange(newContext change.Detector, contextChanges []change.Change, configuration string, actionChanges *[]change.Change) (change.Detector, []change.Change, error) {
 	return newContext, nil, nil
 }

--- a/convert/changeset.go
+++ b/convert/changeset.go
@@ -2,7 +2,7 @@ package convert
 
 // ChangeDetector defines funcs for getting a changeset from two
 // instances of a class. This interface has to be implemented by
-// all
+// all entities that should trigger action rule runs.
 type ChangeDetector interface {
 	ChangeSet(older ChangeDetector) ([]Change, error)
 }

--- a/convert/changeset.go
+++ b/convert/changeset.go
@@ -1,0 +1,16 @@
+package convert
+
+// ChangeDetector defines funcs for getting a changeset from two
+// instances of a class. This interface has to be implemented by
+// all
+type ChangeDetector interface {
+	ChangeSet(older ChangeDetector) ([]Change, error)
+}
+
+// Change defines a set of changed values in an entity. It holds
+// the attribute name as the key and old and new values.
+type Change struct {
+	AttributeName string
+	NewValue      interface{}
+	OldValue      interface{}
+}

--- a/workitem/workitem.go
+++ b/workitem/workitem.go
@@ -59,11 +59,11 @@ func (wi WorkItem) GetLastModified() time.Time {
 }
 
 // ChangeSet derives a changeset between this workitem and a given workitem.
-func (wi WorkItem) ChangeSet(older change.Detector) ([]change.Change, error) {
+func (wi WorkItem) ChangeSet(older change.Detector) (change.Set, error) {
 	if older == nil {
 		// this is changeset for a new ChangeDetector, report all observed attributes to
 		// the change set. This needs extension once we support more attributes.
-		changeSet := []change.Change{
+		changeSet := change.Set{
 			{
 				AttributeName: SystemState,
 				NewValue:      wi.Fields[SystemState],

--- a/workitem/workitem.go
+++ b/workitem/workitem.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/log"
-	"github.com/fabric8-services/fabric8-wit/convert"
+	"github.com/fabric8-services/fabric8-wit/actions/change"
 
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -59,11 +59,11 @@ func (wi WorkItem) GetLastModified() time.Time {
 }
 
 // ChangeSet derives a changeset between this workitem and a given workitem.
-func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, error) {
+func (wi WorkItem) ChangeSet(older change.Detector) ([]change.Change, error) {
 	if older == nil {
 		// this is changeset for a new ChangeDetector, report all observed attributes to
 		// the change set. This needs extension once we support more attributes.
-		changeSet := []convert.Change{
+		changeSet := []change.Change{
 			{
 				AttributeName: SystemState,
 				NewValue:      wi.Fields[SystemState],
@@ -71,7 +71,7 @@ func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, er
 			},
 		}
 		if wi.Fields[SystemBoardcolumns] != nil && len(wi.Fields[SystemBoardcolumns].([]interface{})) != 0 {
-			changeSet = append(changeSet, convert.Change{
+			changeSet = append(changeSet, change.Change{
 				AttributeName: SystemBoardcolumns,
 				NewValue:      wi.Fields[SystemBoardcolumns],
 				OldValue:      nil,
@@ -86,14 +86,14 @@ func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, er
 	if wi.ID != olderWorkItem.ID {
 		return nil, errs.New("Other entity has not the same ID: " + olderWorkItem.ID.String())
 	}
-	changes := []convert.Change{}
+	changes := []change.Change{}
 	// CAUTION: we're only supporting changes to the system.state and to the
 	// board position relationship for now. If we need to support more
 	// attribute changes, this has to be added here. This will be likely
 	// necessary when adding new Actions.
 	// compare system.state
 	if wi.Fields[SystemState] != olderWorkItem.Fields[SystemState] {
-		changes = append(changes, convert.Change{
+		changes = append(changes, change.Change{
 			AttributeName: SystemState,
 			NewValue:      wi.Fields[SystemState],
 			OldValue:      olderWorkItem.Fields[SystemState],
@@ -106,7 +106,7 @@ func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, er
 		return changes, nil
 	}
 	if wi.Fields[SystemBoardcolumns] == nil || olderWorkItem.Fields[SystemBoardcolumns] == nil {
-		changes = append(changes, convert.Change{
+		changes = append(changes, change.Change{
 			AttributeName: SystemBoardcolumns,
 			NewValue:      wi.Fields[SystemBoardcolumns],
 			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],
@@ -119,7 +119,7 @@ func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, er
 			return changes, nil
 		}
 		// one of the lists is empty, do return a change.
-		changes = append(changes, convert.Change{
+		changes = append(changes, change.Change{
 			AttributeName: SystemBoardcolumns,
 			NewValue:      wi.Fields[SystemBoardcolumns],
 			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],
@@ -132,7 +132,7 @@ func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, er
 		return nil, errs.New("Boardcolumn slice is not a interface{} slice")
 	}
 	if len(bcThis) != len(bcOlder) {
-		changes = append(changes, convert.Change{
+		changes = append(changes, change.Change{
 			AttributeName: SystemBoardcolumns,
 			NewValue:      wi.Fields[SystemBoardcolumns],
 			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],
@@ -157,7 +157,7 @@ func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, er
 	sort.Strings(thisCopyStr)
 	sort.Strings(olderCopyStr)
 	if !reflect.DeepEqual(thisCopyStr, olderCopyStr) {
-		changes = append(changes, convert.Change{
+		changes = append(changes, change.Change{
 			AttributeName: SystemBoardcolumns,
 			NewValue:      wi.Fields[SystemBoardcolumns],
 			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],

--- a/workitem/workitem.go
+++ b/workitem/workitem.go
@@ -1,12 +1,12 @@
 package workitem
 
 import (
-	"sort"
 	"reflect"
+	"sort"
 	"time"
 
-	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/fabric8-services/fabric8-wit/actions/change"
+	"github.com/fabric8-services/fabric8-wit/log"
 
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"

--- a/workitem/workitem.go
+++ b/workitem/workitem.go
@@ -1,10 +1,14 @@
 package workitem
 
 import (
+	"sort"
+	"reflect"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/log"
+	"github.com/fabric8-services/fabric8-wit/convert"
 
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -52,4 +56,113 @@ func (wi WorkItem) GetLastModified() time.Time {
 
 	log.Debug(nil, map[string]interface{}{"wi_id": wi.ID}, "Last modified value: %v", lastModified)
 	return *lastModified
+}
+
+// ChangeSet derives a changeset between this workitem and a given workitem.
+func (wi WorkItem) ChangeSet(older convert.ChangeDetector) ([]convert.Change, error) {
+	if older == nil {
+		// this is changeset for a new ChangeDetector, report all observed attributes to
+		// the change set. This needs extension once we support more attributes.
+		changeSet := []convert.Change{
+			{
+				AttributeName: SystemState,
+				NewValue:      wi.Fields[SystemState],
+				OldValue:      nil,
+			},
+		}
+		if wi.Fields[SystemBoardcolumns] != nil && len(wi.Fields[SystemBoardcolumns].([]interface{})) != 0 {
+			changeSet = append(changeSet, convert.Change{
+				AttributeName: SystemBoardcolumns,
+				NewValue:      wi.Fields[SystemBoardcolumns],
+				OldValue:      nil,
+			})
+		}
+		return changeSet, nil
+	}
+	olderWorkItem, ok := older.(WorkItem)
+	if !ok {
+		return nil, errs.New("Other entity is not a WorkItem: " + reflect.TypeOf(older).String())
+	}
+	if wi.ID != olderWorkItem.ID {
+		return nil, errs.New("Other entity has not the same ID: " + olderWorkItem.ID.String())
+	}
+	changes := []convert.Change{}
+	// CAUTION: we're only supporting changes to the system.state and to the
+	// board position relationship for now. If we need to support more
+	// attribute changes, this has to be added here. This will be likely
+	// necessary when adding new Actions.
+	// compare system.state
+	if wi.Fields[SystemState] != olderWorkItem.Fields[SystemState] {
+		changes = append(changes, convert.Change{
+			AttributeName: SystemState,
+			NewValue:      wi.Fields[SystemState],
+			OldValue:      olderWorkItem.Fields[SystemState],
+		})
+	}
+	// compare system.boardcolumns
+	// this field looks like this:
+	// system.boardcolumns": ["43f9e838-3b4b-45e8-85eb-dd402e8324b5", "69699af8-cb28-4b90-b829-24c1aad12797"]
+	if wi.Fields[SystemBoardcolumns] == nil && olderWorkItem.Fields[SystemBoardcolumns] == nil {
+		return changes, nil
+	}
+	if wi.Fields[SystemBoardcolumns] == nil || olderWorkItem.Fields[SystemBoardcolumns] == nil {
+		changes = append(changes, convert.Change{
+			AttributeName: SystemBoardcolumns,
+			NewValue:      wi.Fields[SystemBoardcolumns],
+			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],
+		})
+		return changes, nil
+	}
+	if len(wi.Fields[SystemBoardcolumns].([]interface{})) == 0 || len(olderWorkItem.Fields[SystemBoardcolumns].([]interface{})) == 0 {
+		if len(wi.Fields[SystemBoardcolumns].([]interface{})) == 0 && len(olderWorkItem.Fields[SystemBoardcolumns].([]interface{})) == 0 {
+			// both lists are empty, return no change.
+			return changes, nil
+		}
+		// one of the lists is empty, do return a change.
+		changes = append(changes, convert.Change{
+			AttributeName: SystemBoardcolumns,
+			NewValue:      wi.Fields[SystemBoardcolumns],
+			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],
+		})
+		return changes, nil
+	}
+	bcThis, ok1 := wi.Fields[SystemBoardcolumns].([]interface{})
+	bcOlder, ok2 := olderWorkItem.Fields[SystemBoardcolumns].([]interface{})
+	if !ok1 || !ok2 {
+		return nil, errs.New("Boardcolumn slice is not a interface{} slice")
+	}
+	if len(bcThis) != len(bcOlder) {
+		changes = append(changes, convert.Change{
+			AttributeName: SystemBoardcolumns,
+			NewValue:      wi.Fields[SystemBoardcolumns],
+			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],
+		})
+		return changes, nil
+	}
+	// because of the handing of interface{}, we need to do manual conversion here.
+	thisCopyStr := make([]string, len(bcThis))
+	for i := range bcThis {
+		thisCopyStr[i], ok = bcThis[i].(string)
+		if !ok {
+			return nil, errs.New("Boardcolumn slice values are not of type string")
+		}
+	}
+	olderCopyStr := make([]string, len(bcOlder))
+	for i := range bcOlder {
+		olderCopyStr[i], ok = bcOlder[i].(string)
+		if !ok {
+			return nil, errs.New("Boardcolumn slice values are not of type string")
+		}
+	}
+	sort.Strings(thisCopyStr)
+	sort.Strings(olderCopyStr)
+	if !reflect.DeepEqual(thisCopyStr, olderCopyStr) {
+		changes = append(changes, convert.Change{
+			AttributeName: SystemBoardcolumns,
+			NewValue:      wi.Fields[SystemBoardcolumns],
+			OldValue:      olderWorkItem.Fields[SystemBoardcolumns],
+		})
+		return changes, nil
+	}
+	return changes, nil
 }


### PR DESCRIPTION
The actions system is a key component for process automation in WIT. It provides a way of executing user-configurable, dynamic process steps depending on user settings, schema settings and events in the WIT.

The idea here is to provide a simple, yet powerful "signal-slot" system that can connect any "event" in the system to any "action" with a clear decoupling of events and actions with the goal of making the associations later dynamic and configurable by the user ("user connects this event to this action"). Think of a "IFTTT for WIT".

Actions are generic and atomic execution steps that do exactly one task and are configurable. The actions system around the actions provide a key-based execution of the actions.

Some examples for an application of this system would be:

closing all childs of a parent that is being closed (the user connects the "close" attribute change event of a WI to an action that closes all WIs of a matching query).
sending out notifications for mentions on markdown (the system executes an action "send notification" for every mention found in markdown values).
moving all WIs from one iteration to the next in the time sequence when the original iteration is closed.
For all these automations, the actions system provides a re-usable, flexible and later user configurable way of doing that without creating lots of custom code and/or custom process implementations that are hardcoded in the WIT.

The current PR provides the basic actions infrastructure and an implementation of an example action rules for testing.