### PR TITLE
update number for existing iterations

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -465,6 +465,9 @@ func GetMigrations() Migrations {
 	// Version 109
 	m = append(m, steps{ExecuteSQLFile("109-number-column-for-iteration.sql")})
 
+	// Version 110
+	m = append(m, steps{ExecuteSQLFile("110-update-number-for-existing-iterations.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -1386,7 +1386,7 @@ func testMigration109NumberColumnForIteration(t *testing.T) {
 
 func testMigration110UpdateNumberForExistingIterations(t *testing.T) {
 	t.Run("migrate to previous version", func(t *testing.T) {
-		migrateToVersion(t, sqlDB, migrations[:110, 110)
+		migrateToVersion(t, sqlDB, migrations[:110], 110)
 	})
 
 	spaceTemplateID := uuid.NewV4()

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -155,10 +155,15 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration103", testMigration103NotNullNotEmptyonEmail)
 	t.Run("TestMirgraion104", testMigration104IndexOnWIRevisionTable)
 	t.Run("TestMirgraion105", testMigration105UpdateRootIterationAreaPathField)
+<<<<<<< HEAD
 	t.Run("TestMirgraion106", testMigration106RemoveLinkCategoryConcept)
 	t.Run("TestMirgraion107", testMigration107NumberSequencesTable)
 	t.Run("TestMirgraion108", testMigration108NumberColumnForArea)
 	t.Run("TestMirgraion109", testMigration109NumberColumnForIteration)
+||||||| parent of a917dfe4... Introduce number column for area and iteration and allow searching it (#2287)
+=======
+	t.Run("TestMirgraion106", testMigration106NumberSequences)
+>>>>>>> a917dfe4... Introduce number column for area and iteration and allow searching it (#2287)
 
 	// Perform the migration
 	err = migration.Migrate(sqlDB, databaseName)
@@ -1381,6 +1386,83 @@ func testMigration108NumberColumnForArea(t *testing.T) {
 func testMigration109NumberColumnForIteration(t *testing.T) {
 	migrateToVersion(t, sqlDB, migrations[:110], 110)
 	require.True(t, dialect.HasColumn("iterations", "number"))
+}
+
+func testMigration110UpdateNumberForExistingIterations(t *testing.T) {
+	t.Run("migrate to previous version", func(t *testing.T) {
+		migrateToVersion(t, sqlDB, migrations[:110, 110)
+	})
+
+	spaceTemplateID := uuid.NewV4()
+	space1ID := uuid.NewV4()
+	space2ID := uuid.NewV4()
+	// two iterations in space 1
+	iter1ID := uuid.NewV4()
+	iter2ID := uuid.NewV4()
+	// two iterations in space 2
+	iter3ID := uuid.NewV4()
+	iter4ID := uuid.NewV4()
+
+	t.Run("setup test data to migrate", func(t *testing.T) {
+		require.Nil(t, runSQLscript(sqlDB, "110-update-number-for-existing-iterations.sql",
+			spaceTemplateID.String(),
+			space1ID.String(),
+			space2ID.String(),
+			iter1ID.String(),
+			iter2ID.String(),
+			iter3ID.String(),
+			iter4ID.String(),
+		))
+	})
+
+	// Helper functions
+
+	getNumberOf := func(t *testing.T, table string, id uuid.UUID) int {
+		q := fmt.Sprintf("SELECT number FROM %s WHERE id = $1", table)
+		row := sqlDB.QueryRow(q, id)
+		require.NotNil(t, row)
+		var p int32
+		err := row.Scan(&p)
+		require.NoError(t, err, "%+v", err)
+		return int(p)
+	}
+	getNumberOfIteration := func(t *testing.T, iterID uuid.UUID) int { return getNumberOf(t, "iterations", iterID) }
+
+	t.Run("migrate to current version", func(t *testing.T) {
+		migrateToVersion(t, sqlDB, migrations[:111], 111)
+	})
+
+	t.Run("checks after migration", func(t *testing.T) {
+		// check that the newest iteration/area has the smaller number and that
+		// the numbering is partitioned by space_id
+		assert.Equal(t, 2, getNumberOfIteration(t, iter1ID))
+		assert.Equal(t, 1, getNumberOfIteration(t, iter2ID))
+		assert.Equal(t, 2, getNumberOfIteration(t, iter3ID))
+		assert.Equal(t, 1, getNumberOfIteration(t, iter4ID))
+
+		// check that the sequences table has the expected values
+		type numberSequence struct {
+			spaceID    uuid.UUID
+			tableName  string
+			currentVal int
+		}
+		rows, err := sqlDB.Query("SELECT space_id, table_name, current_val FROM number_sequences WHERE space_id IN ($1, $2)", space1ID, space2ID)
+		require.NoError(t, err)
+		defer rows.Close()
+		toBeFound := map[numberSequence]struct{}{
+			{space1ID, "iterations", 2}: {},
+			{space2ID, "iterations", 2}: {},
+		}
+		for rows.Next() {
+			seq := numberSequence{}
+			err := rows.Scan(&seq.spaceID, &seq.tableName, &seq.currentVal)
+			require.NoError(t, err)
+			delete(toBeFound, seq)
+		}
+		require.Empty(t, toBeFound, "failed to find these number sequences: %+v", spew.Sdump(toBeFound))
+
+		require.True(t, dialect.HasIndex("iterations", "iterations_space_id_number_idx"))
+	})
 }
 
 // runSQLscript loads the given filename from the packaged SQL test files and

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -155,15 +155,11 @@ func TestMigrations(t *testing.T) {
 	t.Run("TestMigration103", testMigration103NotNullNotEmptyonEmail)
 	t.Run("TestMirgraion104", testMigration104IndexOnWIRevisionTable)
 	t.Run("TestMirgraion105", testMigration105UpdateRootIterationAreaPathField)
-<<<<<<< HEAD
 	t.Run("TestMirgraion106", testMigration106RemoveLinkCategoryConcept)
 	t.Run("TestMirgraion107", testMigration107NumberSequencesTable)
 	t.Run("TestMirgraion108", testMigration108NumberColumnForArea)
 	t.Run("TestMirgraion109", testMigration109NumberColumnForIteration)
-||||||| parent of a917dfe4... Introduce number column for area and iteration and allow searching it (#2287)
-=======
-	t.Run("TestMirgraion106", testMigration106NumberSequences)
->>>>>>> a917dfe4... Introduce number column for area and iteration and allow searching it (#2287)
+	t.Run("TestMirgraion110", testMigration110UpdateNumberForExistingIterations)
 
 	// Perform the migration
 	err = migration.Migrate(sqlDB, databaseName)

--- a/migration/sql-files/110-update-number-for-existing-iterations.sql
+++ b/migration/sql-files/110-update-number-for-existing-iterations.sql
@@ -1,0 +1,20 @@
+-- Assign a number to every existing iteration partitioned by their space and in
+-- ascending creation order.
+UPDATE iterations SET number = seq.row_number
+FROM (
+    SELECT id, space_id, created_at, row_number() OVER (PARTITION BY space_id ORDER BY created_at ASC)
+    FROM iterations
+) AS seq
+WHERE iterations.id = seq.id;
+
+-- Make "number" a required column and add an index for faster querying over
+-- "space_id" and "number".
+ALTER TABLE iterations ALTER COLUMN number SET NOT NULL;
+ALTER TABLE iterations ADD CONSTRAINT iterations_space_id_number_idx UNIQUE (space_id, number);
+
+-- Update the "number_sequences" table with the maximum for iterations.
+INSERT INTO number_sequences (space_id, table_name, current_val)
+    SELECT space_id, 'iterations' "table_name", MAX(number)
+    FROM iterations
+    WHERE number IS NOT NULL
+    GROUP BY 1,2;

--- a/migration/sql-test-files/110-update-number-for-existing-iterations.sql
+++ b/migration/sql-test-files/110-update-number-for-existing-iterations.sql
@@ -1,0 +1,25 @@
+SET sp_template.id = '{{index . 0}}';
+SET sp1.id = '{{index . 1}}';
+SET sp2.id = '{{index . 2}}';
+
+SET iter1.id = '{{index . 3}}';
+SET iter2.id = '{{index . 4}}';
+SET iter3.id = '{{index . 5}}';
+SET iter4.id = '{{index . 6}}';
+
+-- create space template
+INSERT INTO space_templates (id,name,description)
+    VALUES(current_setting('sp_template.id')::uuid, current_setting('sp_template.id'), 'test template');
+
+-- create two spaces
+INSERT INTO spaces (id,name,space_template_id) 
+    VALUES
+        (current_setting('sp1.id')::uuid, current_setting('sp1.id'), current_setting('sp_template.id')::uuid),
+        (current_setting('sp2.id')::uuid, current_setting('sp2.id'), current_setting('sp_template.id')::uuid);
+
+INSERT INTO iterations (id, name, path, space_id, created_at) 
+VALUES 
+    (current_setting('iter1.id')::uuid, 'iteration 1', replace(current_setting('iter1.id'), '-', '_')::ltree, current_setting('sp1.id')::uuid, '2018-09-17 16:01'),
+    (current_setting('iter2.id')::uuid, 'iteration 2', replace(current_setting('iter2.id'), '-', '_')::ltree, current_setting('sp1.id')::uuid, '2018-09-17 15:01'),
+    (current_setting('iter3.id')::uuid, 'iteration 3', replace(current_setting('iter3.id'), '-', '_')::ltree, current_setting('sp2.id')::uuid, '2018-09-17 16:01'),
+    (current_setting('iter4.id')::uuid, 'iteration 4', replace(current_setting('iter4.id'), '-', '_')::ltree, current_setting('sp2.id')::uuid, '2018-09-17 15:01');


### PR DESCRIPTION
This updates all existing iterations and assigns a number to each iteration partitioned by space and in ascending order by creation time.

This change also makes the number a not-NULLable column on the iterations.

Also a constraint (`iterations_space_id_number_idx`) is created that ensures an iteration number can only occur once per iteration.