### PR TITLE
Update 105-update-root-area-and-iteration-path-field.sql

### DIFF
--- a/migration/sql-files/105-update-root-area-and-iteration-path-field.sql
+++ b/migration/sql-files/105-update-root-area-and-iteration-path-field.sql
@@ -1,10 +1,10 @@
--- append ID to non-root iteration and area paths
-UPDATE iterations SET path=text2ltree(concat(path, concat('.',replace(cast(id as text), '-', '_')))) WHERE path!='' AND path IS NOT NULL;
-UPDATE areas SET path=text2ltree(concat(path, concat('.',replace(cast(id as text), '-', '_')))) WHERE path!='' AND path IS NOT NULL;
-
 -- drop constraints
 ALTER TABLE iterations DROP CONSTRAINT iterations_name_space_id_path_unique;
 ALTER TABLE areas DROP CONSTRAINT areas_name_space_id_path_unique;
+
+-- append ID to non-root iteration and area paths
+UPDATE iterations SET path=text2ltree(concat(path, concat('.',replace(cast(id as text), '-', '_')))) WHERE path!='' AND path IS NOT NULL;
+UPDATE areas SET path=text2ltree(concat(path, concat('.',replace(cast(id as text), '-', '_')))) WHERE path!='' AND path IS NOT NULL;
 
 -- update root iteration and area paths to use converted ids
 UPDATE iterations SET path=text2ltree(replace(cast(id as text), '-', '_')) WHERE path='' OR PATH IS NULL;


### PR DESCRIPTION
Based on [this discussion](https://chat.openshift.io/developers/pl/6m4cojtiotdoueqot8uww5ybpe) we first remove the unique name index on the `iterations` and `areas` table before we modify the data.

In a previous attempt (https://github.com/fabric8-services/fabric8-wit/pull/2312) I haven't moved the removal of the index enough up.

This should fix the migration issue that was visible here: https://github.com/openshiftio/saas-openshiftio/pull/1082