### PR TITLE
Default value

### DIFF
--- a/controller/test-files/work_item_type/list/ok_agile.res.payload.golden.json
+++ b/controller/test-files/work_item_type/list/ok_agile.res.payload.golden.json
@@ -416,6 +416,7 @@
             "required": false,
             "type": {
               "baseType": "string",
+              "defaultValue": "P3 - Medium",
               "kind": "enum",
               "values": [
                 "P1 - Critical",
@@ -458,6 +459,7 @@
             "required": false,
             "type": {
               "baseType": "string",
+              "defaultValue": "SEV3 - Medium",
               "kind": "enum",
               "values": [
                 "SEV1 - Urgent",

--- a/controller/test-files/work_item_type/list/ok_scrum.res.payload.golden.json
+++ b/controller/test-files/work_item_type/list/ok_scrum.res.payload.golden.json
@@ -709,6 +709,7 @@
             "required": false,
             "type": {
               "baseType": "string",
+              "defaultValue": "Medium",
               "kind": "enum",
               "values": [
                 "Critical",

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -146,10 +146,11 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		}
 		// convert list default value from app to model
 		if t.DefaultValue != nil {
-			listType, err = listType.SetDefaultValue(*t.DefaultValue)
+			fieldType, err := listType.SetDefaultValue(*t.DefaultValue)
 			if err != nil {
 				return nil, errs.Wrapf(err, "failed to convert default list value: %+v", *t.DefaultValue)
 			}
+			return fieldType, nil
 		}
 		return listType, nil
 	case workitem.KindEnum:
@@ -180,20 +181,22 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		}
 		// convert enum default value from app to model
 		if t.DefaultValue != nil {
-			enumType, err = enumType.SetDefaultValue(*t.DefaultValue)
+			fieldType, err := enumType.SetDefaultValue(*t.DefaultValue)
 			if err != nil {
 				return nil, errs.Wrapf(err, "failed to convert default enum value: %+v", *t.DefaultValue)
 			}
+			return fieldType, nil
 		}
 		return enumType, nil
 	default:
 		simpleType := workitem.SimpleType{Kind: *kind}
 		// convert simple type default value from app to model
 		if t.DefaultValue != nil {
-			simpleType, err = simpleType.SetDefaultValue(*t.DefaultValue)
+			fieldType, err := simpleType.SetDefaultValue(*t.DefaultValue)
 			if err != nil {
 				return nil, errs.Wrapf(err, "failed to convert default simple type value: %+v", *t.DefaultValue)
 			}
+			return fieldType, nil
 		}
 		return simpleType, nil
 	}

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -148,7 +148,7 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		if t.DefaultValue != nil {
 			defVal, err := listType.ConvertToModel(*t.DefaultValue)
 			if err != nil {
-				return nil, errs.Wrapf(err, "failed to convert default enum value: %+v", *t.DefaultValue)
+				return nil, errs.Wrapf(err, "failed to convert default list value: %+v", *t.DefaultValue)
 			}
 			listType.DefaultValue = defVal
 		}

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -101,16 +101,26 @@ func ConvertWorkItemTypeFromModel(request *http.Request, t *workitem.WorkItemTyp
 	return converted
 }
 
-// converts the field type from modesl to app representation
+// converts the field type from model to app representation
 func ConvertFieldTypeFromModel(t workitem.FieldType) app.FieldType {
 	result := app.FieldType{}
 	result.Kind = string(t.GetKind())
-	switch t2 := t.(type) {
+	switch modelFieldType := t.(type) {
 	case workitem.ListType:
-		result.ComponentType = ptr.String(string(t2.ComponentType.GetKind()))
+		result.ComponentType = ptr.String(string(modelFieldType.ComponentType.GetKind()))
+		if modelFieldType.DefaultValue != nil {
+			result.DefaultValue = &modelFieldType.DefaultValue
+		}
 	case workitem.EnumType:
-		result.BaseType = ptr.String(string(t2.BaseType.GetKind()))
-		result.Values = t2.Values
+		result.BaseType = ptr.String(string(modelFieldType.BaseType.GetKind()))
+		result.Values = modelFieldType.Values
+		if modelFieldType.DefaultValue != nil {
+			result.DefaultValue = &modelFieldType.DefaultValue
+		}
+	case workitem.SimpleType:
+		if modelFieldType.DefaultValue != nil {
+			result.DefaultValue = &modelFieldType.DefaultValue
+		}
 	}
 
 	return result
@@ -130,7 +140,19 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		if !componentType.IsSimpleType() {
 			return nil, fmt.Errorf("Component type is not list type: %T", componentType)
 		}
-		return workitem.ListType{workitem.SimpleType{*kind}, workitem.SimpleType{*componentType}}, nil
+		listType := workitem.ListType{
+			SimpleType:    workitem.SimpleType{Kind: *kind},
+			ComponentType: workitem.SimpleType{Kind: *componentType},
+		}
+		// convert list default value from app to model
+		if t.DefaultValue != nil {
+			defVal, err := listType.ConvertToModel(*t.DefaultValue)
+			if err != nil {
+				return nil, errs.Wrapf(err, "failed to convert default enum value: %+v", *t.DefaultValue)
+			}
+			listType.DefaultValue = defVal
+		}
+		return listType, nil
 	case workitem.KindEnum:
 		bt, err := workitem.ConvertAnyToKind(*t.BaseType)
 		if err != nil {
@@ -139,8 +161,9 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		if !bt.IsSimpleType() {
 			return nil, fmt.Errorf("baseType type is not list type: %T", bt)
 		}
-		baseType := workitem.SimpleType{*bt}
+		baseType := workitem.SimpleType{Kind: *bt}
 
+		// convert enum values from app to model
 		values := t.Values
 		converted, err := workitem.ConvertList(func(ft workitem.FieldType, element interface{}) (interface{}, error) {
 			return ft.ConvertToModel(element)
@@ -148,15 +171,34 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		if err != nil {
 			return nil, errs.WithStack(err)
 		}
-		return workitem.EnumType{ // TODO(kwk): handle RewritableValues here?
+
+		enumType := workitem.EnumType{ // TODO(kwk): handle RewritableValues here?
 			SimpleType: workitem.SimpleType{
 				Kind: *kind,
 			},
 			BaseType: baseType,
 			Values:   converted,
-		}, nil
+		}
+		// convert enum default value from app to model
+		if t.DefaultValue != nil {
+			defVal, err := enumType.ConvertToModel(*t.DefaultValue)
+			if err != nil {
+				return nil, errs.Wrapf(err, "failed to convert default enum value: %+v", *t.DefaultValue)
+			}
+			enumType.DefaultValue = defVal
+		}
+		return enumType, nil
 	default:
-		return workitem.SimpleType{*kind}, nil
+		simpleType := workitem.SimpleType{Kind: *kind}
+		// convert simple type default value from app to model
+		if t.DefaultValue != nil {
+			defVal, err := simpleType.ConvertToModel(*t.DefaultValue)
+			if err != nil {
+				return nil, errs.Wrapf(err, "failed to convert default simple type value: %+v", *t.DefaultValue)
+			}
+			simpleType.DefaultValue = defVal
+		}
+		return simpleType, nil
 	}
 }
 

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -146,11 +146,10 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		}
 		// convert list default value from app to model
 		if t.DefaultValue != nil {
-			defVal, err := listType.ConvertToModel(*t.DefaultValue)
+			listType, err = listType.SetDefaultValue(*t.DefaultValue)
 			if err != nil {
 				return nil, errs.Wrapf(err, "failed to convert default list value: %+v", *t.DefaultValue)
 			}
-			listType.DefaultValue = defVal
 		}
 		return listType, nil
 	case workitem.KindEnum:
@@ -181,22 +180,20 @@ func ConvertFieldTypeToModel(t app.FieldType) (workitem.FieldType, error) {
 		}
 		// convert enum default value from app to model
 		if t.DefaultValue != nil {
-			defVal, err := enumType.ConvertToModel(*t.DefaultValue)
+			enumType, err = enumType.SetDefaultValue(*t.DefaultValue)
 			if err != nil {
 				return nil, errs.Wrapf(err, "failed to convert default enum value: %+v", *t.DefaultValue)
 			}
-			enumType.DefaultValue = defVal
 		}
 		return enumType, nil
 	default:
 		simpleType := workitem.SimpleType{Kind: *kind}
 		// convert simple type default value from app to model
 		if t.DefaultValue != nil {
-			defVal, err := simpleType.ConvertToModel(*t.DefaultValue)
+			simpleType, err = simpleType.SetDefaultValue(*t.DefaultValue)
 			if err != nil {
 				return nil, errs.Wrapf(err, "failed to convert default simple type value: %+v", *t.DefaultValue)
 			}
-			simpleType.DefaultValue = defVal
 		}
 		return simpleType, nil
 	}

--- a/design/workitemtype.go
+++ b/design/workitemtype.go
@@ -12,7 +12,7 @@ var fieldType = a.Type("fieldType", func() {
 	a.Attribute("componentType", d.String, "The kind of type of the individual elements for a list type. Required for list types. Must be a simple type, not  enum or list")
 	a.Attribute("baseType", d.String, "The kind of type of the enumeration values for an enum type. Required for enum types. Must be a simple type, not  enum or list")
 	a.Attribute("values", a.ArrayOf(d.Any), "The possible values for an enum type. The values must be of a type convertible to the base type")
-
+	a.Attribute("defaultValue", d.Any, "Optional default value (if any)")
 	a.Required("kind")
 })
 

--- a/spacetemplate/assets/agile.yaml
+++ b/spacetemplate/assets/agile.yaml
@@ -123,6 +123,7 @@ work_item_types:
         - SEV2 - High
         - SEV3 - Medium
         - SEV4 - Low
+        default_value: SEV3 - Medium
     "priority":
       label: Priority
       description: The order in which the developer should resolve a defect.
@@ -137,6 +138,7 @@ work_item_types:
         - P2 - High
         - P3 - Medium
         - P4 - Low
+        default_value: P3 - Medium
     "resolution":
       label: Resolution
       description: >

--- a/spacetemplate/assets/scrum.yaml
+++ b/spacetemplate/assets/scrum.yaml
@@ -58,6 +58,7 @@ work_item_types:
           - Minor
           - Optional
           - Trivial
+          default_value: Minor
 
 - id: &impedimentID "ec6918d6-f732-4fc0-a902-6571415aa73c"
   extends: *scrumCommonTypeID
@@ -178,6 +179,7 @@ work_item_types:
         - High
         - Medium
         - Low
+        default_value: Medium
     "found_in":
       label: Found in
       description: >

--- a/spacetemplate/importer/import_helper.go
+++ b/spacetemplate/importer/import_helper.go
@@ -29,10 +29,14 @@ func (s *ImportHelper) Validate() error {
 		return errs.Wrap(err, "failed to validate space template")
 	}
 
-	// Ensure all artifacts have the correct space template ID set
+	// Ensure all artifacts have the correct space template ID set and are
+	// valid
 	for _, wit := range s.WITs {
 		if wit.SpaceTemplateID != s.Template.ID {
 			return errors.NewBadParameterError("work item types's space template ID", wit.SpaceTemplateID.String()).Expected(s.Template.ID.String())
+		}
+		if err := wit.Validate(); err != nil {
+			return errs.Wrapf(err, `failed to validate work item type "%s" (ID=%s)`, wit.Name, wit.ID)
 		}
 	}
 	for _, wilt := range s.WILTs {

--- a/spacetemplate/importer/importer_blackbox_test.go
+++ b/spacetemplate/importer/importer_blackbox_test.go
@@ -283,6 +283,7 @@ work_item_types:
       required: yes
       type:
         kind: string
+        default_value: "foobar"
     state:
       label: State
       description: The state of the bug
@@ -295,6 +296,7 @@ work_item_types:
         values:
           - new
           - closed
+        default_value: closed
     priority:
       label: Priority
       description: The priority of the bug
@@ -304,6 +306,7 @@ work_item_types:
           kind: list
         component_type:
           kind: integer
+        default_value: 42
 work_item_link_types:
 - id: "` + wiltID.String() + `"
   name: Blocker
@@ -375,7 +378,8 @@ func getValidTestTemplateParsed(t *testing.T, spaceTemplateID, witID, wiltID uui
 						Description: "The title of the bug",
 						Required:    true,
 						Type: workitem.SimpleType{
-							Kind: workitem.KindString,
+							Kind:         workitem.KindString,
+							DefaultValue: "foobar",
 						},
 					},
 					"state": {
@@ -390,6 +394,7 @@ func getValidTestTemplateParsed(t *testing.T, spaceTemplateID, witID, wiltID uui
 								"new",
 								"closed",
 							},
+							DefaultValue: "closed",
 						},
 					},
 					"priority": {
@@ -399,6 +404,7 @@ func getValidTestTemplateParsed(t *testing.T, spaceTemplateID, witID, wiltID uui
 						Type: workitem.ListType{
 							SimpleType:    workitem.SimpleType{Kind: workitem.KindList},
 							ComponentType: workitem.SimpleType{Kind: workitem.KindInteger},
+							DefaultValue:  42.0,
 						},
 					},
 				},

--- a/spacetemplate/importer/importer_blackbox_test.go
+++ b/spacetemplate/importer/importer_blackbox_test.go
@@ -305,8 +305,8 @@ work_item_types:
         simple_type:
           kind: list
         component_type:
-          kind: integer
-        default_value: 42
+          kind: float
+        default_value: 42.0
 work_item_link_types:
 - id: "` + wiltID.String() + `"
   name: Blocker
@@ -403,7 +403,7 @@ func getValidTestTemplateParsed(t *testing.T, spaceTemplateID, witID, wiltID uui
 						Required:    false,
 						Type: workitem.ListType{
 							SimpleType:    workitem.SimpleType{Kind: workitem.KindList},
-							ComponentType: workitem.SimpleType{Kind: workitem.KindInteger},
+							ComponentType: workitem.SimpleType{Kind: workitem.KindFloat},
 							DefaultValue:  42.0,
 						},
 					},

--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -145,10 +145,10 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 			loadedWIT.Icon = wit.Icon
 			loadedWIT.CanConstruct = wit.CanConstruct
 
-			//-----------------------------------------------------------------
-			// Double check all existing fields are still present in new fields
-			// with same type
-			//-----------------------------------------------------------------
+			//------------------------------------------------------------------
+			// Double check all fields from the old work item type are still
+			// present in new work item type and still have the same field type.
+			//------------------------------------------------------------------
 			// verify that FieldTypes are same as loadedWIT
 			toBeFoundFields := map[string]workitem.FieldType{}
 			for k, fd := range loadedWIT.Fields {

--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/id"
 	"github.com/fabric8-services/fabric8-wit/log"
@@ -178,7 +179,7 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 							equal = newEnum.EqualEnclosing(origEnum)
 						}
 						if !equal {
-							return errs.Errorf("type of the field %s changed from %s to %s", fieldName, oldFieldType, fd.Type)
+							return errs.Errorf("type of the field %s changed from %+v to %+v", fieldName, spew.Sdump(oldFieldType), spew.Sdump(fd.Type))
 						}
 					}
 				}

--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -157,6 +157,35 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 			for fieldName, fd := range wit.Fields {
 				// verify FieldType with original value
 				if originalType, ok := toBeFoundFields[fieldName]; ok {
+
+					// We always overwrite the default value for the comparison
+					// of field type to ignore the default value during
+					// comparison.
+
+					// determine new default value
+					var newDefVar interface{}
+					switch tmp := fd.Type.(type) {
+					case workitem.EnumType:
+						newDefVar = tmp.DefaultValue
+					case workitem.ListType:
+						newDefVar = tmp.DefaultValue
+					case workitem.SimpleType:
+						newDefVar = tmp.DefaultValue
+					}
+
+					// overwrite default value in old type
+					switch ft := originalType.(type) {
+					case workitem.EnumType:
+						ft.DefaultValue = newDefVar
+						originalType = ft
+					case workitem.ListType:
+						ft.DefaultValue = newDefVar
+						originalType = ft
+					case workitem.SimpleType:
+						ft.DefaultValue = newDefVar
+						originalType = ft
+					}
+
 					if equal := fd.Type.Equal(originalType); !equal {
 						// Special treatment for EnumType
 						origEnum, ok1 := originalType.(workitem.EnumType)

--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -158,9 +158,10 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 				// verify FieldType with original value
 				if originalType, ok := toBeFoundFields[fieldName]; ok {
 
-					// We always overwrite the default value for the comparison
-					// of field type to ignore the default value during
-					// comparison.
+					// When comparing the new and old field types we don't want
+					// to compare the default value. That is why we always
+					// temporarily overwrite the default value of the old type
+					// with the default value of the new type.
 
 					// determine new default value
 					var newDefVar interface{}

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -37,7 +37,7 @@ func (t EnumType) Validate() error {
 		return errs.Errorf(`enum has a base type "%s" but needs "%s"`, t.Kind, KindEnum)
 	}
 	if !t.BaseType.Kind.IsSimpleType() {
-		return errs.Errorf(`list type must have a simple component type and not "%s"`, t.Kind)
+		return errs.Errorf(`enum type must have a simple component type and not "%s"`, t.Kind)
 	}
 	if t.DefaultValue != nil {
 		_, err := t.ConvertToModel(t.DefaultValue)

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -34,7 +34,7 @@ var _ FieldType = (*EnumType)(nil)
 // allowed values and that the Values are all of the base type.
 func (t EnumType) Validate() error {
 	if t.Kind != KindEnum {
-		return errs.Errorf(`list type cannot have a base type "%s" but needs "%s"`, t.Kind, KindList)
+		return errs.Errorf(`enum has a base type "%s" but needs "%s"`, t.Kind, KindEnum)
 	}
 	if !t.BaseType.Kind.IsSimpleType() {
 		return errs.Errorf(`list type must have a simple component type and not "%s"`, t.Kind)

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -58,6 +58,10 @@ func (t EnumType) Validate() error {
 
 // SetDefaultValue implements FieldType
 func (t EnumType) SetDefaultValue(v interface{}) (FieldType, error) {
+	if v == nil {
+		t.DefaultValue = nil
+		return &t, nil
+	}
 	defVal, err := t.ConvertToModel(v)
 	if err != nil {
 		return nil, errs.Wrapf(err, "failed to set default value of enum type to %+v (%[1]T)", v)

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -58,24 +58,28 @@ func (t EnumType) Validate() error {
 	return nil
 }
 
+// SetDefaultValue implements FieldType
+func (t EnumType) SetDefaultValue(v interface{}) (FieldType, error) {
+	defVal, err := t.ConvertToModel(v)
+	if err != nil {
+		return nil, errs.Wrapf(err, "failed to set default value of enum type to %+v (%[1]T)", v)
+	}
+	t.DefaultValue = defVal
+	return &t, nil
+}
+
 // GetDefaultValue implements FieldType
-func (t EnumType) GetDefaultValue(value interface{}) (interface{}, error) {
-	if err := t.Validate(); err != nil {
-		return nil, errs.Wrapf(err, "failed to validate enum type")
-	}
-	if value != nil {
-		if !contains(t.Values, value) {
-			return nil, errs.Errorf(`value "%+v" is not among the set of allowed enum values: %+v`, value, t.Values)
-		}
-		return value, nil
-	}
+func (t EnumType) GetDefaultValue() interface{} {
 	// manual default value has precedence over first value in list of allowed
 	// values
 	if t.DefaultValue != nil {
-		return t.DefaultValue, nil
+		return t.DefaultValue
 	}
 	// fallback to first permitted element
-	return t.Values[0], nil
+	if len(t.Values) > 0 {
+		return t.Values[0]
+	}
+	return nil
 }
 
 // Ensure EnumType implements the Equaler interface

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -60,7 +60,7 @@ func (t EnumType) Validate() error {
 func (t EnumType) SetDefaultValue(v interface{}) (FieldType, error) {
 	if v == nil {
 		t.DefaultValue = nil
-		return &t, nil
+		return t, nil
 	}
 	defVal, err := t.ConvertToModel(v)
 	if err != nil {

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -42,7 +42,7 @@ func (t EnumType) Validate() error {
 	if t.DefaultValue != nil {
 		_, err := t.ConvertToModel(t.DefaultValue)
 		if err != nil {
-			return errs.Wrapf(err, `failed to convert default list value to kind "%s": %+v`, t.Kind, t.DefaultValue)
+			return errs.Wrapf(err, `failed to convert default enum value to kind "%s": %+v`, t.Kind, t.DefaultValue)
 		}
 	}
 	// verify that we have a set of permitted values

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -29,7 +29,7 @@ var _ FieldType = EnumType{}
 var _ FieldType = (*EnumType)(nil)
 
 // Validate checks that the type of the enum is "enum", that the base type
-// iteself a simple type (e.g. not a list or an enum), that the default value
+// itself a simple type (e.g. not a list or an enum), that the default value
 // matches the Kind of the BaseType, that the default value is in the list of
 // allowed values and that the Values are all of the base type.
 func (t EnumType) Validate() error {

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -39,11 +39,9 @@ func (t EnumType) Validate() error {
 	if !t.BaseType.Kind.IsSimpleType() {
 		return errs.Errorf(`enum type must have a simple component type and not "%s"`, t.Kind)
 	}
-	if t.DefaultValue != nil {
-		_, err := t.ConvertToModel(t.DefaultValue)
-		if err != nil {
-			return errs.Wrapf(err, `failed to convert default enum value to kind "%s": %+v`, t.Kind, t.DefaultValue)
-		}
+	_, err := t.SetDefaultValue(t.DefaultValue)
+	if err != nil {
+		return errs.Wrapf(err, "failed to validate default value for kind %s: %+v (%[1]T)", t.Kind, t.DefaultValue)
 	}
 	// verify that we have a set of permitted values
 	if t.Values == nil || len(t.Values) <= 0 {

--- a/workitem/enum_type.go
+++ b/workitem/enum_type.go
@@ -67,7 +67,7 @@ func (t EnumType) SetDefaultValue(v interface{}) (FieldType, error) {
 		return nil, errs.Wrapf(err, "failed to set default value of enum type to %+v (%[1]T)", v)
 	}
 	t.DefaultValue = defVal
-	return &t, nil
+	return t, nil
 }
 
 // GetDefaultValue implements FieldType

--- a/workitem/enum_type_blackbox_test.go
+++ b/workitem/enum_type_blackbox_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/convert"
 	"github.com/fabric8-services/fabric8-wit/resource"
-	"github.com/fabric8-services/fabric8-wit/workitem"
+	w "github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,26 +13,32 @@ func TestEnumType_Equal(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 
-	a := workitem.EnumType{
-		SimpleType:       workitem.SimpleType{Kind: workitem.KindEnum},
-		BaseType:         workitem.SimpleType{Kind: workitem.KindString},
+	a := w.EnumType{
+		SimpleType:       w.SimpleType{Kind: w.KindEnum},
+		BaseType:         w.SimpleType{Kind: w.KindString},
 		Values:           []interface{}{"foo", "bar"},
 		RewritableValues: false,
+		DefaultValue:     "fooooooobar",
 	}
-
 	t.Run("type inequality", func(t *testing.T) {
 		require.False(t, a.Equal(convert.DummyEqualer{}))
 	})
 
 	t.Run("simple type difference", func(t *testing.T) {
 		b := a
-		b.SimpleType = workitem.SimpleType{Kind: workitem.KindArea}
+		b.SimpleType = w.SimpleType{Kind: w.KindArea}
 		require.False(t, a.Equal(b))
 	})
 
 	t.Run("base type difference", func(t *testing.T) {
 		b := a
-		b.BaseType = workitem.SimpleType{Kind: workitem.KindInteger}
+		b.BaseType = w.SimpleType{Kind: w.KindInteger}
+		require.False(t, a.Equal(b))
+	})
+
+	t.Run("default value difference", func(t *testing.T) {
+		b := a
+		b.DefaultValue = "foo"
 		require.False(t, a.Equal(b))
 	})
 
@@ -68,26 +74,194 @@ func TestEnumType_Equal(t *testing.T) {
 	})
 }
 
+func TestEnumType_GetDefaultValue(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	tests := []struct {
+		name           string
+		enum           w.EnumType
+		input          interface{}
+		expectedOutput interface{}
+		wantErr        bool
+	}{
+		{"return first value of enum when input is nil", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindString},
+			Values:     []interface{}{"first", "second", "third"},
+		}, nil, "first", false},
+		{"return input value as is in list of allowed values", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindString},
+			Values:     []interface{}{"first", "second", "third"},
+		}, "second", "second", false},
+		{"return error when input value is not in list of allowed values", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindString},
+			Values:     []interface{}{"first", "second", "third"},
+		}, "fourth", nil, true},
+		{"return error when input value is of wrong type", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindString},
+			Values:     []interface{}{"first", "second", "third"},
+		}, 123, nil, true},
+		{"return input value converted to output type if possible", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindFloat},
+			Values:     []interface{}{111.3, 123.0, 222.1},
+		}, 123, 123.0, false},
+		{"return error when input value cannot be converted to output type", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindInteger},
+			Values:     []interface{}{111, 222, 333},
+		}, 222.0, 222, true},
+		{"return custom default when input value is nil", w.EnumType{
+			SimpleType:   w.SimpleType{Kind: w.KindEnum},
+			BaseType:     w.SimpleType{Kind: w.KindInteger},
+			Values:       []interface{}{111, 222, 333},
+			DefaultValue: 222,
+		}, nil, 222, false},
+		{"return error when custom default is of wrong type", w.EnumType{
+			SimpleType:   w.SimpleType{Kind: w.KindEnum},
+			BaseType:     w.SimpleType{Kind: w.KindInteger},
+			Values:       []interface{}{111, 222, 333},
+			DefaultValue: 222.0,
+		}, nil, nil, true},
+		{"return error when values are empty", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindInteger},
+			Values:     []interface{}{},
+		}, nil, nil, true},
+		{"return error when values are nil", w.EnumType{
+			SimpleType: w.SimpleType{Kind: w.KindEnum},
+			BaseType:   w.SimpleType{Kind: w.KindInteger},
+			Values:     nil,
+		}, nil, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output, err := tt.enum.GetDefaultValue(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedOutput, output)
+			}
+		})
+	}
+}
+func TestEnumType_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		obj     w.EnumType
+		wantErr bool
+	}{
+		{"ok", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindString},
+			Values:           []interface{}{"who", "let", "the", "dogs", "out"},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, false},
+		{"error - empty values", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindString},
+			Values:           []interface{}{},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"error - nil values", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindString},
+			Values:           nil,
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"invalid type", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindString},
+			BaseType:         w.SimpleType{Kind: w.KindString},
+			Values:           []interface{}{"who", "let", "the", "dogs", "out"},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"invalid base type (list)", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindList},
+			Values:           []interface{}{"who", "let", "the", "dogs", "out"},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"invalid base type (enum)", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindEnum},
+			Values:           []interface{}{"who", "let", "the", "dogs", "out"},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"invalid string values", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindString},
+			Values:           []interface{}{"who", 1, "the", "dogs", "out"},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"invalid integer values", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindInteger},
+			Values:           []interface{}{1, 2, "the", 4, 5},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"invalid default value (wrong type)", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindInteger},
+			Values:           []interface{}{1, 2, 3, 4, 5},
+			RewritableValues: false,
+			DefaultValue:     "the",
+		}, true},
+		{"invalid default value (not in allowed values)", w.EnumType{
+			SimpleType:       w.SimpleType{Kind: w.KindEnum},
+			BaseType:         w.SimpleType{Kind: w.KindInteger},
+			Values:           []interface{}{1, 2, 3, 4, 5},
+			RewritableValues: false,
+			DefaultValue:     42,
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.obj.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestEnumType_EqualEnclosing(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 
-	a := workitem.EnumType{
-		SimpleType:       workitem.SimpleType{Kind: workitem.KindEnum},
-		BaseType:         workitem.SimpleType{Kind: workitem.KindString},
+	a := w.EnumType{
+		SimpleType:       w.SimpleType{Kind: w.KindEnum},
+		BaseType:         w.SimpleType{Kind: w.KindString},
 		Values:           []interface{}{"foo", "bar", "baz"},
 		RewritableValues: false,
 	}
 
 	t.Run("simple type difference", func(t *testing.T) {
 		b := a
-		b.SimpleType = workitem.SimpleType{Kind: workitem.KindArea}
+		b.SimpleType = w.SimpleType{Kind: w.KindArea}
 		require.False(t, a.EqualEnclosing(b))
 	})
 
 	t.Run("base type difference", func(t *testing.T) {
 		b := a
-		b.BaseType = workitem.SimpleType{Kind: workitem.KindInteger}
+		b.BaseType = w.SimpleType{Kind: w.KindInteger}
 		require.False(t, a.EqualEnclosing(b))
 	})
 

--- a/workitem/enum_type_whitebox_test.go
+++ b/workitem/enum_type_whitebox_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEnumTypeContains(t *testing.T) {
@@ -101,74 +100,5 @@ func TestEnumTypeContainsAll(t *testing.T) {
 			needle{id: 4, name: "Four"},
 		}
 		assert.False(t, containsAll(haystack, needles))
-	})
-}
-
-func TestEnumTypeDefaultValue(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	// given
-	vals := []interface{}{"first", "second", "third"}
-	e := EnumType{
-		SimpleType: SimpleType{Kind: KindEnum},
-		BaseType:   SimpleType{Kind: KindString},
-		Values:     vals,
-	}
-
-	t.Run("default to first value of enum", func(t *testing.T) {
-		t.Parallel()
-		// when
-		def, err := e.DefaultValue(nil)
-		// then
-		require.NoError(t, err)
-		require.Equal(t, def, vals[0])
-	})
-
-	t.Run("return value as is if not nil", func(t *testing.T) {
-		t.Parallel()
-		// when
-		def, err := e.DefaultValue("second")
-		// then
-		require.NoError(t, err)
-		require.Equal(t, def, vals[1])
-	})
-
-	t.Run("return value as is (even if it is not one of the permissable values)", func(t *testing.T) {
-		t.Parallel()
-		// when
-		def, err := e.DefaultValue("not existing value")
-		// then
-		require.NoError(t, err)
-		require.Equal(t, def, "not existing value")
-	})
-
-	t.Run("return error when values are nil", func(t *testing.T) {
-		t.Parallel()
-		// given
-		a := EnumType{
-			SimpleType: SimpleType{Kind: KindEnum},
-			BaseType:   SimpleType{Kind: KindString},
-		}
-		// when
-		def, err := a.DefaultValue(nil)
-		// then
-		require.Error(t, err)
-		require.Nil(t, def)
-	})
-
-	t.Run("return error when values are empty", func(t *testing.T) {
-		t.Parallel()
-		// given
-		a := EnumType{
-			SimpleType: SimpleType{Kind: KindEnum},
-			BaseType:   SimpleType{Kind: KindString},
-			Values:     []interface{}{},
-		}
-		// when
-		def, err := a.DefaultValue(nil)
-		// then
-		require.Error(t, err)
-		require.Nil(t, def)
 	})
 }

--- a/workitem/field_definition.go
+++ b/workitem/field_definition.go
@@ -72,9 +72,15 @@ type FieldType interface {
 	ConvertFromModel(value interface{}) (interface{}, error)
 	// Implement the Equaler interface
 	Equal(u convert.Equaler) bool
-	// DefaultValue is called if a field is not specified. In it's simplest form
-	// the DefaultValue returns the given input value without any conversion.
-	DefaultValue(value interface{}) (interface{}, error)
+	// GetDefaultValue is called if a field is not specified. In it's simplest
+	// form the DefaultValue returns the given input value without any
+	// conversion. An implementation of GetDefaultValue() should always call
+	// Validate() as the first action to make sure the type is set up correctly.
+	GetDefaultValue(value interface{}) (interface{}, error)
+	// Validate checks that the type definition of a field is correct. Take a
+	// look at the implementation of this function to find out what's actually
+	// been checked for each individual type.
+	Validate() error
 }
 
 // FieldDefinition describes type & other restrictions of a field
@@ -93,8 +99,13 @@ var _ convert.Equaler = (*FieldDefinition)(nil)
 // Ensure FieldDefinition implements the json.Unmarshaler interface
 var _ json.Unmarshaler = (*FieldDefinition)(nil)
 
-// // Ensure FieldDefinition implements the yaml.Unmarshaler interface
-// var _ yaml.Unmarshaler = (*FieldDefinition)(nil)
+// Validate checks that a field has a proper setup
+func (f FieldDefinition) Validate() error {
+	if strings.TrimSpace(f.Label) == "" {
+		return errs.Errorf(`field label is empty "%s" when trimmed`, f.Label)
+	}
+	return f.Type.Validate()
+}
 
 // Equal returns true if two FieldDefinition objects are equal; otherwise false is returned.
 func (f FieldDefinition) Equal(u convert.Equaler) bool {
@@ -121,7 +132,7 @@ func (f FieldDefinition) Equal(u convert.Equaler) bool {
 func (f FieldDefinition) ConvertToModel(name string, value interface{}) (interface{}, error) {
 	// Overwrite value if default value if none was provided
 	if value == nil {
-		defValue, err := f.Type.DefaultValue(value)
+		defValue, err := f.Type.GetDefaultValue(value)
 		if err != nil {
 			return nil, errs.Wrapf(err, "failed to get default value for field \"%s\"", name)
 		}
@@ -183,19 +194,15 @@ func (f rawFieldDef) Equal(u convert.Equaler) bool {
 	if f.Description != other.Description {
 		return false
 	}
-	if f.Type == nil && other.Type == nil {
-		return true
+	if !reflect.DeepEqual(f.Type, other.Type) {
+		return false
 	}
-	if f.Type != nil && other.Type != nil {
-		return reflect.DeepEqual(f.Type, other.Type)
-	}
-	return false
+	return true
 }
 
 // UnmarshalJSON implements encoding/json.Unmarshaler
 func (f *FieldDefinition) UnmarshalJSON(bytes []byte) error {
 	temp := rawFieldDef{}
-
 	err := json.Unmarshal(bytes, &temp)
 	if err != nil {
 		return errs.Wrapf(err, "failed to unmarshall field definition into rawFieldDef")

--- a/workitem/field_definition.go
+++ b/workitem/field_definition.go
@@ -72,11 +72,11 @@ type FieldType interface {
 	ConvertFromModel(value interface{}) (interface{}, error)
 	// Implement the Equaler interface
 	Equal(u convert.Equaler) bool
-	// GetDefaultValue is called if a field is not specified. In it's simplest
-	// form the DefaultValue returns the given input value without any
-	// conversion. An implementation of GetDefaultValue() should always call
-	// Validate() as the first action to make sure the type is set up correctly.
-	GetDefaultValue(value interface{}) (interface{}, error)
+	// GetDefaultValue is called if a field's value is nil.
+	GetDefaultValue() interface{}
+	// SetDefaultValue returns a copy of the FieldType object at hand if there
+	// was no error setting the default value of that field type.
+	SetDefaultValue(v interface{}) (FieldType, error)
 	// Validate checks that the type definition of a field is correct. Take a
 	// look at the implementation of this function to find out what's actually
 	// been checked for each individual type.
@@ -132,11 +132,7 @@ func (f FieldDefinition) Equal(u convert.Equaler) bool {
 func (f FieldDefinition) ConvertToModel(name string, value interface{}) (interface{}, error) {
 	// Overwrite value if default value if none was provided
 	if value == nil {
-		defValue, err := f.Type.GetDefaultValue(value)
-		if err != nil {
-			return nil, errs.Wrapf(err, "failed to get default value for field \"%s\"", name)
-		}
-		value = defValue
+		value = f.Type.GetDefaultValue()
 	}
 
 	if f.Required {

--- a/workitem/json_storage.go
+++ b/workitem/json_storage.go
@@ -10,13 +10,15 @@ import (
 	errs "github.com/pkg/errors"
 )
 
+// Fields is a helper map that later gets replaced with the FieldDefinitions
+// type and only exists for parsing in content from JSON.
 type Fields map[string]interface{}
 
 // Ensure Fields implements the Equaler interface
 var _ convert.Equaler = Fields{}
 var _ convert.Equaler = (*Fields)(nil)
 
-// Ensure Fields implements the Scanner and Valuer interfaces
+// Ensure Fields implements the sql.Scanner and driver.Valuer interfaces
 var _ sql.Scanner = (*Fields)(nil)
 var _ driver.Valuer = (*Fields)(nil)
 
@@ -30,6 +32,7 @@ func (f Fields) Equal(u convert.Equaler) bool {
 	return reflect.DeepEqual(f, other)
 }
 
+// Value implements the driver.Valuer interface
 func (f Fields) Value() (driver.Value, error) {
 	return toBytes(f)
 }
@@ -41,6 +44,8 @@ func (f *Fields) Scan(src interface{}) error {
 	return fromBytes(src, f)
 }
 
+// FieldDefinitions define a map of field names pointing to their field
+// definition.
 type FieldDefinitions map[string]FieldDefinition
 
 // Ensure FieldDefinitions implements the Scanner and Valuer interfaces
@@ -57,6 +62,19 @@ func (j FieldDefinitions) Value() (driver.Value, error) {
 // See also https://github.com/jinzhu/gorm/issues/302#issuecomment-80566841
 func (j *FieldDefinitions) Scan(src interface{}) error {
 	return fromBytes(src, j)
+}
+
+// Validate checks that each field definition is valid
+func (j *FieldDefinitions) Validate() error {
+	if j == nil {
+		return errs.New("fields not defined")
+	}
+	for name, field := range *j {
+		if err := field.Validate(); err != nil {
+			return errs.Wrapf(err, "failed to validate field %s", name)
+		}
+	}
+	return nil
 }
 
 func toBytes(j interface{}) (driver.Value, error) {

--- a/workitem/list_type.go
+++ b/workitem/list_type.go
@@ -44,7 +44,7 @@ func (t ListType) Validate() error {
 func (t ListType) SetDefaultValue(v interface{}) (FieldType, error) {
 	if v == nil {
 		t.DefaultValue = nil
-		return &t, nil
+		return t, nil
 	}
 	defVal, err := t.ComponentType.ConvertToModel(v)
 	if err != nil {

--- a/workitem/list_type.go
+++ b/workitem/list_type.go
@@ -42,7 +42,7 @@ func (t ListType) Validate() error {
 
 // SetDefaultValue implements FieldType
 func (t ListType) SetDefaultValue(v interface{}) (FieldType, error) {
-	defVal, err := t.ConvertToModel(v)
+	defVal, err := t.ComponentType.ConvertToModel(v)
 	if err != nil {
 		return nil, errs.Wrapf(err, "failed to set default value of list type to %+v (%[1]T)", v)
 	}

--- a/workitem/list_type.go
+++ b/workitem/list_type.go
@@ -51,7 +51,7 @@ func (t ListType) SetDefaultValue(v interface{}) (FieldType, error) {
 		return nil, errs.Wrapf(err, "failed to set default value of list type to %+v (%[1]T)", v)
 	}
 	t.DefaultValue = defVal
-	return &t, nil
+	return t, nil
 }
 
 // GetDefaultValue implements FieldType

--- a/workitem/list_type.go
+++ b/workitem/list_type.go
@@ -42,6 +42,10 @@ func (t ListType) Validate() error {
 
 // SetDefaultValue implements FieldType
 func (t ListType) SetDefaultValue(v interface{}) (FieldType, error) {
+	if v == nil {
+		t.DefaultValue = nil
+		return &t, nil
+	}
 	defVal, err := t.ComponentType.ConvertToModel(v)
 	if err != nil {
 		return nil, errs.Wrapf(err, "failed to set default value of list type to %+v (%[1]T)", v)

--- a/workitem/list_type.go
+++ b/workitem/list_type.go
@@ -54,7 +54,10 @@ func (t ListType) GetDefaultValue(value interface{}) (interface{}, error) {
 		}
 		return v, nil
 	}
-	return t.DefaultValue, nil
+	if t.DefaultValue != nil {
+		return t.DefaultValue, nil
+	}
+	return value, nil
 }
 
 // Equal returns true if two ListType objects are equal; otherwise false is returned.

--- a/workitem/list_type.go
+++ b/workitem/list_type.go
@@ -33,11 +33,9 @@ func (t ListType) Validate() error {
 	if !t.ComponentType.Kind.IsSimpleType() {
 		return errs.Errorf(`list type must have a simple component type and not "%s"`, t.Kind)
 	}
-	if t.DefaultValue != nil {
-		_, err := t.ComponentType.ConvertToModel(t.DefaultValue)
-		if err != nil {
-			return errs.Wrapf(err, `failed to convert default list value to kind "%s": %+v`, t.Kind, t.DefaultValue)
-		}
+	_, err := t.SetDefaultValue(t.DefaultValue)
+	if err != nil {
+		return errs.Wrapf(err, "failed to validate default value for kind %s: %+v (%[1]T)", t.Kind, t.DefaultValue)
 	}
 	return nil
 }

--- a/workitem/list_type.go
+++ b/workitem/list_type.go
@@ -42,22 +42,19 @@ func (t ListType) Validate() error {
 	return nil
 }
 
+// SetDefaultValue implements FieldType
+func (t ListType) SetDefaultValue(v interface{}) (FieldType, error) {
+	defVal, err := t.ConvertToModel(v)
+	if err != nil {
+		return nil, errs.Wrapf(err, "failed to set default value of list type to %+v (%[1]T)", v)
+	}
+	t.DefaultValue = defVal
+	return &t, nil
+}
+
 // GetDefaultValue implements FieldType
-func (t ListType) GetDefaultValue(value interface{}) (interface{}, error) {
-	if err := t.Validate(); err != nil {
-		return nil, errs.Wrapf(err, "failed to validate list type")
-	}
-	if value != nil {
-		v, err := t.ComponentType.ConvertToModel(value)
-		if err != nil {
-			return nil, errs.Wrapf(err, `value "%+v" is not a valid list value`)
-		}
-		return v, nil
-	}
-	if t.DefaultValue != nil {
-		return t.DefaultValue, nil
-	}
-	return value, nil
+func (t ListType) GetDefaultValue() interface{} {
+	return t.DefaultValue
 }
 
 // Equal returns true if two ListType objects are equal; otherwise false is returned.

--- a/workitem/list_type_blackbox_test.go
+++ b/workitem/list_type_blackbox_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fabric8-services/fabric8-wit/resource"
 	. "github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListType_Equal(t *testing.T) {
@@ -42,4 +43,104 @@ func TestListType_Equal(t *testing.T) {
 	}
 	assert.True(t, d.Equal(a))
 	assert.True(t, a.Equal(d)) // test the inverse
+}
+
+func TestListType_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		obj     ListType
+		wantErr bool
+	}{
+		{"ok", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindString},
+			DefaultValue:  "the",
+		}, false},
+		{"invalid type", ListType{
+			SimpleType:    SimpleType{Kind: KindInteger},
+			ComponentType: SimpleType{Kind: KindString},
+			DefaultValue:  "the",
+		}, true},
+		{"invalid component type (enum)", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindEnum},
+			DefaultValue:  "the",
+		}, true},
+		{"invalid component type (list)", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindList},
+			DefaultValue:  "the",
+		}, true},
+		{"invalid default value (string expect, int provided)", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindString},
+			DefaultValue:  42,
+		}, true},
+		{"invalid default value (int expect, string provided)", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindInteger},
+			DefaultValue:  "foo",
+		}, true},
+		{"invalid default value (int expect, array of int provided)", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindInteger},
+			DefaultValue:  []int{1, 2, 3},
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.obj.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListType_GetDefaultValue(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		listType ListType
+		input    interface{}
+		output   interface{}
+		wantErr  bool
+	}{
+		{"ok - string list, input nil output default", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindString},
+			DefaultValue:  "the",
+		}, nil, "the", false},
+		{"ok - integer list, input nil output default", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindInteger},
+			DefaultValue:  123,
+		}, nil, 123, false},
+		{"ok - float list, input nil output default", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindFloat},
+			DefaultValue:  3.141,
+		}, nil, 3.141, false},
+		{"error - float not allowed in int list", ListType{
+			SimpleType:    SimpleType{Kind: KindList},
+			ComponentType: SimpleType{Kind: KindInteger},
+			DefaultValue:  333,
+		}, 3.141, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output, err := tt.listType.GetDefaultValue(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.output, output)
+			}
+		})
+	}
 }

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -31,11 +31,9 @@ func (t SimpleType) Validate() error {
 	if !t.Kind.IsSimpleType() {
 		return errs.New("a simple type can only have a simple type (e.g. no list or enum)")
 	}
-	if t.DefaultValue != nil {
-		_, err := t.ConvertToModel(t.DefaultValue)
-		if err != nil {
-			return errs.Wrapf(err, "failed to convert value to kind %s: %+v", t.Kind, t.DefaultValue)
-		}
+	_, err := t.SetDefaultValue(t.DefaultValue)
+	if err != nil {
+		return errs.Wrapf(err, "failed to validate default value for kind %s: %+v (%[1]T)", t.Kind, t.DefaultValue)
 	}
 	return nil
 }

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -49,7 +49,7 @@ func (t SimpleType) SetDefaultValue(v interface{}) (FieldType, error) {
 		return nil, errs.Wrapf(err, "failed to set default value of simple type to %+v (%[1]T)", v)
 	}
 	t.DefaultValue = defVal
-	return &t, nil
+	return t, nil
 }
 
 // GetDefaultValue implements FieldType

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -40,6 +40,10 @@ func (t SimpleType) Validate() error {
 
 // SetDefaultValue implements FieldType
 func (t SimpleType) SetDefaultValue(v interface{}) (FieldType, error) {
+	if v == nil {
+		t.DefaultValue = nil
+		return &t, nil
+	}
 	defVal, err := t.ConvertToModel(v)
 	if err != nil {
 		return nil, errs.Wrapf(err, "failed to set default value of simple type to %+v (%[1]T)", v)

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -19,7 +19,7 @@ type SimpleType struct {
 }
 
 // Ensure SimpleType implements the FieldType interface
-var _ FieldType = &SimpleType{}
+var _ FieldType = SimpleType{}
 var _ FieldType = (*SimpleType)(nil)
 
 // Ensure SimpleType implements the Equaler interface

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -42,7 +42,7 @@ func (t SimpleType) Validate() error {
 func (t SimpleType) SetDefaultValue(v interface{}) (FieldType, error) {
 	if v == nil {
 		t.DefaultValue = nil
-		return &t, nil
+		return t, nil
 	}
 	defVal, err := t.ConvertToModel(v)
 	if err != nil {

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -19,7 +19,7 @@ type SimpleType struct {
 }
 
 // Ensure SimpleType implements the FieldType interface
-var _ FieldType = SimpleType{}
+var _ FieldType = &SimpleType{}
 var _ FieldType = (*SimpleType)(nil)
 
 // Ensure SimpleType implements the Equaler interface
@@ -40,22 +40,19 @@ func (t SimpleType) Validate() error {
 	return nil
 }
 
+// SetDefaultValue implements FieldType
+func (t SimpleType) SetDefaultValue(v interface{}) (FieldType, error) {
+	defVal, err := t.ConvertToModel(v)
+	if err != nil {
+		return nil, errs.Wrapf(err, "failed to set default value of simple type to %+v (%[1]T)", v)
+	}
+	t.DefaultValue = defVal
+	return &t, nil
+}
+
 // GetDefaultValue implements FieldType
-func (t SimpleType) GetDefaultValue(value interface{}) (interface{}, error) {
-	if err := t.Validate(); err != nil {
-		return nil, errs.Wrapf(err, "failed to validate simple type")
-	}
-	if value != nil {
-		v, err := t.ConvertToModel(value)
-		if err != nil {
-			return nil, errs.Wrapf(err, `value "%+v" is not a valid simple value`)
-		}
-		return v, nil
-	}
-	if t.DefaultValue != nil {
-		return t.DefaultValue, nil
-	}
-	return value, nil
+func (t SimpleType) GetDefaultValue() interface{} {
+	return t.DefaultValue
 }
 
 // Equal returns true if two SimpleType objects are equal; otherwise false is returned.

--- a/workitem/simple_type_blackbox_test.go
+++ b/workitem/simple_type_blackbox_test.go
@@ -6,36 +6,95 @@ import (
 	"github.com/fabric8-services/fabric8-wit/convert"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	. "github.com/fabric8-services/fabric8-wit/workitem"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSimpleTypeEqual(t *testing.T) {
+func TestSimpleType_Equal(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 
-	// Test type difference
-	a := SimpleType{Kind: KindString}
-	assert.False(t, a.Equal(convert.DummyEqualer{}))
+	t.Run("type difference", func(t *testing.T) {
+		t.Parallel()
+		a := SimpleType{Kind: KindString}
+		require.False(t, a.Equal(convert.DummyEqualer{}))
+	})
 
-	// Test kind difference
-	b := SimpleType{Kind: KindInteger}
-	assert.False(t, a.Equal(b))
+	t.Run("kind difference", func(t *testing.T) {
+		t.Parallel()
+		a := SimpleType{Kind: KindString}
+		b := SimpleType{Kind: KindInteger}
+		require.False(t, a.Equal(b))
+	})
+
+	t.Run("default difference", func(t *testing.T) {
+		t.Parallel()
+		a := SimpleType{Kind: KindInteger, DefaultValue: 1}
+		b := SimpleType{Kind: KindInteger}
+		require.False(t, a.Equal(b))
+	})
 }
 
-func TestConvertToModel(t *testing.T) {
+func TestSimpleType_Validate(t *testing.T) {
 	t.Parallel()
-	resource.Require(t, resource.UnitTest)
+	tests := []struct {
+		name    string
+		obj     SimpleType
+		wantErr bool
+	}{
+		{"ok int field", SimpleType{Kind: KindInteger, DefaultValue: 333}, false},
+		{"ok string field", SimpleType{Kind: KindString, DefaultValue: "foo"}, false},
+		{"invalid default (int given, string expected)", SimpleType{Kind: KindString, DefaultValue: 333}, true},
+		{"ok string field", SimpleType{Kind: KindInteger, DefaultValue: "foo"}, true},
+		{"invalud kind (enum)", SimpleType{Kind: KindEnum, DefaultValue: "foo"}, true},
+		{"invalid kind (list)", SimpleType{Kind: KindList, DefaultValue: "foo"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.obj.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
-	// Test nil value
-	a := SimpleType{Kind: KindString}
-	res, err := a.ConvertToModel(nil)
-	assert.Nil(t, res)
-	require.NoError(t, err)
+func TestSimpleType_GetDefault(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		obj     SimpleType
+		intput  interface{}
+		output  interface{}
+		wantErr bool
+	}{
+		{"ok - int field: input nil output 333", SimpleType{Kind: KindInteger, DefaultValue: 333}, nil, 333, false},
+		{"ok - float field: input nil output 33.3", SimpleType{Kind: KindFloat, DefaultValue: 33.3}, nil, 33.3, false},
+		{"ok - string field: input nil output \"foo\"", SimpleType{Kind: KindString, DefaultValue: "foo"}, nil, "foo", false},
 
-	// Test default case in swtich statement
-	b := 42
-	res, err = a.ConvertToModel(&b)
-	assert.NotNil(t, err)
-	assert.Nil(t, res)
+		{"ok - int field: input 333 output 444", SimpleType{Kind: KindInteger, DefaultValue: 333}, 444, 444, false},
+		{"ok - float field: input 44.4 output 44.4", SimpleType{Kind: KindFloat, DefaultValue: 33.3}, 44.4, 44.4, false},
+		{"ok - string field: input \"bar\" output \"bar\"", SimpleType{Kind: KindString, DefaultValue: "foo"}, "bar", "bar", false},
+
+		{"error - list field is invalid for a simple type", SimpleType{Kind: KindList, DefaultValue: "foo"}, nil, nil, true},
+		{"error - enum field is invalid for a simple type", SimpleType{Kind: KindEnum, DefaultValue: "foo"}, nil, nil, true},
+
+		{"error - input int on string field", SimpleType{Kind: KindString, DefaultValue: "foo"}, 123, nil, true},
+		{"ok - input int on float field", SimpleType{Kind: KindFloat, DefaultValue: 123.0}, 22, 22.0, false},
+		{"ok - input float on int field", SimpleType{Kind: KindInteger, DefaultValue: 123}, 22.0, 22, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output, err := tt.obj.GetDefaultValue(tt.intput)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.output, output)
+			}
+		})
+	}
 }

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -728,7 +728,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, spaceID uuid.UUID, 
 		var err error
 		wi.Fields[fieldName], err = fieldDef.ConvertToModel(fieldName, fieldValue)
 		if err != nil {
-			return nil, errors.NewBadParameterError(fieldName, fieldValue)
+			return nil, errors.NewBadParameterError(fieldName, fieldValue) // TODO(kwk): Change errors pkg to consume the original error as well
 		}
 		if (fieldName == SystemAssignees || fieldName == SystemLabels || fieldName == SystemBoardcolumns) && fieldValue == nil {
 			delete(wi.Fields, fieldName)

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -1,13 +1,14 @@
 package workitem
 
 import (
+	"reflect"
 	"strings"
 	"time"
 
 	"github.com/fabric8-services/fabric8-wit/convert"
 	"github.com/fabric8-services/fabric8-wit/gormsupport"
 
-	"github.com/pkg/errors"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -112,6 +113,18 @@ type WorkItemType struct {
 	ChildTypeIDs []uuid.UUID `gorm:"-" json:"child_types,omitempty"`
 }
 
+// Validate runs some checks on the work item type to ensure the field
+// definitions make sense.
+func (wit WorkItemType) Validate() error {
+	if strings.TrimSpace(wit.Name) == "" {
+		return errs.Errorf(`work item type name "%s" when trimmed has a zero-length`, wit.Name)
+	}
+	if err := wit.Fields.Validate(); err != nil {
+		return errs.Wrapf(err, "failed to validate work item type's fields")
+	}
+	return nil
+}
+
 // GetTypePathSeparator returns the work item type's path separator "."
 func GetTypePathSeparator() string {
 	return pathSep
@@ -178,7 +191,7 @@ func (wit WorkItemType) Equal(u convert.Equaler) bool {
 	if wit.CanConstruct != other.CanConstruct {
 		return false
 	}
-	if !strPtrIsNilOrContentIsEqual(wit.Description, other.Description) {
+	if !reflect.DeepEqual(wit.Description, other.Description) {
 		return false
 	}
 	if wit.Icon != other.Icon {
@@ -232,7 +245,7 @@ func (wit WorkItemType) ConvertWorkItemStorageToModel(workItem WorkItemStorage) 
 		}
 		result.Fields[name], err = field.ConvertFromModel(name, workItem.Fields[name])
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		result.Fields[SystemOrder] = workItem.ExecutionOrder
 	}


### PR DESCRIPTION
## Defaults for fields

This change introduces the ability for any field type to OPTIONALLY specify a custom default value. See also https://openshift.io/openshiftio/Openshift_io/plan/detail/35 and https://github.com/openshiftio/openshift.io/issues/3832.

For lists and simple types, the only restriction is that the default value is of the same kind as the list or simple type (e.g. integer, float, string, user, label, ...). For enum fields the custom default value needs to be in the list of allowed values.

### Example usage of the feature

As an example, we've set the default for severity and priority fields to a medium value instead of the first on in the list, which would be a high severity/priority. (See also https://github.com/openshiftio/openshift.io/issues/3832)

## Improvements to tests

### Space template import
When a space template is imported it creates or overrides the work item types. With this change I've introduced a cascading validation that checks 

1. the work item types, 
2. the fields inside each work item type
3. the field type of each field.

This ensures that people don't accidentally specify a float default (e.g. `33.45`) for an integer field.

Before this change, most of the input and output validation happened at runtime when a value was converted into another representation. Now, the validation happens at import time and also when a default value for a field is calculated.
