### PR TITLE
Make agile default template for space creation

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -237,7 +237,7 @@ func (s *searchControllerTestSuite) searchByURL(customHost, queryString string) 
 	return mt
 }
 
-// verifySearchByKnownURLs performs actual tests on search result and knwonURL map
+// verifySearchByKnownURLs performs actual tests on search result and knownURL map
 func (s *searchControllerTestSuite) verifySearchByKnownURLs(wi *workitem.WorkItem, host, searchQuery string) {
 	result := s.searchByURL(host, searchQuery)
 	assert.NotEmpty(s.T(), result.Data)
@@ -250,7 +250,7 @@ func (s *searchControllerTestSuite) verifySearchByKnownURLs(wi *workitem.WorkIte
 	assert.Contains(s.T(), known[search.HostRegistrationKeyForBoardWI].URLRegex, host)
 }
 
-// TestAutoRegisterHostURL checks if client's host is neatly registered as a KnwonURL or not
+// TestAutoRegisterHostURL checks if client's host is neatly registered as a KnownURL or not
 // Uses helper functions verifySearchByKnownURLs, searchByURL
 func (s *searchControllerTestSuite) TestAutoRegisterHostURL() {
 	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItems(1))

--- a/controller/space.go
+++ b/controller/space.go
@@ -92,8 +92,8 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 			ID:      spaceID,
 			Name:    spaceName,
 			OwnerID: *currentUser,
-			// Default to legacy space template to avoid breaking the API
-			SpaceTemplateID: spacetemplate.SystemLegacyTemplateID,
+			// Default to Agile space template
+			SpaceTemplateID: spacetemplate.SystemAgileTemplateID,
 		}
 		if reqSpace.Attributes.Description != nil {
 			newSpace.Description = *reqSpace.Attributes.Description


### PR DESCRIPTION
With this PR
 - The default template used for space creation would be `Agile`.

The only relevant change is https://github.com/fabric8-services/fabric8-wit/pull/2323/commits/306a8f3781f0bddf154e62e8f4547bf87a687445. 

Rest of the changes are fixes to the tests which depended on the default template. I've changed them to use `fxt.WorkitemTypes` instead of `workitem.SystemFeature/workitem.SystemBug`

See https://github.com/fabric8-services/fabric8-wit/issues/2317 and https://github.com/openshiftio/openshift.io/issues/4427
