### PR TITLE
Improve perf of calculating WIs in iteration

### DIFF
--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -950,7 +950,7 @@ func (r *GormWorkItemRepository) getAllIterationWithCounts(ctx context.Context, 
 	db = r.db.Table(workitemTableName).Select(`
 		iterations.id AS IterationId,
 		count(*) AS Total,
-		count(1) FILTER (WHERE fields->>'system.state' = 'closed') AS Closed
+		count(*) FILTER (WHERE fields->>'system.state' ILIKE 'closed') AS Closed
 	`).Joins(`
 		LEFT JOIN iterations
 		ON

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -952,7 +952,7 @@ func (r *GormWorkItemRepository) getAllIterationWithCounts(ctx context.Context, 
 		count(*) AS Total,
 		count(*) FILTER (WHERE fields->>'system.state' ILIKE 'closed') AS Closed
 	`).Joins(`
-		LEFT JOIN iterations
+		INNER JOIN iterations
 		ON
 			iterations.space_id = $1
 			AND fields @> concat('{"system.iteration": "', iterations.id, '"}')::jsonb


### PR DESCRIPTION
We're seriously wasting time in calculating numbers of work items in
iterations by ignoring the fact that we're in a space. @pbergene gave
me a dump of slow queries this morning and while I was looking for
something completely else I noticed this piece:

```
 "Query Text": "SELECT iterations.id as IterationId, count(*) as Total,\
\    \    \    count( case fields->>'system.state' when 'closed' then '1' else null end ) as Closed FROM \\"work_items\\" left join iterations\
\    \    \    on fields@> concat('{\\"system.iteration\\": \\"', iterations.id, '\\"}')::jsonb WHERE (iterations.space_id = $1\
\    \    \    and work_items.deleted_at IS NULL) GROUP BY IterationId",
```

This query is so slow (~55 to 60ms) that and it appears so often that
the log of slow queries is cluttered with this.

This change is supposed to address this by limiting the number of work
items that are queried to the current space. Also the counting is
simplified by using PostgreSQLs `FILTER` expression (see
https://www.postgresql.org/docs/9.6/static/sql-expressions.html). We have
switched from a `LEFT JOIN` to an `INNER JOIN` for because we can
discard work items in the search result if they don't have an iteration
assigned (thanks to @jarifibrahim for measuring this here: https://github.com/fabric8-services/fabric8-wit/pull/2294#issuecomment-423544436).

No functionality should have been changed which is why all the test
should continue to work as expected.