### PR TITLE
Add API to show resource usage for the current space

### DIFF
--- a/controller/deployments_blackbox_test.go
+++ b/controller/deployments_blackbox_test.go
@@ -82,13 +82,13 @@ type deleteTestResults struct {
 	envName   string
 }
 
-func (c *testKubeClient) DeleteDeployment(spaceName string, appName string, envName string) error {
-	c.deleteResults = &deleteTestResults{
+func (kc *testKubeClient) DeleteDeployment(spaceName string, appName string, envName string) error {
+	kc.deleteResults = &deleteTestResults{
 		spaceName: spaceName,
 		appName:   appName,
 		envName:   envName,
 	}
-	return c.fixture.deleteDeploymentError
+	return kc.fixture.deleteDeploymentError
 }
 
 func (fixture *deploymentsTestFixture) GetAndCheckOSIOClient(ctx context.Context) (controller.OpenshiftIOClient, error) {
@@ -589,11 +589,11 @@ func TestShowSpaceEnvironments(t *testing.T) {
 func TestShowEnvironmentsBySpace(t *testing.T) {
 
 	fakeEnvName := "fakeEnvName"
-	fakeCpuCores := 6.0
+	fakeCPUCores := 6.0
 	fakeMemUsage := 5.0
 
 	fakeQuota := &app.SpaceEnvironmentUsageQuota{
-		Cpucores: &fakeCpuCores,
+		Cpucores: &fakeCPUCores,
 		Memory:   &fakeMemUsage,
 	}
 

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -158,31 +158,32 @@ var simpleDeploymentPodLimitRange = a.Type("SimpleDeploymentPodLimitRange", func
 
 var spaceAndOtherEnvironmentUsage = a.Type("SpaceAndOtherEnvironmentUsage", func() {
 	a.Description("Environment usage by specific space and all others")
-	a.Attribute("SpaceUsage", a.ArrayOf(spaceEnvironmentUsage))
-	a.Attribute("OtherUsage", a.ArrayOf(simpleEnvironment))
+	a.Attribute("type", d.String, "The type of the related resource", func() {
+		a.Enum("environment")
+	})
+	a.Attribute("id", d.String, "ID of the environment (same as 'name')")
+	a.Attribute("attributes", spaceAndOtherEnvironmentAttributes)
+	a.Required("type", "id", "attributes")
 })
 
-var spaceEnvironmentUsage = a.Type("SpaceEnvironmentUsage", func() {
-	a.Description("Environment usage info for a single space")
-	a.Attribute("attributes", spaceEnvironmentUsageAttributes)
-})
-
-var spaceEnvironmentUsageAttributes = a.Type("SpaceEnvironmentUsageAttributes", func() {
+var spaceAndOtherEnvironmentAttributes = a.Type("SpaceAndOtherEnvironmentUsageAttributes", func() {
 	a.Description("Attributes for environment usage info for a single space")
-	a.Attribute("Name", d.String)
-	a.Attribute("Quota", spaceEnvironmentUsageQuota)
+	a.Attribute("name", d.String)
+	a.Attribute("space_usage", spaceEnvironmentUsageQuota)
+	a.Attribute("other_usage", envStats)
 })
 
 var spaceEnvironmentUsageQuota = a.Type("SpaceEnvironmentUsageQuota", func() {
-	a.Description("Quota info for a single spaces environment usage")
-	a.Attribute("CPUCores", d.Number)
-	a.Attribute("Memory", d.Number)
+	a.Description("Quota info for space-aware environment usage")
+	a.Attribute("cpucores", d.Number)
+	a.Attribute("memory", d.Number)
 })
 
-var simpleSpaceAndOtherEnvironmentUsage = JSONSingle(
-	"SimpleSpaceAndOtherEnvironmentUsage",
-	"Holds a single response to a space environment usage request",
+var spaceAndOtherEnvironmentUsageMultiple = JSONList(
+	"spaceAndOtherEnvironmentUsage",
+	"Holds a response to environment usage for a space compared to other spaces",
 	spaceAndOtherEnvironmentUsage,
+	nil,
 	nil)
 
 var simpleSpaceSingle = JSONSingle(
@@ -191,7 +192,7 @@ var simpleSpaceSingle = JSONSingle(
 	nil)
 
 var simpleEnvironmentMultiple = JSONList(
-	"SimpleEnvironment", "Holds a response to a space/environment request",
+	"SimpleEnvironment", "Holds a response to a environment request",
 	simpleEnvironment,
 	nil,
 	nil)
@@ -322,15 +323,32 @@ var _ = a.Resource("deployments", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 	})
 
+	// FIXME Keep original API around until frontend is completely moved over to
+	// showEnvironmentsBySpace, since this is a breaking change.
 	a.Action("showSpaceEnvironments", func() {
 		a.Routing(
 			a.GET("/spaces/:spaceID/environments"),
+		)
+		a.Description("DEPRECATED: please use /environments/spaces/:spaceID instead")
+		a.Params(func() {
+			a.Param("spaceID", d.UUID, "ID of the space")
+		})
+		a.Response(d.OK, simpleEnvironmentMultiple)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.BadRequest, JSONAPIErrors)
+	})
+
+	a.Action("showEnvironmentsBySpace", func() {
+		a.Routing(
+			a.GET("/environments/spaces/:spaceID"),
 		)
 		a.Description("list all environments for a space and information for all others")
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 		})
-		a.Response(d.OK, simpleSpaceAndOtherEnvironmentUsage)
+		a.Response(d.OK, spaceAndOtherEnvironmentUsageMultiple)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)

--- a/design/deployments.go
+++ b/design/deployments.go
@@ -156,6 +156,35 @@ var simpleDeploymentPodLimitRange = a.Type("SimpleDeploymentPodLimitRange", func
 	a.Attribute("limits", podsQuota)
 })
 
+var spaceAndOtherEnvironmentUsage = a.Type("SpaceAndOtherEnvironmentUsage", func() {
+	a.Description("Environment usage by specific space and all others")
+	a.Attribute("SpaceUsage", a.ArrayOf(spaceEnvironmentUsage))
+	a.Attribute("OtherUsage", a.ArrayOf(simpleEnvironment))
+})
+
+var spaceEnvironmentUsage = a.Type("SpaceEnvironmentUsage", func() {
+	a.Description("Environment usage info for a single space")
+	a.Attribute("attributes", spaceEnvironmentUsageAttributes)
+})
+
+var spaceEnvironmentUsageAttributes = a.Type("SpaceEnvironmentUsageAttributes", func() {
+	a.Description("Attributes for environment usage info for a single space")
+	a.Attribute("Name", d.String)
+	a.Attribute("Quota", spaceEnvironmentUsageQuota)
+})
+
+var spaceEnvironmentUsageQuota = a.Type("SpaceEnvironmentUsageQuota", func() {
+	a.Description("Quota info for a single spaces environment usage")
+	a.Attribute("CPUCores", d.Number)
+	a.Attribute("Memory", d.Number)
+})
+
+var simpleSpaceAndOtherEnvironmentUsage = JSONSingle(
+	"SimpleSpaceAndOtherEnvironmentUsage",
+	"Holds a single response to a space environment usage request",
+	spaceAndOtherEnvironmentUsage,
+	nil)
+
 var simpleSpaceSingle = JSONSingle(
 	"SimpleSpace", "Holds a single response to a space request",
 	simpleSpace,
@@ -297,11 +326,11 @@ var _ = a.Resource("deployments", func() {
 		a.Routing(
 			a.GET("/spaces/:spaceID/environments"),
 		)
-		a.Description("list all environments for a space")
+		a.Description("list all environments for a space and information for all others")
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 		})
-		a.Response(d.OK, simpleEnvironmentMultiple)
+		a.Response(d.OK, simpleSpaceAndOtherEnvironmentUsage)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)

--- a/test/kubernetes/getspaceandotherenvironmentusage-rq-error.yaml
+++ b/test/kubernetes/getspaceandotherenvironmentusage-rq-error.yaml
@@ -1,0 +1,124 @@
+---
+version: 1
+interactions:
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas/compute-resources
+    method: GET
+  response:
+    body: |
+        {
+            "kind": "Status",
+            "apiVersion": "v1",
+            "metadata": {},
+            "status": "Failure",
+            "message": "resourcequotas \"compute-resources\" not found",
+            "reason": "NotFound",
+            "details": {
+                "name": "compute-resources",
+                "kind": "resourcequotas"
+            },
+            "code": 404
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas/compute-resources
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "ResourceQuota",
+            "metadata": {
+                "creationTimestamp": "2017-05-10T20:06:15Z",
+                "name": "compute-resources",
+                "namespace": "my-stage",
+                "resourceVersion": "1066766807",
+                "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
+                "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
+            },
+            "spec": {
+                "hard": {
+                    "limits.cpu": "2",
+                    "limits.memory": "1Gi"
+                },
+                "scopes": [
+                    "NotTerminating"
+                ]
+            },
+            "status": {
+                "hard": {
+                    "limits.cpu": "2",
+                    "limits.memory": "1Gi"
+                },
+                "used": {
+                    "limits.cpu": "1488m",
+                    "limits.memory": "762Mi"
+                }
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas/compute-resources
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "ResourceQuota",
+            "metadata": {
+                "creationTimestamp": "2017-05-10T20:06:06Z",
+                "name": "compute-resources",
+                "namespace": "myNamespace",
+                "resourceVersion": "682306837",
+                "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
+                "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
+            },
+            "spec": {
+                "hard": {
+                    "limits.cpu": "2",
+                    "limits.memory": "1Gi"
+                },
+                "scopes": [
+                    "NotTerminating"
+                ]
+            },
+            "status": {
+                "hard": {
+                    "limits.cpu": "2",
+                    "limits.memory": "1Gi"
+                },
+                "used": {
+                    "limits.cpu": "0",
+                    "limits.memory": "0"
+                }
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200

--- a/test/kubernetes/getspaceandotherenvironmentusage-rq-error.yaml
+++ b/test/kubernetes/getspaceandotherenvironmentusage-rq-error.yaml
@@ -1,74 +1,411 @@
 ---
 version: 1
 interactions:
-  # Resource Quotas
+  # Build Configs
 - request:
     body: ""
     form: {}
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas/compute-resources
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/buildconfigs?labelSelector=space%3DmySpace
     method: GET
   response:
     body: |
         {
-            "kind": "Status",
             "apiVersion": "v1",
+            "kind": "BuildConfigList",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "BuildConfig",
+                    "metadata": {
+                        "annotations": {
+                            "che.fabric8.io/stack": "java-centos",
+                            "jenkins.openshift.org/disable-sync-create-on": "jenkins",
+                            "jenkins.openshift.org/generated-by": "jenkins",
+                            "jenkins.openshift.org/job-path": "myUser/myApp/master"
+                        },
+                        "creationTimestamp": "2018-01-17T20:23:30Z",
+                        "labels": {
+                            "space": "mySpace"
+                        },
+                        "name": "myApp",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "828221505",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/buildconfigs/myApp",
+                        "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                    },
+                    "spec": {
+                        "failedBuildsHistoryLimit": 5,
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "runPolicy": "Serial",
+                        "source": {
+                            "git": {
+                                "ref": "master",
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "successfulBuildsHistoryLimit": 5,
+                        "triggers": [
+                            {
+                                "generic": {
+                                    "secret": "mySecret"
+                                },
+                                "type": "Generic"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "lastVersion": 4
+                    }
+                }
+            ],
             "metadata": {},
-            "status": "Failure",
-            "message": "resourcequotas \"compute-resources\" not found",
-            "reason": "NotFound",
-            "details": {
-                "name": "compute-resources",
-                "kind": "resourcequotas"
-            },
-            "code": 404
+            "resourceVersion": "",
+            "selfLink": ""
         }
     headers:
       Content-Type:
       - application/json;charset=UTF-8
-    status: 404 Not Found
-    code: 404
+    status: 200 OK
+    code: 200
+  # Builds
 - request:
     body: ""
     form: {}
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas/compute-resources
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyApp%2Cspace%3DmySpace
     method: GET
   response:
     body: |
         {
             "apiVersion": "v1",
-            "kind": "ResourceQuota",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-run.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myApp",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myApp",
+                                "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myApp-1",
+                        "uid": "cc39e185-f392-40fe-9862-d7f559d17e3b"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Deployment Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
             "metadata": {
-                "creationTimestamp": "2017-05-10T20:06:15Z",
-                "name": "compute-resources",
-                "namespace": "my-stage",
-                "resourceVersion": "1066766807",
-                "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
-                "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
             },
             "spec": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
                 },
-                "scopes": [
-                    "NotTerminating"
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.2",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
                 ]
             },
             "status": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
                 },
-                "used": {
-                    "limits.cpu": "1488m",
-                    "limits.memory": "762Mi"
-                }
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
             }
         }
     headers:
@@ -82,40 +419,1128 @@ interactions:
     headers:
       Content-Type:
       - application/json
-    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas/compute-resources
+    url: http://api.myCluster/oapi/v1/namespaces/my-stage/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/deploymentconfigs/myApp
+    method: GET
+  response:
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
+  # Routes
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/routes
     method: GET
   response:
     body: |
         {
             "apiVersion": "v1",
-            "kind": "ResourceQuota",
-            "metadata": {
-                "creationTimestamp": "2017-05-10T20:06:06Z",
-                "name": "compute-resources",
-                "namespace": "myNamespace",
-                "resourceVersion": "682306837",
-                "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
-                "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
-            },
-            "spec": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Route",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/host.generated": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:29:33Z",
+                        "labels": {
+                            "app": "myOtherDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "version": "1.0.1"
+                        },
+                        "name": "myOtherDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837351613",
+                        "selfLink": "/oapi/v1/namespaces/my-run/routes/myOtherDeploy",
+                        "uid": "ba127f7e-c735-4470-a96f-e3462a050d0a"
+                    },
+                    "spec": {
+                        "host": "myOtherDeploy-my-run.example.com",
+                        "port": {
+                            "targetPort": 8080
+                        },
+                        "to": {
+                            "kind": "Service",
+                            "name": "myOtherDeploy",
+                            "weight": 100
+                        },
+                        "wildcardPolicy": "None"
+                    },
+                    "status": {
+                        "ingress": [
+                            {
+                                "conditions": [
+                                    {
+                                        "lastTransitionTime": "2018-01-25T16:29:33Z",
+                                        "status": "True",
+                                        "type": "Admitted"
+                                    }
+                                ],
+                                "host": "myOtherDeploy-my-run.example.com",
+                                "routerCanonicalHostname": "router.example.com",
+                                "routerName": "router",
+                                "wildcardPolicy": "None"
+                            }
+                        ]
+                    }
                 },
-                "scopes": [
-                    "NotTerminating"
-                ]
-            },
-            "status": {
-                "hard": {
-                    "limits.cpu": "2",
-                    "limits.memory": "1Gi"
-                },
-                "used": {
-                    "limits.cpu": "0",
-                    "limits.memory": "0"
+                {
+                    "apiVersion": "v1",
+                    "kind": "Route",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/host.generated": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:08Z",
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837362360",
+                        "selfLink": "/oapi/v1/namespaces/my-run/routes/myDeploy",
+                        "uid": "d727601d-8c5a-4271-bd1b-90929461c947"
+                    },
+                    "spec": {
+                        "host": "myDeploy-my-run.example.com",
+                        "port": {
+                            "targetPort": 8080
+                        },
+                        "to": {
+                            "kind": "Service",
+                            "name": "myDeploy",
+                            "weight": 100
+                        },
+                        "wildcardPolicy": "None"
+                    },
+                    "status": {
+                        "ingress": [
+                            {
+                                "conditions": [
+                                    {
+                                        "lastTransitionTime": "2018-01-25T16:33:09Z",
+                                        "status": "True",
+                                        "type": "Admitted"
+                                    }
+                                ],
+                                "host": "myDeploy-my-run.example.com",
+                                "routerCanonicalHostname": "router.example.com",
+                                "routerName": "router",
+                                "wildcardPolicy": "None"
+                            }
+                        ]
+                    }
                 }
-            }
+            ],
+            "kind": "RouteList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Replication Controllers
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/replicationcontrollers
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ReplicationController",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/deployer-pod.completed-at": "2018-01-25 16:33:26 +0000 UTC",
+                            "openshift.io/deployer-pod.created-at": "2018-01-25 16:33:03 +0000 UTC",
+                            "openshift.io/deployer-pod.name": "myDeploy-1-deploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.phase": "Complete",
+                            "openshift.io/deployment.replicas": "1",
+                            "openshift.io/deployment.status-reason": "config change",
+                            "openshift.io/encoded-deployment-config": "{\"kind\":\"DeploymentConfig\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"myDeploy\",\"namespace\":\"my-run\",\"selfLink\":\"/apis/apps.openshift.io/v1/namespaces/my-run/deploymentconfigs/myDeploy\",\"uid\":\"8db1c9ba-91b5-46c6-be99-576245f42b3b\",\"resourceVersion\":\"837362058\",\"generation\":2,\"creationTimestamp\":\"2018-01-25T16:33:02Z\",\"labels\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myDeploy/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myDeploy\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myDeploy\"}},\"spec\":{\"strategy\":{\"type\":\"Rolling\",\"rollingParams\":{\"updatePeriodSeconds\":1,\"intervalSeconds\":1,\"timeoutSeconds\":3600,\"maxUnavailable\":\"25%\",\"maxSurge\":\"25%\"},\"resources\":{},\"activeDeadlineSeconds\":21600},\"triggers\":[{\"type\":\"ConfigChange\"},{\"type\":\"ImageChange\",\"imageChangeParams\":{\"automatic\":true,\"containerNames\":[\"myDeploy\"],\"from\":{\"kind\":\"ImageStreamTag\",\"namespace\":\"my-run\",\"name\":\"myDeploy:1.0.2\"},\"lastTriggeredImage\":\"127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\"}}],\"replicas\":1,\"revisionHistoryLimit\":2,\"test\":false,\"selector\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\"},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myDeploy/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myDeploy\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myDeploy\"}},\"spec\":{\"containers\":[{\"name\":\"myDeploy\",\"image\":\"127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\",\"ports\":[{\"name\":\"http\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"prometheus\",\"containerPort\":9779,\"protocol\":\"TCP\"},{\"name\":\"jolokia\",\"containerPort\":8778,\"protocol\":\"TCP\"}],\"env\":[{\"name\":\"KUBERNETES_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"apiVersion\":\"v1\",\"fieldPath\":\"metadata.namespace\"}}}],\"resources\":{\"limits\":{\"memory\":\"250Mi\"}},\"livenessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":180,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"readinessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"IfNotPresent\",\"securityContext\":{\"privileged\":false}}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\"}}},\"status\":{\"latestVersion\":1,\"observedGeneration\":2,\"replicas\":0,\"updatedReplicas\":0,\"availableReplicas\":0,\"unavailableReplicas\":0,\"details\":{\"message\":\"config change\",\"causes\":[{\"type\":\"ConfigChange\"}]},\"conditions\":[{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2018-01-25T16:33:02Z\",\"lastTransitionTime\":\"2018-01-25T16:33:02Z\",\"message\":\"Deployment config does not have minimum availability.\"}]}}\n"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:03Z",
+                        "generation": 3,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy-1",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "apps.openshift.io/v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "DeploymentConfig",
+                                "name": "myDeploy",
+                                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+                            }
+                        ],
+                        "resourceVersion": "838024576",
+                        "selfLink": "/api/v1/namespaces/my-run/replicationcontrollers/myDeploy-1",
+                        "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                    },
+                    "spec": {
+                        "replicas": 2,
+                        "selector": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "template": {
+                            "metadata": {
+                                "annotations": {
+                                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                                    "fabric8.io/iconUrl": "img/icon.svg",
+                                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                                    "fabric8.io/scm-tag": "myTag",
+                                    "fabric8.io/scm-url": "https://example.com/myDeploy",
+                                    "openshift.io/deployment-config.latest-version": "1",
+                                    "openshift.io/deployment-config.name": "myDeploy",
+                                    "openshift.io/deployment.name": "myDeploy-1"
+                                },
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "myDeploy",
+                                    "deployment": "myDeploy-1",
+                                    "deploymentconfig": "myDeploy",
+                                    "group": "myGroup",
+                                    "provider": "fabric8",
+                                    "space": "mySpace",
+                                    "version": "1.0.2"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "env": [
+                                            {
+                                                "name": "KUBERNETES_NAMESPACE",
+                                                "valueFrom": {
+                                                    "fieldRef": {
+                                                        "apiVersion": "v1",
+                                                        "fieldPath": "metadata.namespace"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                        "imagePullPolicy": "IfNotPresent",
+                                        "livenessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 180,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "name": "myDeploy",
+                                        "ports": [
+                                            {
+                                                "containerPort": 8080,
+                                                "name": "http",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 9779,
+                                                "name": "prometheus",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 8778,
+                                                "name": "jolokia",
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "readinessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 10,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "resources": {
+                                            "limits": {
+                                                "memory": "250Mi"
+                                            }
+                                        },
+                                        "securityContext": {
+                                            "privileged": false
+                                        },
+                                        "terminationMessagePath": "/dev/termination-log",
+                                        "terminationMessagePolicy": "File"
+                                    }
+                                ],
+                                "dnsPolicy": "ClusterFirst",
+                                "restartPolicy": "Always",
+                                "schedulerName": "default-scheduler",
+                                "securityContext": {},
+                                "terminationGracePeriodSeconds": 30
+                            }
+                        }
+                    },
+                    "status": {
+                        "availableReplicas": 2,
+                        "fullyLabeledReplicas": 2,
+                        "observedGeneration": 3,
+                        "readyReplicas": 2,
+                        "replicas": 2
+                    }
+                }
+            ],
+            "kind": "ReplicationControllerList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Pods
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/pods
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"my-run\",\"name\":\"myDeploy-1\",\"uid\":\"b780baac-ca27-4742-8649-e7af7b46fbb8\",\"apiVersion\":\"v1\",\"resourceVersion\":\"838023666\"}}\n",
+                            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container myDeploy; cpu limit for container myDeploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.name": "myDeploy-1",
+                            "openshift.io/scc": "restricted"
+                        },
+                        "creationTimestamp": "2018-01-25T20:40:05Z",
+                        "generateName": "myDeploy-1-",
+                        "labels": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "myspace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy-1-nfs9w",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "ReplicationController",
+                                "name": "myDeploy-1",
+                                "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                            }
+                        ],
+                        "resourceVersion": "838024574",
+                        "selfLink": "/api/v1/namespaces/my-run/pods/myDeploy-1-nfs9w",
+                        "uid": "f04e8f3b-5c4a-4ffd-94ec-0e8bcbc7b468"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "488m",
+                                        "memory": "250Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "29m",
+                                        "memory": "150Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {
+                                        "drop": [
+                                            "KILL",
+                                            "MKNOD",
+                                            "NET_RAW",
+                                            "SETGID",
+                                            "SETUID"
+                                        ]
+                                    },
+                                    "privileged": false,
+                                    "runAsUser": 123456,
+                                    "seLinuxOptions": {
+                                        "level": "s0:c123,c456"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                        "name": "default-token-jzp5t",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-k77kj"
+                            }
+                        ],
+                        "nodeName": "my.node",
+                        "nodeSelector": {
+                            "type": "compute"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {
+                            "fsGroup": 123456,
+                            "seLinuxOptions": {
+                                "level": "s0:c123,c456"
+                            }
+                        },
+                        "serviceAccount": "default",
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "default-token-jzp5t",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "default-token-jzp5t"
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "conditions": [
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:05Z",
+                                "status": "True",
+                                "type": "Initialized"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:25Z",
+                                "status": "True",
+                                "type": "Ready"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:05Z",
+                                "status": "True",
+                                "type": "PodScheduled"
+                            }
+                        ],
+                        "containerStatuses": [
+                            {
+                                "containerID": "docker://f425202d2f8e1758bd3e5fb681afeab5f4fdd4da93e57a0ea3b6819e40d6d39c",
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imageID": "docker-pullable://127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "lastState": {},
+                                "name": "myDeploy",
+                                "ready": true,
+                                "restartCount": 0,
+                                "state": {
+                                    "running": {
+                                        "startedAt": "2018-01-25T20:40:07Z"
+                                    }
+                                }
+                            }
+                        ],
+                        "hostIP": "127.0.0.4",
+                        "phase": "Running",
+                        "podIP": "127.0.0.5",
+                        "qosClass": "Burstable",
+                        "startTime": "2018-01-25T20:40:05Z"
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"my-run\",\"name\":\"myDeploy-1\",\"uid\":\"b780baac-ca27-4742-8649-e7af7b46fbb8\",\"apiVersion\":\"v1\",\"resourceVersion\":\"837362212\"}}\n",
+                            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container myDeploy; cpu limit for container myDeploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.name": "myDeploy-1",
+                            "openshift.io/scc": "restricted"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:06Z",
+                        "generateName": "myDeploy-1-",
+                        "labels": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "myspace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy-1-sdmzq",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "ReplicationController",
+                                "name": "myDeploy-1",
+                                "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                            }
+                        ],
+                        "resourceVersion": "837363149",
+                        "selfLink": "/api/v1/namespaces/my-run/pods/myDeploy-1-sdmzq",
+                        "uid": "447b7d6f-7072-4e9a-8cba-7e29c2f53761"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "488m",
+                                        "memory": "250Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "29m",
+                                        "memory": "150Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {
+                                        "drop": [
+                                            "KILL",
+                                            "MKNOD",
+                                            "NET_RAW",
+                                            "SETGID",
+                                            "SETUID"
+                                        ]
+                                    },
+                                    "privileged": false,
+                                    "runAsUser": 123456,
+                                    "seLinuxOptions": {
+                                        "level": "s0:c123,c456"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                        "name": "default-token-jzp5t",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-k77kj"
+                            }
+                        ],
+                        "nodeName": "my.node",
+                        "nodeSelector": {
+                            "type": "compute"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {
+                            "fsGroup": 123456,
+                            "seLinuxOptions": {
+                                "level": "s0:c123,c456"
+                            }
+                        },
+                        "serviceAccount": "default",
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "default-token-jzp5t",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "default-token-jzp5t"
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "conditions": [
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "Initialized"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:26Z",
+                                "status": "True",
+                                "type": "Ready"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "PodScheduled"
+                            }
+                        ],
+                        "containerStatuses": [
+                            {
+                                "containerID": "docker://e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317",
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imageID": "docker-pullable://127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "lastState": {},
+                                "name": "myDeploy",
+                                "ready": true,
+                                "restartCount": 0,
+                                "state": {
+                                    "running": {
+                                        "startedAt": "2018-01-25T16:33:08Z"
+                                    }
+                                }
+                            }
+                        ],
+                        "hostIP": "127.0.0.2",
+                        "phase": "Running",
+                        "podIP": "127.0.0.3",
+                        "qosClass": "Burstable",
+                        "startTime": "2018-01-25T16:33:06Z"
+                    }
+                }
+            ],
+            "kind": "PodList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Services
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/services
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/exposeUrl": "http://myOtherDeploy-my-run.example.com",
+                            "fabric8.io/git-branch": "ebaron/myOtherDeploy/master-1.0.1",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myOtherDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myOtherDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myOtherDeploy",
+                            "prometheus.io/port": "9779",
+                            "prometheus.io/scrape": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:29:24Z",
+                        "labels": {
+                            "app": "myOtherDeploy",
+                            "expose": "true",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.1"
+                        },
+                        "name": "myOtherDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837351634",
+                        "selfLink": "/api/v1/namespaces/my-run/services/myOtherDeploy",
+                        "uid": "b8a09642-a164-4491-a3b5-9e990e977bab"
+                    },
+                    "spec": {
+                        "clusterIP": "127.0.0.102",
+                        "ports": [
+                            {
+                                "name": "http",
+                                "port": 8080,
+                                "protocol": "TCP",
+                                "targetPort": 8080
+                            }
+                        ],
+                        "selector": {
+                            "app": "myOtherDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "sessionAffinity": "None",
+                        "type": "ClusterIP"
+                    },
+                    "status": {
+                        "loadBalancer": {}
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/exposeUrl": "http://myDeploy-my-run.example.com",
+                            "fabric8.io/git-branch": "ebaron/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "prometheus.io/port": "9779",
+                            "prometheus.io/scrape": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:02Z",
+                        "labels": {
+                            "app": "myDeploy",
+                            "expose": "true",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837362353",
+                        "selfLink": "/api/v1/namespaces/my-run/services/myDeploy",
+                        "uid": "f4e6e2b2-f86d-4e78-94e5-079bb3f0b05d"
+                    },
+                    "spec": {
+                        "clusterIP": "127.0.0.101",
+                        "ports": [
+                            {
+                                "name": "http",
+                                "port": 8080,
+                                "protocol": "TCP",
+                                "targetPort": 8080
+                            }
+                        ],
+                        "selector": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "sessionAffinity": "None",
+                        "type": "ClusterIP"
+                    },
+                    "status": {
+                        "loadBalancer": {}
+                    }
+                }
+            ],
+            "kind": "ServiceList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "kind": "Status",
+            "apiVersion": "v1",
+            "metadata": {},
+            "status": "Failure",
+            "message": "the server doesn't have a resource type "resourcequota",
+            "reason": "NotFound",
+            "details": {},
+            "code": 404
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:15Z",
+                        "name": "compute-resources",
+                        "namespace": "my-stage",
+                        "resourceVersion": "1066766807",
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
+                        "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "1488m",
+                            "limits.memory": "762Mi"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-stage",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/object-counts",
+                        "uid": "74ad59a6-3071-454b-a719-7c07a3a8e7df"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "5",
+                            "secrets": "9",
+                            "services": "2"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "compute-resources",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "682306837",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
+                        "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "0",
+                            "limits.memory": "0"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/object-counts",
+                        "uid": "2928ac2c-d240-4582-a4fb-a0edf65c8069"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "1",
+                            "secrets": "12",
+                            "services": "1"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
         }
     headers:
       Content-Type:

--- a/test/kubernetes/getspaceandotherenvironmentusage.yaml
+++ b/test/kubernetes/getspaceandotherenvironmentusage.yaml
@@ -1,6 +1,3036 @@
 ---
 version: 1
 interactions:
+  # Build Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/buildconfigs?labelSelector=space%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "BuildConfigList",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "BuildConfig",
+                    "metadata": {
+                        "annotations": {
+                            "che.fabric8.io/stack": "java-centos",
+                            "jenkins.openshift.org/disable-sync-create-on": "jenkins",
+                            "jenkins.openshift.org/generated-by": "jenkins",
+                            "jenkins.openshift.org/job-path": "myUser/myApp/master"
+                        },
+                        "creationTimestamp": "2018-01-17T20:23:30Z",
+                        "labels": {
+                            "space": "mySpace"
+                        },
+                        "name": "myApp",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "828221505",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/buildconfigs/myApp",
+                        "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                    },
+                    "spec": {
+                        "failedBuildsHistoryLimit": 5,
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "runPolicy": "Serial",
+                        "source": {
+                            "git": {
+                                "ref": "master",
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "successfulBuildsHistoryLimit": 5,
+                        "triggers": [
+                            {
+                                "generic": {
+                                    "secret": "mySecret"
+                                },
+                                "type": "Generic"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "lastVersion": 4
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "BuildConfig",
+                    "metadata": {
+                        "annotations": {
+                            "che.fabric8.io/stack": "java-centos",
+                            "jenkins.openshift.org/disable-sync-create-on": "jenkins",
+                            "jenkins.openshift.org/generated-by": "jenkins",
+                            "jenkins.openshift.org/job-path": "myUser/myOtherApp/master"
+                        },
+                        "creationTimestamp": "2018-01-17T19:06:47Z",
+                        "labels": {
+                            "space": "mySpace"
+                        },
+                        "name": "myOtherApp",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "815711585",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/buildconfigs/myOtherApp",
+                        "uid": "50e57129-618d-48c4-8ac6-f04f852170d4"
+                    },
+                    "spec": {
+                        "failedBuildsHistoryLimit": 5,
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "runPolicy": "Serial",
+                        "source": {
+                            "git": {
+                                "ref": "master",
+                                "uri": "https://example.com/myOtherApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "successfulBuildsHistoryLimit": 5,
+                        "triggers": [
+                            {
+                                "generic": {
+                                    "secret": "mySecret"
+                                },
+                                "type": "Generic"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "lastVersion": 2
+                    }
+                }
+            ],
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Builds
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyApp%2Cspace%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-run.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myDeploy: \"http://myDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myApp",
+                            "openshift.io/build-config.name": "myApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myApp",
+                                "uid": "b4bde2cd-fc5c-4e1d-9c37-8fb07ee6c30f"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myApp-1",
+                        "uid": "cc39e185-f392-40fe-9862-d7f559d17e3b"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/builds?labelSelector=openshift.io%2Fbuild-config.name%3DmyOtherApp%2Cspace%3DmySpace
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Build",
+                    "metadata": {
+                        "annotations": {
+                            "environment.services.fabric8.io/my-run": "---\nenvironmentName: \"Run\"\nserviceUrls:\n  myOtherDeploy: \"http://myOtherDeploy-my-run.example.com\"\ndeploymentVersions:\n  myOtherDeploy: \"1.0.3\"\n",
+                            "environment.services.fabric8.io/my-stage": "---\nenvironmentName: \"Stage\"\nserviceUrls:\n  myOtherDeploy: \"http://myOtherDeploy-my-stage.example.com\"\ndeploymentVersions:\n  myOtherDeploy: \"1.0.3\"\n",
+                            "fabric8.io/bayesian.analysisUrl": "https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc",
+                            "fabric8.io/jenkins.testReportUrl": "nulltestReport",
+                            "fabric8.io/version": "1.0.3",
+                            "openshift.io/build-config.name": "myOtherApp",
+                            "openshift.io/build.number": "1",
+                            "openshift.io/jenkins-build-uri": "https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/",
+                            "openshift.io/jenkins-log-url": "https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/consoleText",
+                            "openshift.io/jenkins-namespace": "my-jenkins",
+                            "openshift.io/jenkins-pending-input-actions-json": "[{\"id\":\"Proceed\",\"proceedText\":\"Proceed\",\"message\":\"\\nWould you like to promote version 1.0.3 to the next environment?\\n\",\"inputs\":[],\"proceedUrl\":\"//job/myUser/job/myOtherDeploy/job/master/3/wfapi/inputSubmit?inputId=Proceed\",\"abortUrl\":\"//job/myUser/job/myOtherDeploy/job/master/3/input/Proceed/abort\",\"redirectApprovalUrl\":\"//job/myUser/job/myOtherDeploy/job/master/3/input/\"}]",
+                            "openshift.io/jenkins-status-json": "{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/wfapi/describe\"},\"changesets\":null,\"pendingInputActions\":null,\"nextPendingInputAction\":null,\"artifacts\":null},\"id\":\"3\",\"name\":\"#3\",\"status\":\"SUCCESS\",\"startTimeMillis\":1524087821807,\"endTimeMillis\":1524088260580,\"durationMillis\":438773,\"queueDurationMillis\":1,\"pauseDurationMillis\":0,\"stages\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/20/wfapi/describe\"},\"log\":null},\"id\":\"20\",\"name\":\"Build Release\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087895667,\"durationMillis\":313263,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/21/wfapi/describe\"},\"log\":null},\"id\":\"21\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898053,\"durationMillis\":277,\"pauseDurationMillis\":0,\"parentNodes\":[\"20\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/22/wfapi/describe\"},\"log\":null},\"id\":\"22\",\"name\":\"Read a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"pom.xml\",\"startTimeMillis\":1524087898330,\"durationMillis\":46,\"pauseDurationMillis\":0,\"parentNodes\":[\"21\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/23/wfapi/describe\"},\"log\":null},\"id\":\"23\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"patching maven plugin for fabric8-maven-plugin v3.5.38\",\"startTimeMillis\":1524087898376,\"durationMillis\":11,\"pauseDurationMillis\":0,\"parentNodes\":[\"22\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/24/wfapi/describe\"},\"log\":null},\"id\":\"24\",\"name\":\"Write a maven project file.\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524087898387,\"durationMillis\":1213,\"pauseDurationMillis\":0,\"parentNodes\":[\"23\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/25/wfapi/describe\"},\"log\":null},\"id\":\"25\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=1.0.3\",\"startTimeMillis\":1524087899600,\"durationMillis\":23026,\"pauseDurationMillis\":0,\"parentNodes\":[\"24\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/26/wfapi/describe\"},\"log\":null},\"id\":\"26\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn clean -B -e -U deploy -Dmaven.test.skip=false -P openshift\",\"startTimeMillis\":1524087922626,\"durationMillis\":270944,\"pauseDurationMillis\":0,\"parentNodes\":[\"25\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/27/wfapi/describe\"},\"log\":null},\"id\":\"27\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/surefire-reports/*.xml\",\"startTimeMillis\":1524088193570,\"durationMillis\":202,\"pauseDurationMillis\":0,\"parentNodes\":[\"26\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/28/wfapi/describe\"},\"log\":null},\"id\":\"28\",\"name\":\"Publish JUnit test result report\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088193772,\"durationMillis\":1583,\"pauseDurationMillis\":0,\"parentNodes\":[\"27\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/29/wfapi/describe\"},\"log\":null},\"id\":\"29\",\"name\":\"Find files in the workspace\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"**/failsafe-reports/*.xml\",\"startTimeMillis\":1524088195355,\"durationMillis\":843,\"pauseDurationMillis\":0,\"parentNodes\":[\"28\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/30/wfapi/describe\"},\"log\":null},\"id\":\"30\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myOtherApp-1\",\"startTimeMillis\":1524088196198,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"29\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/31/wfapi/describe\"},\"log\":null},\"id\":\"31\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myOtherApp-1\",\"startTimeMillis\":1524088196199,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"30\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/32/wfapi/describe\"},\"log\":null},\"id\":\"32\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/jenkins.testReportUrl: nulltestReport' to Build myOtherApp-1\",\"startTimeMillis\":1524088196200,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"31\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/33/wfapi/describe\"},\"log\":null},\"id\":\"33\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myOtherApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088196201,\"durationMillis\":1302,\"pauseDurationMillis\":0,\"parentNodes\":[\"32\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/34/wfapi/describe\"},\"log\":null},\"id\":\"34\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking bayesian-link exists\",\"startTimeMillis\":1524088197503,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"33\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/35/wfapi/describe\"},\"log\":null},\"id\":\"35\",\"name\":\"Shell Script\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn io.github.stackinfo:stackinfo-maven-plugin:0.2:prepare\",\"startTimeMillis\":1524088197504,\"durationMillis\":9508,\"pauseDurationMillis\":0,\"parentNodes\":[\"34\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/38/wfapi/describe\"},\"log\":null},\"id\":\"38\",\"name\":\"Bayesian Analysis\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"https://bayesian-link\",\"startTimeMillis\":1524088207019,\"durationMillis\":800,\"pauseDurationMillis\":0,\"parentNodes\":[\"37\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/39/wfapi/describe\"},\"log\":null},\"id\":\"39\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Looking for matching Build myOtherApp-1\",\"startTimeMillis\":1524088207819,\"durationMillis\":2,\"pauseDurationMillis\":0,\"parentNodes\":[\"38\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/40/wfapi/describe\"},\"log\":null},\"id\":\"40\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Adding annotation 'fabric8.io/bayesian.analysisUrl: https://recommender.api.openshift.io/api/v1/stack-analyses/8f35139bef364d51bb97c0ea92ad01bc' to Build myOtherApp-1\",\"startTimeMillis\":1524088207821,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"39\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/41/wfapi/describe\"},\"log\":null},\"id\":\"41\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"looking for myOtherApp-1 in namespace myNamespace\",\"startTimeMillis\":1524088207822,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"40\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/44/wfapi/describe\"},\"log\":null},\"id\":\"44\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking sonarqube exists\",\"startTimeMillis\":1524088208189,\"durationMillis\":66,\"pauseDurationMillis\":0,\"parentNodes\":[\"43\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/45/wfapi/describe\"},\"log\":null},\"id\":\"45\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Code validation service: sonarqube not available\",\"startTimeMillis\":1524088208255,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"44\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/46/wfapi/describe\"},\"log\":null},\"id\":\"46\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"s2i mode: true\",\"startTimeMillis\":1524088208256,\"durationMillis\":121,\"pauseDurationMillis\":0,\"parentNodes\":[\"45\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/47/wfapi/describe\"},\"log\":null},\"id\":\"47\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Checking content-repository exists\",\"startTimeMillis\":1524088208377,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"46\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/48/wfapi/describe\"},\"log\":null},\"id\":\"48\",\"name\":\"Print Message\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"mvn site disabled\",\"startTimeMillis\":1524088208378,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"47\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/49/wfapi/describe\"},\"log\":null},\"id\":\"49\",\"name\":\"Stash some files to be used later in the build\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088208379,\"durationMillis\":547,\"pauseDurationMillis\":0,\"parentNodes\":[\"48\"]}],\"allChildNodeIds\":[\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/62/wfapi/describe\"},\"log\":null},\"id\":\"62\",\"name\":\"Rollout to Stage\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209074,\"durationMillis\":6811,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/63/wfapi/describe\"},\"log\":null},\"id\":\"63\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088209080,\"durationMillis\":6801,\"pauseDurationMillis\":0,\"parentNodes\":[\"62\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/64/wfapi/describe\"},\"log\":null},\"id\":\"64\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-stage\",\"startTimeMillis\":1524088215881,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"63\"]}],\"allChildNodeIds\":[\"63\",\"64\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/68/wfapi/describe\"},\"log\":null},\"id\":\"68\",\"name\":\"Approve\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215896,\"durationMillis\":38155,\"pauseDurationMillis\":38033,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/69/wfapi/describe\"},\"log\":null},\"id\":\"69\",\"name\":\"Sends a message with proceed/abort instructions to a hubot chat room for a project\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088215985,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"68\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/70/wfapi/describe\"},\"log\":null},\"id\":\"70\",\"name\":\"Creates an Approve requested event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"Stage\",\"startTimeMillis\":1524088215986,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"69\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/73/wfapi/describe\"},\"log\":null},\"id\":\"73\",\"name\":\"Wait for interactive input\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088216000,\"durationMillis\":38032,\"pauseDurationMillis\":38032,\"parentNodes\":[\"72\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/76/wfapi/describe\"},\"log\":null},\"id\":\"76\",\"name\":\"Updates an Approve event in Elasticsearch\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"true\",\"startTimeMillis\":1524088254047,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"75\"]}],\"allChildNodeIds\":[\"69\",\"70\",\"71\",\"72\",\"73\",\"74\",\"75\",\"76\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/80/wfapi/describe\"},\"log\":null},\"id\":\"80\",\"name\":\"Rollout to Run\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254060,\"durationMillis\":6492,\"pauseDurationMillis\":0,\"stageFlowNodes\":[{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/81/wfapi/describe\"},\"log\":null},\"id\":\"81\",\"name\":\"Restore files previously stashed\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":null,\"startTimeMillis\":1524088254066,\"durationMillis\":6481,\"pauseDurationMillis\":0,\"parentNodes\":[\"80\"]},{\"_links\":{\"self\":{\"href\":\"https://jenkins.openshift.io/job/myUser/job/myOtherDeploy/job/master/3/execution/node/82/wfapi/describe\"},\"log\":null},\"id\":\"82\",\"name\":\"Apply resources to Kubernetes, lazily creating environments and routes\",\"execNode\":\"\",\"status\":\"SUCCESS\",\"error\":null,\"parameterDescription\":\"my-run\",\"startTimeMillis\":1524088260547,\"durationMillis\":1,\"pauseDurationMillis\":0,\"parentNodes\":[\"81\"]}],\"allChildNodeIds\":[\"81\",\"82\"]}]}"
+                        },
+                        "creationTimestamp": "2018-04-18T21:28:24Z",
+                        "labels": {
+                            "buildconfig": "myOtherApp",
+                            "openshift.io/build-config.name": "myOtherApp",
+                            "openshift.io/build.start-policy": "Serial",
+                            "space": "mySpace"
+                        },
+                        "name": "myOtherApp-1",
+                        "namespace": "myNamespace",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "controller": true,
+                                "kind": "BuildConfig",
+                                "name": "myOtherApp",
+                                "uid": "50e57129-618d-48c4-8ac6-f04f852170d4"
+                            }
+                        ],
+                        "resourceVersion": "1083508128",
+                        "selfLink": "/oapi/v1/namespaces/myNamespace/builds/myOtherApp-1",
+                        "uid": "7c563b97-8865-47b6-a9cc-d2bfbf05ecd9"
+                    },
+                    "spec": {
+                        "nodeSelector": {},
+                        "output": {},
+                        "postCommit": {},
+                        "resources": {},
+                        "serviceAccount": "builder",
+                        "source": {
+                            "git": {
+                                "uri": "https://example.com/myOtherApp.git"
+                            },
+                            "type": "Git"
+                        },
+                        "strategy": {
+                            "jenkinsPipelineStrategy": {
+                                "env": [
+                                    {
+                                        "name": "FABRIC8_SPACE",
+                                        "value": "mySpace"
+                                    }
+                                ],
+                                "jenkinsfilePath": "Jenkinsfile"
+                            },
+                            "type": "JenkinsPipeline"
+                        },
+                        "triggeredBy": [
+                            {
+                                "message": "Forge triggered"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "completionTimestamp": "2018-04-18T21:51:00Z",
+                        "config": {
+                            "kind": "BuildConfig",
+                            "name": "myOtherApp",
+                            "namespace": "myNamespace"
+                        },
+                        "output": {},
+                        "phase": "Complete",
+                        "startTimestamp": "2018-04-18T21:43:41Z"
+                    }
+                }
+            ],
+            "kind": "BuildList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Deployment Configs
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.2"
+                },
+                "name": "myDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+            },
+            "spec": {
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.2",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-stage/deploymentconfigs/myDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.3",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.3",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.3"
+                },
+                "name": "myDeploy",
+                "namespace": "my-stage",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-stage/deploymentconfigs/myDeploy",
+                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+            },
+            "spec": {
+                "replicas": 2,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.3",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.3",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.3"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myDeploy:1.0.3",
+                                "namespace": "my-stage"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 2
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/deploymentconfigs/myOtherDeploy
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "fabric8.io/git-branch": "myUser/myOtherDeploy/master-1.0.1",
+                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                    "fabric8.io/iconUrl": "img/icon.svg",
+                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myOtherDeploy\u0026var-version=1.0.1",
+                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myOtherDeploy",
+                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myOtherDeploy",
+                    "fabric8.io/scm-tag": "myTag",
+                    "fabric8.io/scm-url": "https://example.com/myOtherDeploy"
+                },
+                "creationTimestamp": "2018-01-25T16:33:02Z",
+                "generation": 3,
+                "labels": {
+                    "app": "myOtherDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8",
+                    "space": "mySpace",
+                    "version": "1.0.1"
+                },
+                "name": "myOtherDeploy",
+                "namespace": "my-run",
+                "resourceVersion": "838024578",
+                "selfLink": "/oapi/v1/namespaces/my-run/deploymentconfigs/myOtherDeploy",
+                "uid": "60914dbe-fff9-47a0-86a3-9fb71822aba4"
+            },
+            "spec": {
+                "replicas": 1,
+                "revisionHistoryLimit": 2,
+                "selector": {
+                    "app": "myOtherDeploy",
+                    "group": "myGroup",
+                    "provider": "fabric8"
+                },
+                "strategy": {
+                    "activeDeadlineSeconds": 21600,
+                    "resources": {},
+                    "rollingParams": {
+                        "intervalSeconds": 1,
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%",
+                        "timeoutSeconds": 3600,
+                        "updatePeriodSeconds": 1
+                    },
+                    "type": "Rolling"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myOtherDeploy/master-1.0.1",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myOtherDeploy\u0026var-version=1.0.1",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myOtherDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com:myOtherDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myOtherDeploy"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "myOtherDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.1"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myOtherDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "250Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "myOtherDeploy"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "myOtherDeploy:1.0.1",
+                                "namespace": "my-run"
+                            },
+                            "lastTriggeredImage": "127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2018-01-25T16:33:06Z",
+                        "lastUpdateTime": "2018-01-25T16:33:27Z",
+                        "message": "replication controller \"myOtherDeploy-1\" successfully rolled out",
+                        "reason": "NewReplicationControllerAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "lastTransitionTime": "2018-01-25T20:40:25Z",
+                        "lastUpdateTime": "2018-01-25T20:40:25Z",
+                        "message": "Deployment config has minimum availability.",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "details": {
+                    "causes": [
+                        {
+                            "type": "ConfigChange"
+                        }
+                    ],
+                    "message": "config change"
+                },
+                "latestVersion": 1,
+                "observedGeneration": 3,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "unavailableReplicas": 0,
+                "updatedReplicas": 1
+            }
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/deploymentconfigs/myApp
+    method: GET
+  response:
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-stage/deploymentconfigs/myOtherDeploy
+    method: GET
+  response:
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/myNamespace/deploymentconfigs/myOtherApp
+    method: GET
+  response:
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 404 Not Found
+    code: 404
+  # Routes
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-run/routes
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Route",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/host.generated": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:29:33Z",
+                        "labels": {
+                            "app": "myOtherDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "version": "1.0.1"
+                        },
+                        "name": "myOtherDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837351613",
+                        "selfLink": "/oapi/v1/namespaces/my-run/routes/myOtherDeploy",
+                        "uid": "ba127f7e-c735-4470-a96f-e3462a050d0a"
+                    },
+                    "spec": {
+                        "host": "myOtherDeploy-my-run.example.com",
+                        "port": {
+                            "targetPort": 8080
+                        },
+                        "to": {
+                            "kind": "Service",
+                            "name": "myOtherDeploy",
+                            "weight": 100
+                        },
+                        "wildcardPolicy": "None"
+                    },
+                    "status": {
+                        "ingress": [
+                            {
+                                "conditions": [
+                                    {
+                                        "lastTransitionTime": "2018-01-25T16:29:33Z",
+                                        "status": "True",
+                                        "type": "Admitted"
+                                    }
+                                ],
+                                "host": "myOtherDeploy-my-run.example.com",
+                                "routerCanonicalHostname": "router.example.com",
+                                "routerName": "router",
+                                "wildcardPolicy": "None"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Route",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/host.generated": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:08Z",
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837362360",
+                        "selfLink": "/oapi/v1/namespaces/my-run/routes/myDeploy",
+                        "uid": "d727601d-8c5a-4271-bd1b-90929461c947"
+                    },
+                    "spec": {
+                        "host": "myDeploy-my-run.example.com",
+                        "port": {
+                            "targetPort": 8080
+                        },
+                        "to": {
+                            "kind": "Service",
+                            "name": "myDeploy",
+                            "weight": 100
+                        },
+                        "wildcardPolicy": "None"
+                    },
+                    "status": {
+                        "ingress": [
+                            {
+                                "conditions": [
+                                    {
+                                        "lastTransitionTime": "2018-01-25T16:33:09Z",
+                                        "status": "True",
+                                        "type": "Admitted"
+                                    }
+                                ],
+                                "host": "myDeploy-my-run.example.com",
+                                "routerCanonicalHostname": "router.example.com",
+                                "routerName": "router",
+                                "wildcardPolicy": "None"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "kind": "RouteList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/oapi/v1/namespaces/my-stage/routes
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [],
+            "kind": "RouteList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Replication Controllers
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/replicationcontrollers
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ReplicationController",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/deployer-pod.completed-at": "2018-01-25 16:33:26 +0000 UTC",
+                            "openshift.io/deployer-pod.created-at": "2018-01-25 16:33:03 +0000 UTC",
+                            "openshift.io/deployer-pod.name": "myDeploy-1-deploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.phase": "Complete",
+                            "openshift.io/deployment.replicas": "1",
+                            "openshift.io/deployment.status-reason": "config change",
+                            "openshift.io/encoded-deployment-config": "{\"kind\":\"DeploymentConfig\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"myDeploy\",\"namespace\":\"my-run\",\"selfLink\":\"/apis/apps.openshift.io/v1/namespaces/my-run/deploymentconfigs/myDeploy\",\"uid\":\"8db1c9ba-91b5-46c6-be99-576245f42b3b\",\"resourceVersion\":\"837362058\",\"generation\":2,\"creationTimestamp\":\"2018-01-25T16:33:02Z\",\"labels\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myDeploy/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myDeploy\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myDeploy\"}},\"spec\":{\"strategy\":{\"type\":\"Rolling\",\"rollingParams\":{\"updatePeriodSeconds\":1,\"intervalSeconds\":1,\"timeoutSeconds\":3600,\"maxUnavailable\":\"25%\",\"maxSurge\":\"25%\"},\"resources\":{},\"activeDeadlineSeconds\":21600},\"triggers\":[{\"type\":\"ConfigChange\"},{\"type\":\"ImageChange\",\"imageChangeParams\":{\"automatic\":true,\"containerNames\":[\"myDeploy\"],\"from\":{\"kind\":\"ImageStreamTag\",\"namespace\":\"my-run\",\"name\":\"myDeploy:1.0.2\"},\"lastTriggeredImage\":\"127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\"}}],\"replicas\":1,\"revisionHistoryLimit\":2,\"test\":false,\"selector\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\"},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myDeploy/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myDeploy\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myDeploy\"}},\"spec\":{\"containers\":[{\"name\":\"myDeploy\",\"image\":\"127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\",\"ports\":[{\"name\":\"http\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"prometheus\",\"containerPort\":9779,\"protocol\":\"TCP\"},{\"name\":\"jolokia\",\"containerPort\":8778,\"protocol\":\"TCP\"}],\"env\":[{\"name\":\"KUBERNETES_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"apiVersion\":\"v1\",\"fieldPath\":\"metadata.namespace\"}}}],\"resources\":{\"limits\":{\"memory\":\"250Mi\"}},\"livenessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":180,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"readinessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"IfNotPresent\",\"securityContext\":{\"privileged\":false}}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\"}}},\"status\":{\"latestVersion\":1,\"observedGeneration\":2,\"replicas\":0,\"updatedReplicas\":0,\"availableReplicas\":0,\"unavailableReplicas\":0,\"details\":{\"message\":\"config change\",\"causes\":[{\"type\":\"ConfigChange\"}]},\"conditions\":[{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2018-01-25T16:33:02Z\",\"lastTransitionTime\":\"2018-01-25T16:33:02Z\",\"message\":\"Deployment config does not have minimum availability.\"}]}}\n"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:03Z",
+                        "generation": 3,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy-1",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "apps.openshift.io/v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "DeploymentConfig",
+                                "name": "myDeploy",
+                                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+                            }
+                        ],
+                        "resourceVersion": "838024576",
+                        "selfLink": "/api/v1/namespaces/my-run/replicationcontrollers/myDeploy-1",
+                        "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                    },
+                    "spec": {
+                        "replicas": 2,
+                        "selector": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "template": {
+                            "metadata": {
+                                "annotations": {
+                                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                                    "fabric8.io/iconUrl": "img/icon.svg",
+                                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                                    "fabric8.io/scm-tag": "myTag",
+                                    "fabric8.io/scm-url": "https://example.com/myDeploy",
+                                    "openshift.io/deployment-config.latest-version": "1",
+                                    "openshift.io/deployment-config.name": "myDeploy",
+                                    "openshift.io/deployment.name": "myDeploy-1"
+                                },
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "myDeploy",
+                                    "deployment": "myDeploy-1",
+                                    "deploymentconfig": "myDeploy",
+                                    "group": "myGroup",
+                                    "provider": "fabric8",
+                                    "space": "mySpace",
+                                    "version": "1.0.2"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "env": [
+                                            {
+                                                "name": "KUBERNETES_NAMESPACE",
+                                                "valueFrom": {
+                                                    "fieldRef": {
+                                                        "apiVersion": "v1",
+                                                        "fieldPath": "metadata.namespace"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                        "imagePullPolicy": "IfNotPresent",
+                                        "livenessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 180,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "name": "myDeploy",
+                                        "ports": [
+                                            {
+                                                "containerPort": 8080,
+                                                "name": "http",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 9779,
+                                                "name": "prometheus",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 8778,
+                                                "name": "jolokia",
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "readinessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 10,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "resources": {
+                                            "limits": {
+                                                "memory": "250Mi"
+                                            }
+                                        },
+                                        "securityContext": {
+                                            "privileged": false
+                                        },
+                                        "terminationMessagePath": "/dev/termination-log",
+                                        "terminationMessagePolicy": "File"
+                                    }
+                                ],
+                                "dnsPolicy": "ClusterFirst",
+                                "restartPolicy": "Always",
+                                "schedulerName": "default-scheduler",
+                                "securityContext": {},
+                                "terminationGracePeriodSeconds": 30
+                            }
+                        }
+                    },
+                    "status": {
+                        "availableReplicas": 2,
+                        "fullyLabeledReplicas": 2,
+                        "observedGeneration": 3,
+                        "readyReplicas": 2,
+                        "replicas": 2
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ReplicationController",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/deployer-pod.completed-at": "2018-01-25 16:33:26 +0000 UTC",
+                            "openshift.io/deployer-pod.created-at": "2018-01-25 16:33:03 +0000 UTC",
+                            "openshift.io/deployer-pod.name": "myOtherDeploy-1-deploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myOtherDeploy",
+                            "openshift.io/deployment.phase": "Complete",
+                            "openshift.io/deployment.replicas": "1",
+                            "openshift.io/deployment.status-reason": "config change",
+                            "openshift.io/encoded-deployment-config": "{\"kind\":\"DeploymentConfig\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"myOtherDeploy\",\"namespace\":\"my-run\",\"selfLink\":\"/apis/apps.openshift.io/v1/namespaces/my-run/deploymentconfigs/myOtherDeploy\",\"uid\":\"8db1c9ba-91b5-46c6-be99-576245f42b3b\",\"resourceVersion\":\"837362058\",\"generation\":2,\"creationTimestamp\":\"2018-01-25T16:33:02Z\",\"labels\":{\"app\":\"myOtherDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.1\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myOtherDeploy/master-1.0.1\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myOtherDeploy\\u0026var-version=1.0.1\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myOtherDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myOtherDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myOtherDeploy\"}},\"spec\":{\"strategy\":{\"type\":\"Rolling\",\"rollingParams\":{\"updatePeriodSeconds\":1,\"intervalSeconds\":1,\"timeoutSeconds\":3600,\"maxUnavailable\":\"25%\",\"maxSurge\":\"25%\"},\"resources\":{},\"activeDeadlineSeconds\":21600},\"triggers\":[{\"type\":\"ConfigChange\"},{\"type\":\"ImageChange\",\"imageChangeParams\":{\"automatic\":true,\"containerNames\":[\"myOtherDeploy\"],\"from\":{\"kind\":\"ImageStreamTag\",\"namespace\":\"my-run\",\"name\":\"myOtherDeploy:1.0.1\"},\"lastTriggeredImage\":\"127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\"}}],\"replicas\":1,\"revisionHistoryLimit\":2,\"test\":false,\"selector\":{\"app\":\"myOtherDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\"},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"myOtherDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.1\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myOtherDeploy/master-1.0.1\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myOtherDeploy\\u0026var-version=1.0.1\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myOtherDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myOtherDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myOtherDeploy\"}},\"spec\":{\"containers\":[{\"name\":\"myOtherDeploy\",\"image\":\"127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\",\"ports\":[{\"name\":\"http\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"prometheus\",\"containerPort\":9779,\"protocol\":\"TCP\"},{\"name\":\"jolokia\",\"containerPort\":8778,\"protocol\":\"TCP\"}],\"env\":[{\"name\":\"KUBERNETES_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"apiVersion\":\"v1\",\"fieldPath\":\"metadata.namespace\"}}}],\"resources\":{\"limits\":{\"memory\":\"250Mi\"}},\"livenessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":180,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"readinessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"IfNotPresent\",\"securityContext\":{\"privileged\":false}}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\"}}},\"status\":{\"latestVersion\":1,\"observedGeneration\":2,\"replicas\":0,\"updatedReplicas\":0,\"availableReplicas\":0,\"unavailableReplicas\":0,\"details\":{\"message\":\"config change\",\"causes\":[{\"type\":\"ConfigChange\"}]},\"conditions\":[{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2018-01-25T16:33:02Z\",\"lastTransitionTime\":\"2018-01-25T16:33:02Z\",\"message\":\"Deployment config does not have minimum availability.\"}]}}\n"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:03Z",
+                        "generation": 3,
+                        "labels": {
+                            "app": "myOtherDeploy",
+                            "group": "myGroup",
+                            "openshift.io/deployment-config.name": "myOtherDeploy",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.1"
+                        },
+                        "name": "myOtherDeploy-1",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "apps.openshift.io/v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "DeploymentConfig",
+                                "name": "myOtherDeploy",
+                                "uid": "60914dbe-fff9-47a0-86a3-9fb71822aba4"
+                            }
+                        ],
+                        "resourceVersion": "838024576",
+                        "selfLink": "/api/v1/namespaces/my-run/replicationcontrollers/myOtherDeploy-1",
+                        "uid": "51fbc77a-cca1-4fc7-8c13-b9a51753d5f6"
+                    },
+                    "spec": {
+                        "replicas": 2,
+                        "selector": {
+                            "app": "myOtherDeploy",
+                            "deployment": "myOtherDeploy-1",
+                            "deploymentconfig": "myOtherDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "template": {
+                            "metadata": {
+                                "annotations": {
+                                    "fabric8.io/git-branch": "myUser/myOtherDeploy/master-1.0.1",
+                                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                                    "fabric8.io/iconUrl": "img/icon.svg",
+                                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myOtherDeploy\u0026var-version=1.0.1",
+                                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myOtherDeploy",
+                                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myOtherDeploy",
+                                    "fabric8.io/scm-tag": "myTag",
+                                    "fabric8.io/scm-url": "https://example.com/myOtherDeploy",
+                                    "openshift.io/deployment-config.latest-version": "1",
+                                    "openshift.io/deployment-config.name": "myOtherDeploy",
+                                    "openshift.io/deployment.name": "myOtherDeploy-1"
+                                },
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "myOtherDeploy",
+                                    "deployment": "myOtherDeploy-1",
+                                    "deploymentconfig": "myOtherDeploy",
+                                    "group": "myGroup",
+                                    "provider": "fabric8",
+                                    "space": "mySpace",
+                                    "version": "1.0.1"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "env": [
+                                            {
+                                                "name": "KUBERNETES_NAMESPACE",
+                                                "valueFrom": {
+                                                    "fieldRef": {
+                                                        "apiVersion": "v1",
+                                                        "fieldPath": "metadata.namespace"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "image": "127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                        "imagePullPolicy": "IfNotPresent",
+                                        "livenessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 180,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "name": "myOtherDeploy",
+                                        "ports": [
+                                            {
+                                                "containerPort": 8080,
+                                                "name": "http",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 9779,
+                                                "name": "prometheus",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 8778,
+                                                "name": "jolokia",
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "readinessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 10,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "resources": {
+                                            "limits": {
+                                                "memory": "250Mi"
+                                            }
+                                        },
+                                        "securityContext": {
+                                            "privileged": false
+                                        },
+                                        "terminationMessagePath": "/dev/termination-log",
+                                        "terminationMessagePolicy": "File"
+                                    }
+                                ],
+                                "dnsPolicy": "ClusterFirst",
+                                "restartPolicy": "Always",
+                                "schedulerName": "default-scheduler",
+                                "securityContext": {},
+                                "terminationGracePeriodSeconds": 30
+                            }
+                        }
+                    },
+                    "status": {
+                        "availableReplicas": 2,
+                        "fullyLabeledReplicas": 2,
+                        "observedGeneration": 3,
+                        "readyReplicas": 2,
+                        "replicas": 2
+                    }
+                }
+            ],
+            "kind": "ReplicationControllerList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-stage/replicationcontrollers
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ReplicationController",
+                    "metadata": {
+                        "annotations": {
+                            "openshift.io/deployer-pod.completed-at": "2018-01-25 16:33:26 +0000 UTC",
+                            "openshift.io/deployer-pod.created-at": "2018-01-25 16:33:03 +0000 UTC",
+                            "openshift.io/deployer-pod.name": "myDeploy-1-deploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.phase": "Complete",
+                            "openshift.io/deployment.replicas": "1",
+                            "openshift.io/deployment.status-reason": "config change",
+                            "openshift.io/encoded-deployment-config": "{\"kind\":\"DeploymentConfig\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"myDeploy\",\"namespace\":\"my-run\",\"selfLink\":\"/apis/apps.openshift.io/v1/namespaces/my-run/deploymentconfigs/myDeploy\",\"uid\":\"8db1c9ba-91b5-46c6-be99-576245f42b3b\",\"resourceVersion\":\"837362058\",\"generation\":2,\"creationTimestamp\":\"2018-01-25T16:33:02Z\",\"labels\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myDeploy/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myDeploy\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myDeploy\"}},\"spec\":{\"strategy\":{\"type\":\"Rolling\",\"rollingParams\":{\"updatePeriodSeconds\":1,\"intervalSeconds\":1,\"timeoutSeconds\":3600,\"maxUnavailable\":\"25%\",\"maxSurge\":\"25%\"},\"resources\":{},\"activeDeadlineSeconds\":21600},\"triggers\":[{\"type\":\"ConfigChange\"},{\"type\":\"ImageChange\",\"imageChangeParams\":{\"automatic\":true,\"containerNames\":[\"myDeploy\"],\"from\":{\"kind\":\"ImageStreamTag\",\"namespace\":\"my-run\",\"name\":\"myDeploy:1.0.2\"},\"lastTriggeredImage\":\"127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\"}}],\"replicas\":1,\"revisionHistoryLimit\":2,\"test\":false,\"selector\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\"},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"myDeploy\",\"group\":\"myGroup\",\"provider\":\"fabric8\",\"space\":\"mySpace\",\"version\":\"1.0.2\"},\"annotations\":{\"fabric8.io/git-branch\":\"myUser/myDeploy/master-1.0.2\",\"fabric8.io/git-commit\":\"55ca6286e3e4f4fba5d0448333fa99fc5a404a73\",\"fabric8.io/iconUrl\":\"img/icon.svg\",\"fabric8.io/metrics-path\":\"dashboard/file/kubernetes-pods.json/?var-project=myDeploy\\u0026var-version=1.0.2\",\"fabric8.io/scm-con-url\":\"scm:git:https://example.com/myDeploy\",\"fabric8.io/scm-devcon-url\":\"scm:git:git:@example.com/myDeploy\",\"fabric8.io/scm-tag\":\"myTag\",\"fabric8.io/scm-url\":\"https://example.com/myDeploy\"}},\"spec\":{\"containers\":[{\"name\":\"myDeploy\",\"image\":\"127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\",\"ports\":[{\"name\":\"http\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"prometheus\",\"containerPort\":9779,\"protocol\":\"TCP\"},{\"name\":\"jolokia\",\"containerPort\":8778,\"protocol\":\"TCP\"}],\"env\":[{\"name\":\"KUBERNETES_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"apiVersion\":\"v1\",\"fieldPath\":\"metadata.namespace\"}}}],\"resources\":{\"limits\":{\"memory\":\"250Mi\"}},\"livenessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":180,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"readinessProbe\":{\"httpGet\":{\"path\":\"/\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10,\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"IfNotPresent\",\"securityContext\":{\"privileged\":false}}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\"}}},\"status\":{\"latestVersion\":1,\"observedGeneration\":2,\"replicas\":0,\"updatedReplicas\":0,\"availableReplicas\":0,\"unavailableReplicas\":0,\"details\":{\"message\":\"config change\",\"causes\":[{\"type\":\"ConfigChange\"}]},\"conditions\":[{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2018-01-25T16:33:02Z\",\"lastTransitionTime\":\"2018-01-25T16:33:02Z\",\"message\":\"Deployment config does not have minimum availability.\"}]}}\n"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:03Z",
+                        "generation": 3,
+                        "labels": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy-1",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "apps.openshift.io/v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "DeploymentConfig",
+                                "name": "myDeploy",
+                                "uid": "8db1c9ba-91b5-46c6-be99-576245f42b3b"
+                            }
+                        ],
+                        "resourceVersion": "838024576",
+                        "selfLink": "/api/v1/namespaces/my-run/replicationcontrollers/myDeploy-1",
+                        "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                    },
+                    "spec": {
+                        "replicas": 2,
+                        "selector": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "template": {
+                            "metadata": {
+                                "annotations": {
+                                    "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                                    "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                                    "fabric8.io/iconUrl": "img/icon.svg",
+                                    "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                                    "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                                    "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                                    "fabric8.io/scm-tag": "myTag",
+                                    "fabric8.io/scm-url": "https://example.com/myDeploy",
+                                    "openshift.io/deployment-config.latest-version": "1",
+                                    "openshift.io/deployment-config.name": "myDeploy",
+                                    "openshift.io/deployment.name": "myDeploy-1"
+                                },
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "myDeploy",
+                                    "deployment": "myDeploy-1",
+                                    "deploymentconfig": "myDeploy",
+                                    "group": "myGroup",
+                                    "provider": "fabric8",
+                                    "space": "mySpace",
+                                    "version": "1.0.2"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "env": [
+                                            {
+                                                "name": "KUBERNETES_NAMESPACE",
+                                                "valueFrom": {
+                                                    "fieldRef": {
+                                                        "apiVersion": "v1",
+                                                        "fieldPath": "metadata.namespace"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                        "imagePullPolicy": "IfNotPresent",
+                                        "livenessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 180,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "name": "myDeploy",
+                                        "ports": [
+                                            {
+                                                "containerPort": 8080,
+                                                "name": "http",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 9779,
+                                                "name": "prometheus",
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 8778,
+                                                "name": "jolokia",
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "readinessProbe": {
+                                            "failureThreshold": 3,
+                                            "httpGet": {
+                                                "path": "/",
+                                                "port": 8080,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 10,
+                                            "periodSeconds": 10,
+                                            "successThreshold": 1,
+                                            "timeoutSeconds": 1
+                                        },
+                                        "resources": {
+                                            "limits": {
+                                                "memory": "250Mi"
+                                            }
+                                        },
+                                        "securityContext": {
+                                            "privileged": false
+                                        },
+                                        "terminationMessagePath": "/dev/termination-log",
+                                        "terminationMessagePolicy": "File"
+                                    }
+                                ],
+                                "dnsPolicy": "ClusterFirst",
+                                "restartPolicy": "Always",
+                                "schedulerName": "default-scheduler",
+                                "securityContext": {},
+                                "terminationGracePeriodSeconds": 30
+                            }
+                        }
+                    },
+                    "status": {
+                        "availableReplicas": 2,
+                        "fullyLabeledReplicas": 2,
+                        "observedGeneration": 3,
+                        "readyReplicas": 2,
+                        "replicas": 2
+                    }
+                }
+            ],
+            "kind": "ReplicationControllerList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Pods
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/pods
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"my-run\",\"name\":\"myDeploy-1\",\"uid\":\"b780baac-ca27-4742-8649-e7af7b46fbb8\",\"apiVersion\":\"v1\",\"resourceVersion\":\"838023666\"}}\n",
+                            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container myDeploy; cpu limit for container myDeploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.name": "myDeploy-1",
+                            "openshift.io/scc": "restricted"
+                        },
+                        "creationTimestamp": "2018-01-25T20:40:05Z",
+                        "generateName": "myDeploy-1-",
+                        "labels": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "myspace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy-1-nfs9w",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "ReplicationController",
+                                "name": "myDeploy-1",
+                                "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                            }
+                        ],
+                        "resourceVersion": "838024574",
+                        "selfLink": "/api/v1/namespaces/my-run/pods/myDeploy-1-nfs9w",
+                        "uid": "f04e8f3b-5c4a-4ffd-94ec-0e8bcbc7b468"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "488m",
+                                        "memory": "250Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "29m",
+                                        "memory": "150Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {
+                                        "drop": [
+                                            "KILL",
+                                            "MKNOD",
+                                            "NET_RAW",
+                                            "SETGID",
+                                            "SETUID"
+                                        ]
+                                    },
+                                    "privileged": false,
+                                    "runAsUser": 123456,
+                                    "seLinuxOptions": {
+                                        "level": "s0:c123,c456"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                        "name": "default-token-jzp5t",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-k77kj"
+                            }
+                        ],
+                        "nodeName": "my.node",
+                        "nodeSelector": {
+                            "type": "compute"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {
+                            "fsGroup": 123456,
+                            "seLinuxOptions": {
+                                "level": "s0:c123,c456"
+                            }
+                        },
+                        "serviceAccount": "default",
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "default-token-jzp5t",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "default-token-jzp5t"
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "conditions": [
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:05Z",
+                                "status": "True",
+                                "type": "Initialized"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:25Z",
+                                "status": "True",
+                                "type": "Ready"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:05Z",
+                                "status": "True",
+                                "type": "PodScheduled"
+                            }
+                        ],
+                        "containerStatuses": [
+                            {
+                                "containerID": "docker://f425202d2f8e1758bd3e5fb681afeab5f4fdd4da93e57a0ea3b6819e40d6d39c",
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imageID": "docker-pullable://127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "lastState": {},
+                                "name": "myDeploy",
+                                "ready": true,
+                                "restartCount": 0,
+                                "state": {
+                                    "running": {
+                                        "startedAt": "2018-01-25T20:40:07Z"
+                                    }
+                                }
+                            }
+                        ],
+                        "hostIP": "127.0.0.4",
+                        "phase": "Running",
+                        "podIP": "127.0.0.5",
+                        "qosClass": "Burstable",
+                        "startTime": "2018-01-25T20:40:05Z"
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.2",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"my-run\",\"name\":\"myDeploy-1\",\"uid\":\"b780baac-ca27-4742-8649-e7af7b46fbb8\",\"apiVersion\":\"v1\",\"resourceVersion\":\"837362212\"}}\n",
+                            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container myDeploy; cpu limit for container myDeploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.name": "myDeploy-1",
+                            "openshift.io/scc": "restricted"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:06Z",
+                        "generateName": "myDeploy-1-",
+                        "labels": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "myspace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy-1-sdmzq",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "ReplicationController",
+                                "name": "myDeploy-1",
+                                "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                            }
+                        ],
+                        "resourceVersion": "837363149",
+                        "selfLink": "/api/v1/namespaces/my-run/pods/myDeploy-1-sdmzq",
+                        "uid": "447b7d6f-7072-4e9a-8cba-7e29c2f53761"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "488m",
+                                        "memory": "250Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "29m",
+                                        "memory": "150Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {
+                                        "drop": [
+                                            "KILL",
+                                            "MKNOD",
+                                            "NET_RAW",
+                                            "SETGID",
+                                            "SETUID"
+                                        ]
+                                    },
+                                    "privileged": false,
+                                    "runAsUser": 123456,
+                                    "seLinuxOptions": {
+                                        "level": "s0:c123,c456"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                        "name": "default-token-jzp5t",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-k77kj"
+                            }
+                        ],
+                        "nodeName": "my.node",
+                        "nodeSelector": {
+                            "type": "compute"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {
+                            "fsGroup": 123456,
+                            "seLinuxOptions": {
+                                "level": "s0:c123,c456"
+                            }
+                        },
+                        "serviceAccount": "default",
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "default-token-jzp5t",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "default-token-jzp5t"
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "conditions": [
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "Initialized"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:26Z",
+                                "status": "True",
+                                "type": "Ready"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "PodScheduled"
+                            }
+                        ],
+                        "containerStatuses": [
+                            {
+                                "containerID": "docker://e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317",
+                                "image": "127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imageID": "docker-pullable://127.0.0.1:5000/my-run/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "lastState": {},
+                                "name": "myDeploy",
+                                "ready": true,
+                                "restartCount": 0,
+                                "state": {
+                                    "running": {
+                                        "startedAt": "2018-01-25T16:33:08Z"
+                                    }
+                                }
+                            }
+                        ],
+                        "hostIP": "127.0.0.2",
+                        "phase": "Running",
+                        "podIP": "127.0.0.3",
+                        "qosClass": "Burstable",
+                        "startTime": "2018-01-25T16:33:06Z"
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myOtherDeploy/master-1.0.1",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myOtherDeploy\u0026var-version=1.0.1",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myOtherDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myOtherDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myOtherDeploy",
+                            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"my-run\",\"name\":\"myOtherDeploy-1\",\"uid\":\"51fbc77a-cca1-4fc7-8c13-b9a51753d5f6\",\"apiVersion\":\"v1\",\"resourceVersion\":\"837362212\"}}\n",
+                            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container myOtherDeploy; cpu limit for container myOtherDeploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myOtherDeploy",
+                            "openshift.io/deployment.name": "myOtherDeploy-1",
+                            "openshift.io/scc": "restricted"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:06Z",
+                        "generateName": "myOtherDeploy-1-",
+                        "labels": {
+                            "app": "myOtherDeploy",
+                            "deployment": "myOtherDeploy-1",
+                            "deploymentconfig": "myOtherDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "myspace",
+                            "version": "1.0.1"
+                        },
+                        "name": "myOtherDeploy-1-67kvt",
+                        "namespace": "my-run",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "ReplicationController",
+                                "name": "myOtherDeploy-1",
+                                "uid": "51fbc77a-cca1-4fc7-8c13-b9a51753d5f6"
+                            }
+                        ],
+                        "resourceVersion": "837363149",
+                        "selfLink": "/api/v1/namespaces/my-run/pods/myOtherDeploy-1-67kvt",
+                        "uid": "97a6923d-c0b1-4262-8f87-31c1a4153400"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myOtherDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "488m",
+                                        "memory": "250Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "29m",
+                                        "memory": "150Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {
+                                        "drop": [
+                                            "KILL",
+                                            "MKNOD",
+                                            "NET_RAW",
+                                            "SETGID",
+                                            "SETUID"
+                                        ]
+                                    },
+                                    "privileged": false,
+                                    "runAsUser": 123456,
+                                    "seLinuxOptions": {
+                                        "level": "s0:c123,c456"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                        "name": "default-token-jzp5t",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-k77kj"
+                            }
+                        ],
+                        "nodeName": "my.node",
+                        "nodeSelector": {
+                            "type": "compute"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {
+                            "fsGroup": 123456,
+                            "seLinuxOptions": {
+                                "level": "s0:c123,c456"
+                            }
+                        },
+                        "serviceAccount": "default",
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "default-token-jzp5t",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "default-token-jzp5t"
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "conditions": [
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "Initialized"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:26Z",
+                                "status": "True",
+                                "type": "Ready"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "PodScheduled"
+                            }
+                        ],
+                        "containerStatuses": [
+                            {
+                                "containerID": "docker://1f2946e2fd7d0be6c4295c1ed828f0ff4aec21e89df898f9efbaddbe445c5c7c",
+                                "image": "127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imageID": "docker-pullable://127.0.0.1:5000/my-run/myOtherDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "lastState": {},
+                                "name": "myOtherDeploy",
+                                "ready": true,
+                                "restartCount": 0,
+                                "state": {
+                                    "running": {
+                                        "startedAt": "2018-01-25T16:33:08Z"
+                                    }
+                                }
+                            }
+                        ],
+                        "hostIP": "127.0.0.12",
+                        "phase": "Running",
+                        "podIP": "127.0.0.13",
+                        "qosClass": "Burstable",
+                        "startTime": "2018-01-25T16:33:06Z"
+                    }
+                }
+            ],
+            "kind": "PodList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-stage/pods
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.3",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.3",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"my-stage\",\"name\":\"myDeploy-1\",\"uid\":\"b780baac-ca27-4742-8649-e7af7b46fbb8\",\"apiVersion\":\"v1\",\"resourceVersion\":\"838023666\"}}\n",
+                            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container myDeploy; cpu limit for container myDeploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.name": "myDeploy-1",
+                            "openshift.io/scc": "restricted"
+                        },
+                        "creationTimestamp": "2018-01-25T20:40:05Z",
+                        "generateName": "myDeploy-1-",
+                        "labels": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "myspace",
+                            "version": "1.0.3"
+                        },
+                        "name": "myDeploy-1-nfs9w",
+                        "namespace": "my-stage",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "ReplicationController",
+                                "name": "myDeploy-1",
+                                "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                            }
+                        ],
+                        "resourceVersion": "838024574",
+                        "selfLink": "/api/v1/namespaces/my-stage/pods/myDeploy-1-nfs9w",
+                        "uid": "f04e8f3b-5c4a-4ffd-94ec-0e8bcbc7b468"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "488m",
+                                        "memory": "250Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "29m",
+                                        "memory": "150Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {
+                                        "drop": [
+                                            "KILL",
+                                            "MKNOD",
+                                            "NET_RAW",
+                                            "SETGID",
+                                            "SETUID"
+                                        ]
+                                    },
+                                    "privileged": false,
+                                    "runAsUser": 123456,
+                                    "seLinuxOptions": {
+                                        "level": "s0:c123,c456"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                        "name": "default-token-jzp5t",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-k77kj"
+                            }
+                        ],
+                        "nodeName": "my.node",
+                        "nodeSelector": {
+                            "type": "compute"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {
+                            "fsGroup": 123456,
+                            "seLinuxOptions": {
+                                "level": "s0:c123,c456"
+                            }
+                        },
+                        "serviceAccount": "default",
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "default-token-jzp5t",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "default-token-jzp5t"
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "conditions": [
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:05Z",
+                                "status": "True",
+                                "type": "Initialized"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:25Z",
+                                "status": "True",
+                                "type": "Ready"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T20:40:05Z",
+                                "status": "True",
+                                "type": "PodScheduled"
+                            }
+                        ],
+                        "containerStatuses": [
+                            {
+                                "containerID": "docker://f425202d2f8e1758bd3e5fb681afeab5f4fdd4da93e57a0ea3b6819e40d6d39c",
+                                "image": "127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imageID": "docker-pullable://127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "lastState": {},
+                                "name": "myDeploy",
+                                "ready": true,
+                                "restartCount": 0,
+                                "state": {
+                                    "running": {
+                                        "startedAt": "2018-01-25T20:40:07Z"
+                                    }
+                                }
+                            }
+                        ],
+                        "hostIP": "127.0.0.4",
+                        "phase": "Running",
+                        "podIP": "127.0.0.5",
+                        "qosClass": "Burstable",
+                        "startTime": "2018-01-25T20:40:05Z"
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/git-branch": "myUser/myDeploy/master-1.0.3",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/metrics-path": "dashboard/file/kubernetes-pods.json/?var-project=myDeploy\u0026var-version=1.0.3",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"my-stage\",\"name\":\"myDeploy-1\",\"uid\":\"b780baac-ca27-4742-8649-e7af7b46fbb8\",\"apiVersion\":\"v1\",\"resourceVersion\":\"837362212\"}}\n",
+                            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container myDeploy; cpu limit for container myDeploy",
+                            "openshift.io/deployment-config.latest-version": "1",
+                            "openshift.io/deployment-config.name": "myDeploy",
+                            "openshift.io/deployment.name": "myDeploy-1",
+                            "openshift.io/scc": "restricted"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:06Z",
+                        "deletionTimestamp": "2018-01-26T16:33:06Z",
+                        "generateName": "myDeploy-1-",
+                        "labels": {
+                            "app": "myDeploy",
+                            "deployment": "myDeploy-1",
+                            "deploymentconfig": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "myspace",
+                            "version": "1.0.3"
+                        },
+                        "name": "myDeploy-1-sdmzq",
+                        "namespace": "my-stage",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "blockOwnerDeletion": true,
+                                "controller": true,
+                                "kind": "ReplicationController",
+                                "name": "myDeploy-1",
+                                "uid": "b780baac-ca27-4742-8649-e7af7b46fbb8"
+                            }
+                        ],
+                        "resourceVersion": "837363149",
+                        "selfLink": "/api/v1/namespaces/my-stage/pods/myDeploy-1-sdmzq",
+                        "uid": "447b7d6f-7072-4e9a-8cba-7e29c2f53761"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "myDeploy",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9779,
+                                        "name": "prometheus",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "488m",
+                                        "memory": "250Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "29m",
+                                        "memory": "150Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {
+                                        "drop": [
+                                            "KILL",
+                                            "MKNOD",
+                                            "NET_RAW",
+                                            "SETGID",
+                                            "SETUID"
+                                        ]
+                                    },
+                                    "privileged": false,
+                                    "runAsUser": 123456,
+                                    "seLinuxOptions": {
+                                        "level": "s0:c123,c456"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                        "name": "default-token-jzp5t",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-k77kj"
+                            }
+                        ],
+                        "nodeName": "my.node",
+                        "nodeSelector": {
+                            "type": "compute"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {
+                            "fsGroup": 123456,
+                            "seLinuxOptions": {
+                                "level": "s0:c123,c456"
+                            }
+                        },
+                        "serviceAccount": "default",
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "default-token-jzp5t",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "default-token-jzp5t"
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "conditions": [
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "Initialized"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:26Z",
+                                "status": "True",
+                                "type": "Ready"
+                            },
+                            {
+                                "lastProbeTime": null,
+                                "lastTransitionTime": "2018-01-25T16:33:06Z",
+                                "status": "True",
+                                "type": "PodScheduled"
+                            }
+                        ],
+                        "containerStatuses": [
+                            {
+                                "containerID": "docker://e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317",
+                                "image": "127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "imageID": "docker-pullable://127.0.0.1:5000/my-stage/myDeploy@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+                                "lastState": {},
+                                "name": "myDeploy",
+                                "ready": true,
+                                "restartCount": 0,
+                                "state": {
+                                    "running": {
+                                        "startedAt": "2018-01-25T16:33:08Z"
+                                    }
+                                }
+                            }
+                        ],
+                        "hostIP": "127.0.0.2",
+                        "phase": "Running",
+                        "podIP": "127.0.0.3",
+                        "qosClass": "Burstable",
+                        "startTime": "2018-01-25T16:33:06Z"
+                    }
+                }
+            ],
+            "kind": "PodList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+  # Services
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/services
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/exposeUrl": "http://myOtherDeploy-my-run.example.com",
+                            "fabric8.io/git-branch": "ebaron/myOtherDeploy/master-1.0.1",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myOtherDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myOtherDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myOtherDeploy",
+                            "prometheus.io/port": "9779",
+                            "prometheus.io/scrape": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:29:24Z",
+                        "labels": {
+                            "app": "myOtherDeploy",
+                            "expose": "true",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.1"
+                        },
+                        "name": "myOtherDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837351634",
+                        "selfLink": "/api/v1/namespaces/my-run/services/myOtherDeploy",
+                        "uid": "b8a09642-a164-4491-a3b5-9e990e977bab"
+                    },
+                    "spec": {
+                        "clusterIP": "127.0.0.102",
+                        "ports": [
+                            {
+                                "name": "http",
+                                "port": 8080,
+                                "protocol": "TCP",
+                                "targetPort": 8080
+                            }
+                        ],
+                        "selector": {
+                            "app": "myOtherDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "sessionAffinity": "None",
+                        "type": "ClusterIP"
+                    },
+                    "status": {
+                        "loadBalancer": {}
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "annotations": {
+                            "fabric8.io/exposeUrl": "http://myDeploy-my-run.example.com",
+                            "fabric8.io/git-branch": "ebaron/myDeploy/master-1.0.2",
+                            "fabric8.io/git-commit": "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+                            "fabric8.io/iconUrl": "img/icon.svg",
+                            "fabric8.io/scm-con-url": "scm:git:https://example.com/myDeploy",
+                            "fabric8.io/scm-devcon-url": "scm:git:git:@example.com/myDeploy",
+                            "fabric8.io/scm-tag": "myTag",
+                            "fabric8.io/scm-url": "https://example.com/myDeploy",
+                            "prometheus.io/port": "9779",
+                            "prometheus.io/scrape": "true"
+                        },
+                        "creationTimestamp": "2018-01-25T16:33:02Z",
+                        "labels": {
+                            "app": "myDeploy",
+                            "expose": "true",
+                            "group": "myGroup",
+                            "provider": "fabric8",
+                            "space": "mySpace",
+                            "version": "1.0.2"
+                        },
+                        "name": "myDeploy",
+                        "namespace": "my-run",
+                        "resourceVersion": "837362353",
+                        "selfLink": "/api/v1/namespaces/my-run/services/myDeploy",
+                        "uid": "f4e6e2b2-f86d-4e78-94e5-079bb3f0b05d"
+                    },
+                    "spec": {
+                        "clusterIP": "127.0.0.101",
+                        "ports": [
+                            {
+                                "name": "http",
+                                "port": 8080,
+                                "protocol": "TCP",
+                                "targetPort": 8080
+                            }
+                        ],
+                        "selector": {
+                            "app": "myDeploy",
+                            "group": "myGroup",
+                            "provider": "fabric8"
+                        },
+                        "sessionAffinity": "None",
+                        "type": "ClusterIP"
+                    },
+                    "status": {
+                        "loadBalancer": {}
+                    }
+                }
+            ],
+            "kind": "ServiceList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-stage/services
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [],
+            "kind": "ServiceList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
   # Resource Quotas
 - request:
     body: ""
@@ -41,8 +3071,8 @@ interactions:
                             "limits.memory": "1Gi"
                         },
                         "used": {
-                            "limits.cpu": "488m",
-                            "limits.memory": "250Mi"
+                            "limits.cpu": "1.9",
+                            "limits.memory": "950Mi"
                         }
                     }
                 },
@@ -108,12 +3138,12 @@ interactions:
                     "apiVersion": "v1",
                     "kind": "ResourceQuota",
                     "metadata": {
-                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "creationTimestamp": "2017-05-10T20:06:15Z",
                         "name": "compute-resources",
                         "namespace": "my-stage",
-                        "resourceVersion": "1048952505",
-                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
-                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                        "resourceVersion": "1066766807",
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/compute-resources",
+                        "uid": "b72ae154-730d-470d-b610-d34a6a7d271c"
                     },
                     "spec": {
                         "hard": {
@@ -130,8 +3160,8 @@ interactions:
                             "limits.memory": "1Gi"
                         },
                         "used": {
-                            "limits.cpu": "488m",
-                            "limits.memory": "250Mi"
+                            "limits.cpu": "976m",
+                            "limits.memory": "500Mi"
                         }
                     }
                 },
@@ -141,10 +3171,10 @@ interactions:
                     "metadata": {
                         "creationTimestamp": "2017-05-10T20:06:06Z",
                         "name": "object-counts",
-                        "namespace": "my-run",
+                        "namespace": "my-stage",
                         "resourceVersion": "1117398667",
-                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
-                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                        "selfLink": "/api/v1/namespaces/my-stage/resourcequotas/object-counts",
+                        "uid": "74ad59a6-3071-454b-a719-7c07a3a8e7df"
                     },
                     "spec": {
                         "hard": {
@@ -162,9 +3192,9 @@ interactions:
                             "services": "5"
                         },
                         "used": {
-                            "persistentvolumeclaims": "1",
-                            "replicationcontrollers": "2",
-                            "secrets": "11",
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "5",
+                            "secrets": "9",
                             "services": "2"
                         }
                     }

--- a/test/kubernetes/getspaceandotherenvironmentusage.yaml
+++ b/test/kubernetes/getspaceandotherenvironmentusage.yaml
@@ -1,0 +1,271 @@
+---
+version: 1
+interactions:
+  # Resource Quotas
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-run/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "name": "compute-resources",
+                        "namespace": "my-run",
+                        "resourceVersion": "1048952505",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
+                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "488m",
+                            "limits.memory": "250Mi"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-run",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
+                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "2",
+                            "secrets": "11",
+                            "services": "2"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/my-stage/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:14Z",
+                        "name": "compute-resources",
+                        "namespace": "my-stage",
+                        "resourceVersion": "1048952505",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/compute-resources",
+                        "uid": "d87810f4-fe36-4d39-9df0-43f08e676c1e"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "488m",
+                            "limits.memory": "250Mi"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "my-run",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/my-run/resourcequotas/object-counts",
+                        "uid": "4921ce39-c361-43b2-81bd-f3cc066e1f0d"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "2",
+                            "secrets": "11",
+                            "services": "2"
+                        }
+                    }
+                }
+            ],
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: http://api.myCluster/api/v1/namespaces/myNamespace/resourcequotas
+    method: GET
+  response:
+    body: |
+        {
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "compute-resources",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "682306837",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/compute-resources",
+                        "uid": "4a83f394-7081-4a54-ac01-7c9ea16e4ac5"
+                    },
+                    "spec": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "scopes": [
+                            "NotTerminating"
+                        ]
+                    },
+                    "status": {
+                        "hard": {
+                            "limits.cpu": "2",
+                            "limits.memory": "1Gi"
+                        },
+                        "used": {
+                            "limits.cpu": "0.2",
+                            "limits.memory": "250Mi"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "ResourceQuota",
+                    "metadata": {
+                        "creationTimestamp": "2017-05-10T20:06:06Z",
+                        "name": "object-counts",
+                        "namespace": "myNamespace",
+                        "resourceVersion": "1117398667",
+                        "selfLink": "/api/v1/namespaces/myNamespace/resourcequotas/object-counts",
+                        "uid": "2928ac2c-d240-4582-a4fb-a0edf65c8069"
+                    },
+                    "spec": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        }
+                    },
+                    "status": {
+                        "hard": {
+                            "persistentvolumeclaims": "1",
+                            "replicationcontrollers": "20",
+                            "secrets": "20",
+                            "services": "5"
+                        },
+                        "used": {
+                            "persistentvolumeclaims": "0",
+                            "replicationcontrollers": "1",
+                            "secrets": "12",
+                            "services": "1"
+                        }
+                    }
+                }
+            ], 
+            "kind": "ResourceQuotaList",
+            "metadata": {},
+            "resourceVersion": "",
+            "selfLink": ""
+        }
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    status: 200 OK
+    code: 200


### PR DESCRIPTION
This PR adds a deployments-related API under `/deployments/environments/spaces/:spaceID`. This endpoint returns resource usage for each of the user's environments, divided into usage by the specified space and usage by all other spaces combined. Currently this only returns CPU and memory usage, and not objects such as pods or secrets.

There is an older `/deployments/spaces/:spaceID/environments` endpoint which has been left for backwards compatibility until the front-end is switched over completely.

Example usage:
Request: `GET https://openshift.io/api/deployments/environments/spaces/$SPACE_ID`
Response:
```json

{
  "data": [
    {
      "attributes": {
        "name": "run",
        "other_usage": {
          "cpucores": {
            "quota": 2,
            "used": 0.488
          },
          "memory": {
            "quota": 1073741824,
            "used": 262144000
          },
          "persistent_volume_claims": {
            "quota": 1,
            "used": 0
          },
          "replication_controllers": {
            "quota": 20,
            "used": 6
          },
          "secrets": {
            "quota": 20,
            "used": 9
          },
          "services": {
            "quota": 5,
            "used": 3
          }
        },
        "space_usage": {
          "cpucores": 1.488,
          "memory": 799014912
        }
      },
      "id": "run",
      "type": "environment"
    },
    {
      "attributes": {
        "name": "stage",
        "other_usage": {
          "cpucores": {
            "quota": 2,
            "used": 0.488
          },
          "memory": {
            "quota": 1073741824,
            "used": 262144000
          },
          "persistent_volume_claims": {
            "quota": 1,
            "used": 0
          },
          "replication_controllers": {
            "quota": 20,
            "used": 7
          },
          "secrets": {
            "quota": 20,
            "used": 9
          },
          "services": {
            "quota": 5,
            "used": 3
          }
        },
        "space_usage": {
          "cpucores": 1.488,
          "memory": 799014912
        }
      },
      "id": "stage",
      "type": "environment"
    }
  ]
}
```

This work was started by @chrislessard, which I have put the finishing touches on and opened the PR on his behalf.

Fixes: https://github.com/openshiftio/openshift.io/issues/3129