### PR TITLE
Update gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -264,7 +264,10 @@
 
 [[projects]]
   name = "github.com/hashicorp/golang-lru"
-  packages = ["simplelru"]
+  packages = [
+    ".",
+    "simplelru"
+  ]
   revision = "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
 
 [[projects]]
@@ -728,6 +731,7 @@
     "pkg/runtime/serializer/versioning",
     "pkg/selection",
     "pkg/types",
+    "pkg/util/cache",
     "pkg/util/clock",
     "pkg/util/diff",
     "pkg/util/errors",
@@ -793,6 +797,7 @@
     "pkg/version",
     "rest",
     "rest/watch",
+    "tools/cache",
     "tools/clientcmd/api",
     "tools/metrics",
     "transport",
@@ -806,6 +811,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "53c6f4e21c8e66f22479929a8b3d16c2ba5df94f6a40ce8936ff8f0ce76e7469"
+  inputs-digest = "f80bc108fd9afc9fc9d238cf49b96bc6473111be28e02db2d8b5e6c049960788"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
The current gopkg.lock file is out of date. This PR fixes this.


Try `make dev` on current `master`. Notice the `gopkg.lock` file has been updated.