### PR TITLE
Add number_sequences table and nullable 'number' column on areas and iterations tables

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -463,7 +463,7 @@ func GetMigrations() Migrations {
 	m = append(m, steps{ExecuteSQLFile("108-number-column-for-area.sql")})
 
 	// Version 109
-	m = append(m, steps{ExecuteSQLFile("108-number-column-for-iteration.sql")})
+	m = append(m, steps{ExecuteSQLFile("109-number-column-for-iteration.sql")})
 
 	// Version N
 	//

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -456,6 +456,15 @@ func GetMigrations() Migrations {
 	// Version 106
 	m = append(m, steps{ExecuteSQLFile("106-remove-link-category-concept.sql")})
 
+	// Version 107
+	m = append(m, steps{ExecuteSQLFile("107-number-sequences-table.sql")})
+
+	// Version 108
+	m = append(m, steps{ExecuteSQLFile("108-number-column-for-area.sql")})
+
+	// Version 109
+	m = append(m, steps{ExecuteSQLFile("108-number-column-for-iteration.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -1370,7 +1370,7 @@ func testMigration106RemoveLinkCategoryConcept(t *testing.T) {
 
 func testMigration107NumberSequencesTable(t *testing.T) {
 	migrateToVersion(t, sqlDB, migrations[:108], 108)
-	require.True(t, dialect.HasTable("number_sequences_table"))
+	require.True(t, dialect.HasTable("number_sequences"))
 }
 
 func testMigration108NumberColumnForArea(t *testing.T) {

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -158,7 +158,7 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMirgraion106", testMigration106RemoveLinkCategoryConcept)
 	t.Run("TestMirgraion107", testMigration107NumberSequencesTable)
 	t.Run("TestMirgraion108", testMigration108NumberColumnForArea)
-	t.Run("TestMirgraion109", testMigration109NumberColumnForArea)
+	t.Run("TestMirgraion109", testMigration109NumberColumnForIteration)
 
 	// Perform the migration
 	err = migration.Migrate(sqlDB, databaseName)

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -156,6 +156,9 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMirgraion104", testMigration104IndexOnWIRevisionTable)
 	t.Run("TestMirgraion105", testMigration105UpdateRootIterationAreaPathField)
 	t.Run("TestMirgraion106", testMigration106RemoveLinkCategoryConcept)
+	t.Run("TestMirgraion107", testMigration107NumberSequencesTable)
+	t.Run("TestMirgraion108", testMigration108NumberColumnForArea)
+	t.Run("TestMirgraion109", testMigration109NumberColumnForArea)
 
 	// Perform the migration
 	err = migration.Migrate(sqlDB, databaseName)
@@ -1363,6 +1366,21 @@ func testMigration106RemoveLinkCategoryConcept(t *testing.T) {
 		require.True(t, exists(t, "work_item_link_types", linkType1ID))
 		require.True(t, exists(t, "work_item_link_types", linkType2ID))
 	})
+}
+
+func testMigration107NumberSequencesTable(t *testing.T) {
+	migrateToVersion(t, sqlDB, migrations[:108], 108)
+	require.True(t, dialect.HasTable("number_sequences_table"))
+}
+
+func testMigration108NumberColumnForArea(t *testing.T) {
+	migrateToVersion(t, sqlDB, migrations[:109], 109)
+	require.True(t, dialect.HasColumn("areas", "number"))
+}
+
+func testMigration109NumberColumnForIteration(t *testing.T) {
+	migrateToVersion(t, sqlDB, migrations[:110], 110)
+	require.True(t, dialect.HasColumn("iterations", "number"))
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/sql-files/107-number-sequences-table.sql
+++ b/migration/sql-files/107-number-sequences-table.sql
@@ -1,0 +1,7 @@
+ -- Create the number_sequences table
+CREATE TABLE number_sequences (
+    space_id uuid REFERENCES spaces(id) ON DELETE CASCADE,
+    table_name text CHECK (trim(table_name::text) <> ''),
+    current_val INTEGER NOT NULL,
+    PRIMARY KEY (space_id, table_name)
+);

--- a/migration/sql-files/108-number-column-for-area.sql
+++ b/migration/sql-files/108-number-column-for-area.sql
@@ -1,0 +1,1 @@
+ALTER TABLE areas ADD COLUMN number INTEGER;

--- a/migration/sql-files/109-number-column-for-iteration.sql
+++ b/migration/sql-files/109-number-column-for-iteration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE iterations ADD COLUMN number INTEGER;


### PR DESCRIPTION
This adds back the `number_sequences` table the `number` columns on the `areas` and `iterations` tables (known from #2287 but then reverted). But it does this in three individual steps. This change is backwards compatible with the old code as the `number` column is nullable. Except for this structural change, no data is changed.
