### PR TITLE
Use default failureThreshold value

### DIFF
--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -166,7 +166,7 @@ objects:
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
-            failureThreshold: 120
+            failureThreshold: 3
             httpGet:
               path: /api/status
               port: 8080


### PR DESCRIPTION
The deployment was successful with https://github.com/fabric8-services/fabric8-wit/pull/2327. We don't need `failureThreshold:120` which is 
```
Minimum consecutive failures for the probe to be considered failed after having succeeded
```
from https://docs.openshift.com/container-platform/3.5/rest_api/openshift_v1.html#v1-probe 


This PR changes the failureThreshold value back to its default value which was changed in https://github.com/fabric8-services/fabric8-wit/pull/2298 and https://github.com/fabric8-services/fabric8-wit/pull/2295

Also see https://github.com/fabric8-services/fabric8-wit/issues/2291