### PR TITLE
The board column tests don't cleanup after themselves.

### DIFF
--- a/controller/work_item_boardcolumns_blackbox_test.go
+++ b/controller/work_item_boardcolumns_blackbox_test.go
@@ -32,6 +32,7 @@ func TestRunWorkItemBoardcolumnREST(t *testing.T) {
 }
 
 func (l *TestWorkItemBoardcolumnREST) SetupTest() {
+	l.DBTestSuite.SetupTest()
 	req := &http.Request{Host: "localhost"}
 	params := url.Values{}
 	l.ctx = goa.NewContext(context.Background(), nil, req, params)


### PR DESCRIPTION
Possibly related to openshiftio/openshift.io#4299