### PR TITLE
acquire exclusive lock on spaces, areas, iterations and work_item_number_sequences table to avoid deadlock during migration

### DIFF
--- a/migration/sql-files/106-number-sequences.sql
+++ b/migration/sql-files/106-number-sequences.sql
@@ -1,4 +1,4 @@
-LOCK spaces, iterations IN EXCLUSIVE MODE;
+LOCK spaces, iterations, areas, work_item_number_sequences IN EXCLUSIVE MODE;
 
 -- Create the number sequences table
 CREATE TABLE number_sequences (

--- a/migration/sql-files/106-number-sequences.sql
+++ b/migration/sql-files/106-number-sequences.sql
@@ -1,3 +1,5 @@
+LOCK spaces, iterations IN EXCLUSIVE MODE;
+
 -- Create the number sequences table
 CREATE TABLE number_sequences (
     space_id uuid REFERENCES spaces(id) ON DELETE CASCADE,


### PR DESCRIPTION
In order to avoid the following deadlock situation, the 106 migration now acquires an exclusive lock on the `spaces`, `iterations`, `areas` and `work_item_number_sequences` tables.

Legend:
 - relation `36029` = `spaces`
 - relation `36042` = `iterations`

```
2018-09-26 07:55:25 UTC:172.31.53.17(37984):dbadmin@postgres:[875]:ERROR:  deadlock detected
2018-09-26 07:55:25 UTC:172.31.53.17(37984):dbadmin@postgres:[875]:DETAIL:  Process 875 waits for AccessExclusiveLock on relation 36029 of database 13322; blocked by process 5634.
    Process 5634 waits for AccessShareLock on relation 36042 of database 13322; blocked by process 875.
    Process 875: -- Create the number sequences table
    CREATE TABLE number_sequences (
        space_id uuid REFERENCES spaces(id) ON DELETE CASCADE,
        table_name text CHECK (trim(table_name::text) <> ''),
        current_val INTEGER NOT NULL,
        PRIMARY KEY (space_id, table_name)
    );
    
    -- Update existing iterations and areas with new "number" column and fill in the
    -- numbers in the order iterations and areas have been created.
    ALTER TABLE iterations ADD COLUMN number INTEGER;
    ALTER TABLE areas ADD COLUMN number INTEGER;
    
    UPDATE iterations SET number = seq.row_number
    FROM (SELECT id, space_id, created_at, row_number() OVER (PARTITION BY space_id ORDER BY created_at ASC) FROM iterations) AS seq
    WHERE iterations.id = seq.id;
    
    UPDATE areas SET number = seq.row_number
    FROM (SELECT id, space_id, created_at, row_number() OVER (PARTITION BY space_id ORDER BY created_at ASC) FROM areas) AS seq
    WHERE areas.id = seq.id;
    
    -- Make number a required column and add an index for faster querying over space_id and number
    ALTER TABLE iterations ALTE
    Process 5634: SELECT * FROM "iterations"  WHERE "iterations"."deleted_at" IS NULL AND ((space_id = $1 AND nlevel(path)=1)) ORDER BY "iterations"."id" ASC LIMIT 1
```