### PR TITLE
Fix searching in `null` field

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/fabric8-services/fabric8-wit/spacetemplate"
 
 	"github.com/fabric8-services/fabric8-wit/account"
@@ -349,21 +350,69 @@ func (s *searchControllerTestSuite) TestSearchWorkItemsWithoutSpaceContext() {
 }
 
 func (s *searchControllerTestSuite) TestSearchFilter() {
-	// given
-	fxt := tf.NewTestFixture(s.T(), s.DB,
-		tf.WorkItems(1, func(fxt *tf.TestFixture, idx int) error {
-			fxt.WorkItems[idx].Fields[workitem.SystemTitle] = "specialwordforsearch"
-			return nil
-		}),
-	)
-	// when
-	filter := fmt.Sprintf(`{"$AND": [{"space": "%s"}]}`, fxt.WorkItems[0].SpaceID)
-	spaceIDStr := fxt.WorkItems[0].SpaceID.String()
-	_, sr := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
-	// then
-	require.NotEmpty(s.T(), sr.Data)
-	r := sr.Data[0]
-	assert.Equal(s.T(), "specialwordforsearch", r.Attributes[workitem.SystemTitle])
+	// // given
+	// fxt := tf.NewTestFixture(s.T(), s.DB,
+	// 	tf.WorkItems(1, func(fxt *tf.TestFixture, idx int) error {
+	// 		fxt.WorkItems[idx].Fields[workitem.SystemTitle] = "specialwordforsearch"
+	// 		return nil
+	// 	}),
+	// )
+	// // when
+	// filter := fmt.Sprintf(`{"$AND": [{"space": "%s"}]}`, fxt.WorkItems[0].SpaceID)
+	// spaceIDStr := fxt.WorkItems[0].SpaceID.String()
+	// _, sr := test.ShowSearchOK(s.T(), nil, nil, s.controller, &filter, nil, nil, nil, nil, &spaceIDStr)
+	// // then
+	// require.NotEmpty(s.T(), sr.Data)
+	// r := sr.Data[0]
+	// assert.Equal(s.T(), "specialwordforsearch", r.Attributes[workitem.SystemTitle])
+
+	// regression test for https://github.com/fabric8-services/fabric8-wit/issues/2267
+	s.T().Run("work item created without board column assigned and then search for a board id", func(t *testing.T) {
+		s.DB.LogMode(true)
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.CreateWorkItemEnvironment(),
+			tf.WorkItemBoards(1),
+			tf.WorkItems(1),
+		)
+
+		spaceID := fxt.Spaces[0].ID
+
+		// // Create a work item
+		// //
+		// // NOTE: We explicitly DO NOT want to use the test fixutre here to find
+		// // out if the default for the board columns is handled differently when
+		// // the work item is created through the controller level.
+		// c := minimumRequiredCreatePayload(fxt.Spaces[0].ID)
+		// c.Data.Attributes[workitem.SystemTitle] = "Regression for #2267"
+		// c.Data.Relationships.BaseType = newRelationBaseType(fxt.WorkItemTypes[0].ID)
+		// // c.Data.Relationships.SystemBoardcolumns = &app.RelationGenericList{
+		// // 	Data: []*app.GenericData{},
+		// // }
+		// cfg, err := config.Get()
+		// workItemsCtrl := NewWorkitemsController(s.svc, s.GormDB, cfg)
+		// require.NoError(s.T(), err)
+		// test.CreateWorkitemsCreated(t, s.svc.Context, s.svc, workItemsCtrl, fxt.Spaces[0].ID, &c)
+		// search must not fail
+
+		db := s.DB.Exec(
+			fmt.Sprintf(
+				`UPDATE %[1]s SET fields = fields || '{"%[2]s": null}'::jsonb WHERE id=?`,
+				workitem.WorkItemStorage{}.TableName(),
+				workitem.SystemBoardcolumns,
+			),
+			fxt.WorkItems[0].ID,
+		)
+		require.NoError(t, db.Error)
+		require.Equal(t, int64(1), db.RowsAffected)
+
+		filter := fmt.Sprintf(`{"$AND": [{"space": "%s"}, {"board.id":{"$EQ":"%s"}}]}`, spaceID, fxt.WorkItemBoards[0].ID)
+		_, sr := test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, ptr.String(spaceID.String()))
+		require.NotNil(t, sr)
+		// no entries should be found
+		// require.Empty(t, sr.Data)
+		compareWithGolden(t, filepath.Join(s.testDir, "filter", "empty-boardcolumns.golden.json"), sr)
+		spew.Dump(sr)
+	})
 }
 
 func (s *searchControllerTestSuite) TestSearchByWorkItemTypeGroup() {

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -16,6 +16,8 @@ import (
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/fabric8-services/fabric8-wit/workitem/link"
+	"github.com/lib/pq"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,6 +227,45 @@ func (s *searchRepositoryBlackboxTest) TestSearchBoardColumnID() {
 				delete(mustHave, workItem.ID.String())
 			}
 			require.Empty(t, mustHave)
+		})
+		// regression test for https://github.com/fabric8-services/fabric8-wit/issues/2267
+		t.Run("work item created without board column set to null", func(t *testing.T) {
+			// given
+			fxt := tf.NewTestFixture(t, s.DB,
+				tf.CreateWorkItemEnvironment(),
+				tf.WorkItemBoards(1),
+				tf.WorkItems(1),
+			)
+			// Set the work board columns field to null
+			db := s.DB.Debug().Exec(
+				fmt.Sprintf(
+					`UPDATE %[1]s SET fields = fields || '{"%[2]s": null}'::jsonb WHERE id=?`,
+					workitem.WorkItemStorage{}.TableName(),
+					workitem.SystemBoardcolumns,
+				),
+				fxt.WorkItems[0].ID,
+			)
+			require.NoError(t, db.Error)
+			require.Equal(t, int64(1), db.RowsAffected)
+			// when
+			filter := fmt.Sprintf(`{"$AND": [{"space": "%s"}, {"board.id":{"$EQ":"%s"}}]}`, fxt.Spaces[0].ID, fxt.WorkItemBoards[0].ID)
+			s.DB.LogMode(true)
+			res, count, _, _, err := s.searchRepo.Filter(context.Background(), filter, nil, nil, nil)
+			s.DB.LogMode(true)
+
+			// then
+
+			// NOTE: Once
+			// https://github.com/fabric8-services/fabric8-wit/issues/2267 is
+			// fixed this should not throw an error.
+			require.Error(t, err)
+			cause := errs.Cause(err)
+			require.Error(t, cause)
+			pqError, ok := cause.(*pq.Error)
+			require.True(t, ok, "error should be a postgres error: %+v", cause)
+			require.Equal(t, "cannot extract elements from a scalar", pqError.Message)
+			require.Equal(t, 0, count)
+			require.Empty(t, res)
 		})
 	})
 }

--- a/workitem/expression_compiler.go
+++ b/workitem/expression_compiler.go
@@ -165,9 +165,11 @@ var DefaultTableJoins = func() TableJoinMap {
 			AllowedColumns:   []string{"name"},
 		},
 		"boardcolumns": {
-			TableName:        "(SELECT id colid, board_id id, jsonb_agg(id::text) AS colids FROM work_item_board_columns GROUP BY 1,2)",
-			TableAlias:       "boardcolumns",
-			On:               Column("boardcolumns", "colid") + "::text IN (SELECT jsonb_array_elements_text(" + Column(WorkItemStorage{}.TableName(), "fields") + "->'system.boardcolumns'))",
+			TableName:  `(SELECT id colid, board_id id, jsonb_agg(id::text) AS colids FROM work_item_board_columns GROUP BY 1,2)`,
+			TableAlias: "boardcolumns",
+			On: fmt.Sprintf(Column("boardcolumns", "colid")+`::text IN (
+				SELECT jsonb_array_elements_text(jsonb_strip_nulls(`+Column(WorkItemStorage{}.TableName(), "fields")+`)->'%s')
+			)`, SystemBoardcolumns),
 			PrefixActivators: []string{"board."},
 			AllowedColumns:   []string{"id"},
 		},


### PR DESCRIPTION
The problem in #2267 was that we were calling a JSONB function `jsonb_array_elements_text` on a JSONB field, namely `system.boardcolumns`, that was `NULL`. That caused a `pq: cannot extract elements from a scalar` error.

## How to reproduce the original bug

The problem can be re-constructed by executing this SQL command:

```sql
SELECT jsonb_array_elements_text(
  '{"system.boardcolumns": null}'::jsonb->'system.boardcolumns'
);
```

This will produce the `cannot extract elements from a scalar`.

## Fixing the problem

If you strip out all `null` values from the object before accessing the field `system.boardcolumns` the error has vanished:

```sql
SELECT jsonb_array_elements_text(
  jsonb_strip_nulls('{"system.boardcolumns": null}'::jsonb)->'system.boardcolumns'
);
```

## Proof that it works with not-`NULL` data

In the above example, the `system.boardcolumns` was purposefully set to `null` but to see it in action with a real array, you can do this:

```sql
SELECT jsonb_array_elements_text(jsonb_strip_nulls('{"system.boardcolumns": ["aa089753-9f08-460c-bf18-708046314e5f", "a9cac35d-6b5d-4d2d-9ace-b09e246d42d8"]}'::jsonb)->'system.boardcolumns');
``` 
This nicely produces the expected results:

```
+--------------------------------------+
| jsonb_array_elements_text            |
|--------------------------------------|
| aa089753-9f08-460c-bf18-708046314e5f |
| a9cac35d-6b5d-4d2d-9ace-b09e246d42d8 |
+--------------------------------------+
```