### PR TITLE
Double the amount of allowed time for a pod to be ready

### DIFF
--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -171,7 +171,7 @@ objects:
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
-            failureThreshold: 6
+            failureThreshold: 12
             httpGet:
               path: /api/status
               port: 8080


### PR DESCRIPTION
from 60 seconds to now 120 seconds

See #2291