### PR TITLE
Add endpoint for workitem type change

### DIFF
--- a/controller/test-files/work_item/changeType/workitem_type.res.payload.golden.json
+++ b/controller/test-files/work_item/changeType/workitem_type.res.payload.golden.json
@@ -1,0 +1,94 @@
+{
+  "data": {
+    "attributes": {
+      "bar": null,
+      "fooBar": "alpha",
+      "fooo": 2.5,
+      "system.created_at": "0001-01-01T00:00:00Z",
+      "system.description": "```\nMissing fields in workitem type: Second WorkItem Type\n\nType1 bar : hello\nType1 fooBar : open\n```\n\n",
+      "system.description.markup": "Markdown",
+      "system.description.rendered": "\u003cpre\u003e\u003ccode class=\"prettyprint\"\u003e\u003cspan class=\"typ\"\u003eMissing\u003c/span\u003e \u003cspan class=\"pln\"\u003efields\u003c/span\u003e \u003cspan class=\"kwd\"\u003ein\u003c/span\u003e \u003cspan class=\"pln\"\u003eworkitem\u003c/span\u003e \u003cspan class=\"kwd\"\u003etype\u003c/span\u003e\u003cspan class=\"pun\"\u003e:\u003c/span\u003e \u003cspan class=\"typ\"\u003eSecond\u003c/span\u003e \u003cspan class=\"typ\"\u003eWorkItem\u003c/span\u003e \u003cspan class=\"typ\"\u003eType\u003c/span\u003e\n\n\u003cspan class=\"typ\"\u003eType1\u003c/span\u003e \u003cspan class=\"pln\"\u003ebar\u003c/span\u003e \u003cspan class=\"pun\"\u003e:\u003c/span\u003e \u003cspan class=\"pln\"\u003ehello\u003c/span\u003e\n\u003cspan class=\"typ\"\u003eType1\u003c/span\u003e \u003cspan class=\"pln\"\u003efooBar\u003c/span\u003e \u003cspan class=\"pun\"\u003e:\u003c/span\u003e \u003cspan class=\"pln\"\u003eopen\u003c/span\u003e\n\u003c/code\u003e\u003c/pre\u003e\n",
+      "system.metastate": null,
+      "system.number": 1,
+      "system.order": 1000,
+      "system.remote_item_id": null,
+      "system.state": "new",
+      "system.title": "work item 00000000-0000-0000-0000-000000000001",
+      "system.updated_at": "0001-01-01T00:00:00Z",
+      "version": 1
+    },
+    "id": "00000000-0000-0000-0000-000000000002",
+    "links": {
+      "related": "http:///api/workitems/00000000-0000-0000-0000-000000000002",
+      "self": "http:///api/workitems/00000000-0000-0000-0000-000000000002"
+    },
+    "relationships": {
+      "area": {},
+      "assignees": {},
+      "baseType": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000003",
+          "type": "workitemtypes"
+        },
+        "links": {
+          "self": "http:///api/workitemtypes/00000000-0000-0000-0000-000000000003"
+        }
+      },
+      "children": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000002/children"
+        },
+        "meta": {
+          "hasChildren": false
+        }
+      },
+      "comments": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000002/comments",
+          "self": "http:///api/workitems/00000000-0000-0000-0000-000000000002/relationships/comments"
+        }
+      },
+      "creator": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000004",
+          "type": "users"
+        },
+        "links": {
+          "related": "http:///api/users/00000000-0000-0000-0000-000000000004",
+          "self": "http:///api/users/00000000-0000-0000-0000-000000000004"
+        }
+      },
+      "events": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000002/events"
+        }
+      },
+      "iteration": {},
+      "labels": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000002/labels"
+        }
+      },
+      "space": {
+        "data": {
+          "id": "00000000-0000-0000-0000-000000000005",
+          "type": "spaces"
+        },
+        "links": {
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000005",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000005"
+        }
+      },
+      "system.boardcolumns": {},
+      "workItemLinks": {
+        "links": {
+          "related": "http:///api/workitems/00000000-0000-0000-0000-000000000002/links"
+        }
+      }
+    },
+    "type": "workitems"
+  },
+  "links": {
+    "self": "http:///api/workitems/00000000-0000-0000-0000-000000000002/relationships/basetype"
+  }
+}

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -287,6 +287,17 @@ func (c *WorkitemController) TypeChange(ctx *app.TypeChangeWorkitemContext) erro
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
+	creator := wi.Fields[workitem.SystemCreator]
+	if creator == nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, errs.New("work item doesn't have creator")))
+	}
+	authorized, err := c.authorizeWorkitemTypeEditor(ctx, wi.SpaceID, creator.(string), currentUserIdentityID.String())
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	if !authorized {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewForbiddenError("user is not authorized to change the workitemtype"))
+	}
 	var updatedWI *workitem.WorkItem
 	var rev *workitem.Revision
 	// Ensure we do not have any other field values apart from workitem version

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -1160,14 +1160,23 @@ func (s *WorkItem2Suite) TestWI2ChangeType() {
 	)
 	u := app.BaseTypeChange{
 		Data: &app.BaseTypeChangeData{
-			Attributes: &app.BaseTypeChangeAttributes{
-				Version: fxt.WorkItems[0].Version,
-				TypeID:  fxt.WorkItemTypes[1].ID,
+			ID:   fxt.WorkItemTypes[1].ID,
+			Type: APIStringTypeWorkItemType,
+			Relationships: &app.BaseTypeChangeRelationships{
+				Workitem: &app.BaseTypeChangeRelationshipWorkitem{
+					ID:   fxt.WorkItems[0].ID,
+					Type: APIStringTypeWorkItem,
+				},
+			},
+		},
+		Included: &app.BaseTypeChangeWorkitem{
+			Data: &app.BaseTypeChangeWorkitemData{
+				Attributes: map[string]interface{}{},
 			},
 			ID:   fxt.WorkItems[0].ID,
-			Type: APIStringTypeWorkItem,
-		},
+			Type: APIStringTypeWorkItem},
 	}
+	u.Included.Data.Attributes[workitem.SystemVersion] = fxt.WorkItems[0].Version
 	svc := testsupport.ServiceAsUser("TypeChangeService", *fxt.Identities[0])
 	s.T().Run("ok", func(t *testing.T) {
 		_, newWI := test.TypeChangeWorkitemOK(t, svc.Context, svc, s.workitemCtrl, fxt.WorkItems[0].ID, &u)

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -85,6 +85,25 @@ var workItemSingle = JSONSingle(
 	workItem,
 	workItemLinks)
 
+var baseTypeChange = a.Type("baseTypeChange", func() {
+	a.Attribute("data", baseTypeChangeData)
+	a.Required("data")
+})
+
+var baseTypeChangeData = a.Type("baseTypeChangeData", func() {
+	a.Attribute("attributes", func() {
+		a.Attribute("typeID", d.UUID, "ID of the new workitem type")
+		a.Attribute("version", d.Integer, "Version of the workitem")
+	})
+	a.Attribute("type", d.String, func() {
+		a.Enum("workitems")
+	})
+	a.Attribute("id", d.UUID, "ID of the work item which is being updated", func() {
+		a.Example("abcd1234-1234-5678-cafe-0123456789ab")
+	})
+	a.Required("attributes", "type")
+})
+
 // Reorder creates a UserTypeDefinition for Reorder action
 func Reorder(name, description string, data *d.UserTypeDefinition, position *d.UserTypeDefinition) *d.MediaTypeDefinition {
 	return a.MediaType("application/vnd."+strings.ToLower(name)+"json", func() {
@@ -180,6 +199,23 @@ var _ = a.Resource("workitem", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.Forbidden, JSONAPIErrors)
+	})
+
+	a.Action("type-change", func() {
+		a.Routing(
+			a.PATCH("/:wiID/relationships/basetype"),
+		)
+		a.Description("Change workitem type (basetype)")
+		a.Params(func() {
+			a.Param("wiID", d.UUID, "ID of the work item to change type")
+		})
+		a.Payload(baseTypeChange)
+		a.Response(d.OK, func() {
+			a.Media(workItemSingle)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
 	})
 })
 

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -87,21 +87,44 @@ var workItemSingle = JSONSingle(
 
 var baseTypeChange = a.Type("baseTypeChange", func() {
 	a.Attribute("data", baseTypeChangeData)
-	a.Required("data")
+	a.Attribute("included", baseTypeChangeWorkitem)
+	a.Required("data", "included")
 })
 
 var baseTypeChangeData = a.Type("baseTypeChangeData", func() {
-	a.Attribute("attributes", func() {
-		a.Attribute("typeID", d.UUID, "ID of the new workitem type")
-		a.Attribute("version", d.Integer, "Version of the workitem")
+	a.Attribute("id", d.UUID, "ID of the new work item type")
+	a.Attribute("type", d.String, func() {
+		a.Enum("workitemtypes")
 	})
+	a.Attribute("relationships", baseTypeChangeRelationships)
+	a.Required("id", "type", "relationships")
+})
+
+var baseTypeChangeRelationships = a.Type("baseTypeChangeRelationships", func() {
+	a.Attribute("workitem", baseTypeChangeRelationshipWorkitem)
+	a.Required("workitem")
+})
+
+var baseTypeChangeRelationshipWorkitem = a.Type("baseTypeChangeRelationshipWorkitem", func() {
 	a.Attribute("type", d.String, func() {
 		a.Enum("workitems")
 	})
-	a.Attribute("id", d.UUID, "ID of the work item which is being updated", func() {
-		a.Example("abcd1234-1234-5678-cafe-0123456789ab")
+	a.Attribute("id", d.UUID, "ID of the workitem")
+	a.Required("id", "type")
+})
+
+var baseTypeChangeWorkitem = a.Type("baseTypeChangeWorkitem", func() {
+	a.Attribute("data", baseTypeChangeWorkitemData)
+	a.Attribute("type", d.String, func() {
+		a.Enum("workitems")
 	})
-	a.Required("attributes", "type")
+	a.Attribute("id", d.UUID, "ID of the workitem")
+	a.Required("data", "id", "type")
+})
+
+var baseTypeChangeWorkitemData = a.Type("baseTypeChangeWorkitemData", func() {
+	a.Attribute("attributes", a.HashOf(d.String, d.Any))
+	a.Required("attributes")
 })
 
 // Reorder creates a UserTypeDefinition for Reorder action


### PR DESCRIPTION
See https://openshift.io/openshiftio/Openshift_io/plan/detail/522


Currently, the workitem type change code is part of the workitem `update` action and this adds unnecesary complexity to the `update` action. The type change implementation should be moved to a separate endpoint.

**Proposal**
We introduce a new endpoint `PATCH` on `/workitem/:workitemID/relationships/basetype`. This endpoint will accept a minimal workitem payload, something like
```
{
    "data": {
        "id": "30289812-f7fd-4b62-8521-b99ae3019e14",
        "type": "workitemtypes",
        "relationships": {
            "workitem": {
                "data": {
                    "id": "42bfa045-7755-4168-a5cc-88a974181a8a",
                    "type": "workitems"
                },
                "links": {
                    "related": "http:///api/workitems/42bfa045-7755-4168-a5cc-88a974181a8a",
                    "self": "http:///api/workitems/42bfa045-7755-4168-a5cc-88a974181a8a"
                }
            }
        }
    },
    "included": [{
        "attributes": {
            "version": "3"
        },
        "id": "42bfa045-7755-4168-a5cc-88a974181a8a",
        "type": "workitems"
    }]
}
```

**NOTE** - Type change functionality will still be available via `PATCH` on `/workitem/:wiID`