### PR TITLE
Add deployments API to compute quota necessary for scale-up

### DIFF
--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -287,7 +287,7 @@ func (c *DeploymentsController) ShowDeploymentStatSeries(ctx *app.ShowDeployment
 
 // ShowDeploymentPodLimitRange runs the showDeploymentPodLimitRange action.
 func (c *DeploymentsController) ShowDeploymentPodLimitRange(ctx *app.ShowDeploymentPodLimitRangeDeploymentsContext) error {
-	// Inputs : appName, envName, spaceId
+	// Inputs : spaceId, appName, deployName
 	kc, err := c.GetKubeClient(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
@@ -297,7 +297,7 @@ func (c *DeploymentsController) ShowDeploymentPodLimitRange(ctx *app.ShowDeploym
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	quotas, err := kc.GetDeploymentPodQuota(*spaceName, ctx.AppName, ctx.EnvName)
+	quotas, err := kc.GetDeploymentPodQuota(*spaceName, ctx.AppName, ctx.DeployName)
 
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/deployments.go
+++ b/controller/deployments.go
@@ -285,6 +285,31 @@ func (c *DeploymentsController) ShowDeploymentStatSeries(ctx *app.ShowDeployment
 	return ctx.OK(res)
 }
 
+// ShowDeploymentPodLimitRange runs the showDeploymentPodLimitRange action.
+func (c *DeploymentsController) ShowDeploymentPodLimitRange(ctx *app.ShowDeploymentPodLimitRangeDeploymentsContext) error {
+	// Inputs : appName, envName, spaceId
+	kc, err := c.GetKubeClient(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	spaceName, err := c.getSpaceNameFromSpaceID(ctx, ctx.SpaceID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
+	quotas, err := kc.GetDeploymentPodQuota(*spaceName, ctx.AppName, ctx.EnvName)
+
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
+	res := &app.SimpleDeploymentPodLimitRangeSingle{
+		Data: quotas,
+	}
+
+	return ctx.OK(res)
+}
+
 func convertToTime(unixMillis int64) time.Time {
 	return time.Unix(0, unixMillis*int64(time.Millisecond))
 }

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -243,13 +243,13 @@ var _ = a.Resource("deployments", func() {
 
 	a.Action("showDeploymentPodLimitRange", func() {
 		a.Routing(
-			a.GET("/spaces/:spaceID/environments/:envName/applications/:appName/podlimits"),
+			a.GET("/spaces/:spaceID/applications/:appName/deployments/:deployName/podlimits"),
 		)
 		a.Description("get pod resource limit range")
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 			a.Param("appName", d.String, "Name of the application")
-			a.Param("envName", d.String, "Name of the environment")
+			a.Param("deployName", d.String, "Name of the deployment")
 		})
 		a.Response(d.OK, simpleDeploymentPodLimitRangeSingle)
 		a.Response(d.Unauthorized, JSONAPIErrors)

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -151,6 +151,11 @@ var simpleDeploymentStatSeries = a.Type("SimpleDeploymentStatSeries", func() {
 	a.Attribute("net_rx", a.ArrayOf(timedNumberTuple))
 })
 
+var simpleDeploymentPodLimitRange = a.Type("SimpleDeploymentPodLimitRange", func() {
+	a.Description("pod limit range")
+	a.Attribute("limits", podsQuota)
+})
+
 var simpleSpaceSingle = JSONSingle(
 	"SimpleSpace", "Holds a single response to a space request",
 	simpleSpace,
@@ -170,6 +175,11 @@ var simpleDeploymentStatsSingle = JSONSingle(
 var simpleDeploymentStatSeriesSingle = JSONSingle(
 	"SimpleDeploymentStatSeries", "Holds a response to a stat series query",
 	simpleDeploymentStatSeries,
+	nil)
+
+var simpleDeploymentPodLimitRangeSingle = JSONSingle(
+	"simpleDeploymentPodLimitRange", "Holds a response to a pod limit range query",
+	simpleDeploymentPodLimitRange,
 	nil)
 
 var _ = a.Resource("deployments", func() {
@@ -225,6 +235,23 @@ var _ = a.Resource("deployments", func() {
 			a.Param("limit", d.Integer, "maximum number of data points to return")
 		})
 		a.Response(d.OK, simpleDeploymentStatSeriesSingle)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.BadRequest, JSONAPIErrors)
+	})
+
+	a.Action("showDeploymentPodLimitRange", func() {
+		a.Routing(
+			a.GET("/spaces/:spaceID/environments/:envName/applications/:appName/podlimits"),
+		)
+		a.Description("get pod resource limit range")
+		a.Params(func() {
+			a.Param("spaceID", d.UUID, "ID of the space")
+			a.Param("appName", d.String, "Name of the application")
+			a.Param("envName", d.String, "Name of the environment")
+		})
+		a.Response(d.OK, simpleDeploymentPodLimitRangeSingle)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)

--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -1607,8 +1607,6 @@ func (kc *kubeClient) GetDeploymentPodQuota(spaceName string, appName string, en
 			return nil, convertError(errs.WithStack(err), "failed to get limit range %s in %s", limitRangeName, namespace)
 		}
 
-		defaultCPULimit := float64(0)
-		defaultMemLimit := float64(0)
 		var containerCPULimit, containerMemLimit *resource.Quantity
 		for _, limit := range limitRange.Spec.Limits {
 			if limit.Type == "Container" {
@@ -1631,11 +1629,11 @@ func (kc *kubeClient) GetDeploymentPodQuota(spaceName string, appName string, en
 			return nil, errs.Errorf("CPU or memory container limit missing from LimitRange for namespace %s", namespace)
 		}
 
-		defaultCPULimit, err = quantityToFloat64(*containerCPULimit)
+		defaultCPULimit, err := quantityToFloat64(*containerCPULimit)
 		if err != nil {
 			return nil, errs.Errorf("could not convert cpu quantity %+v to float64 value", *containerCPULimit)
 		}
-		defaultMemLimit, err = quantityToFloat64(*containerMemLimit)
+		defaultMemLimit, err := quantityToFloat64(*containerMemLimit)
 		if err != nil {
 			return nil, errs.Errorf("could not convert memory quantity %+v to float64 value", *containerMemLimit)
 		}

--- a/kubernetes/deployments_kubeclient.go
+++ b/kubernetes/deployments_kubeclient.go
@@ -1499,6 +1499,8 @@ func (kc *kubeClient) GetDeploymentPodQuota(spaceName string, appName string, en
 	deploymentConfig, err := kc.GetDeploymentConfig(namespace, dcName)
 	if err != nil {
 		return nil, errs.Errorf("could not retrieve deployment config with name %s for namespace %s", dcName, namespace)
+	} else if deploymentConfig == nil {
+		return nil, errors.NewNotFoundErrorFromString(fmt.Sprintf("no deployment config found named %s in %s", dcName, namespace))
 	}
 
 	spec, ok := deploymentConfig["spec"].(map[string]interface{})

--- a/kubernetes/deployments_kubeclient_blackbox_test.go
+++ b/kubernetes/deployments_kubeclient_blackbox_test.go
@@ -1543,6 +1543,95 @@ func verifyDeployment(dep *app.SimpleDeployment, testCase *deployTestData, t *te
 	}
 }
 
+func TestGetDeploymentPodQuota(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		spaceName    string
+		appName      string
+		envName      string
+		cassetteName string
+		expectedCPU  float64
+		expectedMem  float64
+		shouldFail   bool
+	}{
+		{
+			testName:     "Basic",
+			spaceName:    "mySpace",
+			appName:      "myApp",
+			envName:      "run",
+			cassetteName: "podquota",
+			expectedCPU:  1,
+			expectedMem:  262144000,
+		},
+		{
+			testName:     "Bad Environment",
+			spaceName:    "mySpace",
+			appName:      "myApp",
+			envName:      "doesNotExist",
+			cassetteName: "podquota",
+			shouldFail:   true,
+		},
+		{
+			testName:     "Multi Container",
+			spaceName:    "mySpace",
+			appName:      "myApp",
+			envName:      "run",
+			cassetteName: "podquota-multicontainer",
+			expectedCPU:  1.7,
+			expectedMem:  799014912,
+		},
+		{
+			testName:     "No Resources",
+			spaceName:    "mySpace",
+			appName:      "myApp",
+			envName:      "run",
+			cassetteName: "podquota-noresources",
+			expectedCPU:  1,
+			expectedMem:  536870912,
+		},
+		{
+			testName:     "Empty Resources",
+			spaceName:    "mySpace",
+			appName:      "myApp",
+			envName:      "run",
+			cassetteName: "podquota-emptyresources",
+			expectedCPU:  1,
+			expectedMem:  536870912,
+		},
+		{
+			testName:     "Split Limit Range",
+			spaceName:    "mySpace",
+			appName:      "myApp",
+			envName:      "run",
+			cassetteName: "podquota-split",
+			expectedCPU:  1,
+			expectedMem:  262144000,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			r, err := recorder.New(pathToTestJSON + testCase.cassetteName)
+			require.NoError(t, err, "Failed to open cassette")
+			defer r.Stop()
+
+			fixture := &testFixture{}
+			kc := getDefaultKubeClient(fixture, r.Transport, t)
+
+			quota, err := kc.GetDeploymentPodQuota(testCase.spaceName, testCase.appName, testCase.envName)
+			if testCase.shouldFail {
+				require.Error(t, err, "Expected an error")
+			} else {
+				require.NoError(t, err, "Unexpected error occurred")
+				require.NotNil(t, quota.Limits.Cpucores, "CPU limits must be non-nil")
+				require.InDelta(t, testCase.expectedCPU, *quota.Limits.Cpucores, fltDelta, "CPU limits are incorrect")
+				require.NotNil(t, quota.Limits.Memory, "Memory limits must be non-nil")
+				require.InDelta(t, testCase.expectedMem, *quota.Limits.Memory, fltDelta, "Memory limits are incorrect")
+			}
+		})
+	}
+}
+
 // code for test URL provider
 
 func (up *testURLProvider) GetAPIToken() (*string, error) {

--- a/test/kubernetes/podquota-emptyresources.yaml
+++ b/test/kubernetes/podquota-emptyresources.yaml
@@ -1,0 +1,397 @@
+---
+version: 1
+interactions:
+  # Builds
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyApp%2Cspace%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-run.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myApp",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myApp",
+                                "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myApp-1",
+                        "uid": "cc39e185-f392-40fe-9862-d7f559d17e3b"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Deployment Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+            },
+            "spec": {
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.2",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Limit Ranges
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/limitranges/resource-limits
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "LimitRange",
+            "metadata": {
+                "creationTimestamp": "2017-05-10T20:06:06Z",
+                "name": "resource-limits",
+                "namespace": "my-run",
+                "resourceVersion": "1214680542",
+                "selfLink": "/api/v1/namespaces/my-run/limitranges/resource-limits",
+                "uid": "7fcbb12d-d3fe-4e35-8d89-55605c488276"
+            },
+            "spec": {
+                "limits": [
+                    {
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Pod"
+                    },
+                    {
+                        "default": {
+                            "cpu": "1",
+                            "memory": "512Mi"
+                        },
+                        "defaultRequest": {
+                            "cpu": "20m",
+                            "memory": "256Mi"
+                        },
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Container"
+                    },
+                    {
+                        "max": {
+                            "storage": "1Gi"
+                        },
+                        "min": {
+                            "storage": "1Gi"
+                        },
+                        "type": "PersistentVolumeClaim"
+                    }
+                ]
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/podquota-multicontainer.yaml
+++ b/test/kubernetes/podquota-multicontainer.yaml
@@ -1,0 +1,468 @@
+---
+version: 1
+interactions:
+  # Builds
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyApp%2Cspace%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-run.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myApp",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myApp",
+                                "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myApp-1",
+                        "uid": "cc39e185-f392-40fe-9862-d7f559d17e3b"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Deployment Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+            },
+            "spec": {
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            },
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpucores": "700m"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.2",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Limit Ranges
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/limitranges/resource-limits
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "LimitRange",
+            "metadata": {
+                "creationTimestamp": "2017-05-10T20:06:06Z",
+                "name": "resource-limits",
+                "namespace": "my-run",
+                "resourceVersion": "1214680542",
+                "selfLink": "/api/v1/namespaces/my-run/limitranges/resource-limits",
+                "uid": "7fcbb12d-d3fe-4e35-8d89-55605c488276"
+            },
+            "spec": {
+                "limits": [
+                    {
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Pod"
+                    },
+                    {
+                        "default": {
+                            "cpu": "1",
+                            "memory": "512Mi"
+                        },
+                        "defaultRequest": {
+                            "cpu": "20m",
+                            "memory": "256Mi"
+                        },
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Container"
+                    },
+                    {
+                        "max": {
+                            "storage": "1Gi"
+                        },
+                        "min": {
+                            "storage": "1Gi"
+                        },
+                        "type": "PersistentVolumeClaim"
+                    }
+                ]
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/podquota-noresources.yaml
+++ b/test/kubernetes/podquota-noresources.yaml
@@ -1,0 +1,396 @@
+---
+version: 1
+interactions:
+  # Builds
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyApp%2Cspace%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-run.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myApp",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myApp",
+                                "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myApp-1",
+                        "uid": "cc39e185-f392-40fe-9862-d7f559d17e3b"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Deployment Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+            },
+            "spec": {
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.2",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Limit Ranges
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/limitranges/resource-limits
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "LimitRange",
+            "metadata": {
+                "creationTimestamp": "2017-05-10T20:06:06Z",
+                "name": "resource-limits",
+                "namespace": "my-run",
+                "resourceVersion": "1214680542",
+                "selfLink": "/api/v1/namespaces/my-run/limitranges/resource-limits",
+                "uid": "7fcbb12d-d3fe-4e35-8d89-55605c488276"
+            },
+            "spec": {
+                "limits": [
+                    {
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Pod"
+                    },
+                    {
+                        "default": {
+                            "cpu": "1",
+                            "memory": "512Mi"
+                        },
+                        "defaultRequest": {
+                            "cpu": "20m",
+                            "memory": "256Mi"
+                        },
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Container"
+                    },
+                    {
+                        "max": {
+                            "storage": "1Gi"
+                        },
+                        "min": {
+                            "storage": "1Gi"
+                        },
+                        "type": "PersistentVolumeClaim"
+                    }
+                ]
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/podquota-split.yaml
+++ b/test/kubernetes/podquota-split.yaml
@@ -1,0 +1,406 @@
+---
+version: 1
+interactions:
+  # Builds
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyApp%2Cspace%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-run.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myApp",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myApp",
+                                "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myApp-1",
+                        "uid": "cc39e185-f392-40fe-9862-d7f559d17e3b"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Deployment Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+            },
+            "spec": {
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.2",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Limit Ranges
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/limitranges/resource-limits
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "LimitRange",
+            "metadata": {
+                "creationTimestamp": "2017-05-10T20:06:06Z",
+                "name": "resource-limits",
+                "namespace": "my-run",
+                "resourceVersion": "1214680542",
+                "selfLink": "/api/v1/namespaces/my-run/limitranges/resource-limits",
+                "uid": "7fcbb12d-d3fe-4e35-8d89-55605c488276"
+            },
+            "spec": {
+                "limits": [
+                    {
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Pod"
+                    },
+                    {
+                        "default": {
+                            "cpu": "1"
+                        },
+                        "defaultRequest": {
+                            "cpu": "20m",
+                            "memory": "256Mi"
+                        },
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Container"
+                    },
+                                        {
+                        "default": {
+                            "memory": "512Mi"
+                        },
+                        "type": "Container"
+                    },
+                    {
+                        "max": {
+                            "storage": "1Gi"
+                        },
+                        "min": {
+                            "storage": "1Gi"
+                        },
+                        "type": "PersistentVolumeClaim"
+                    }
+                ]
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/podquota.yaml
+++ b/test/kubernetes/podquota.yaml
@@ -1,0 +1,401 @@
+---
+version: 1
+interactions:
+  # Builds
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyApp%2Cspace%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-run.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myApp",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myApp",
+                                "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myApp-1",
+                        "uid": "cc39e185-f392-40fe-9862-d7f559d17e3b"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Deployment Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+            },
+            "spec": {
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.2",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Limit Ranges
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/limitranges/resource-limits
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "LimitRange",
+            "metadata": {
+                "creationTimestamp": "2017-05-10T20:06:06Z",
+                "name": "resource-limits",
+                "namespace": "my-run",
+                "resourceVersion": "1214680542",
+                "selfLink": "/api/v1/namespaces/my-run/limitranges/resource-limits",
+                "uid": "7fcbb12d-d3fe-4e35-8d89-55605c488276"
+            },
+            "spec": {
+                "limits": [
+                    {
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Pod"
+                    },
+                    {
+                        "default": {
+                            "cpu": "1",
+                            "memory": "512Mi"
+                        },
+                        "defaultRequest": {
+                            "cpu": "20m",
+                            "memory": "256Mi"
+                        },
+                        "max": {
+                            "cpu": "2",
+                            "memory": "1Gi"
+                        },
+                        "min": {
+                            "cpu": "7m",
+                            "memory": "100Mi"
+                        },
+                        "type": "Container"
+                    },
+                    {
+                        "max": {
+                            "storage": "1Gi"
+                        },
+                        "min": {
+                            "storage": "1Gi"
+                        },
+                        "type": "PersistentVolumeClaim"
+                    }
+                ]
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/podquota.yaml
+++ b/test/kubernetes/podquota.yaml
@@ -328,6 +328,20 @@ interactions:
       - application/json;charset=UTF-8
     status: 200 OK
     code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-stage/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
   # Limit Ranges
 - request:
     body: ""


### PR DESCRIPTION
This PR adds a new API serviced by the deployments controller at `/deployments/spaces/{spaceID}/applications/{appName}/deployments/{deployName}/podlimits`. 

Calling this API on a particular deployment determines the CPU and memory resources required in order to add a new pod to the deployment. This will allow the front-end to decide whether to stop the user from attempting to scale up a deployment if they do not have sufficient quota to do so successfully.

Example usage:
Request: `GET https://openshift.io/api/deployments/spaces/$SPACE/applications/$APP/deployments/run/podlimits`
Response: `{"data":{"limits":{"cpucores":1,"memory":262144000}}}`

This work was initially done by @chrislessard, and I have added tests and some modifications.

Fixes: https://github.com/openshiftio/openshift.io/issues/3388