### PR TITLE
Add 'None' as default resolution for defect

### DIFF
--- a/controller/test-files/work_item_type/list/ok_agile.res.payload.golden.json
+++ b/controller/test-files/work_item_type/list/ok_agile.res.payload.golden.json
@@ -442,6 +442,7 @@
               "baseType": "string",
               "kind": "enum",
               "values": [
+                "None",
                 "Done",
                 "Duplicate",
                 "Incomplete Description",

--- a/spacetemplate/assets/agile.yaml
+++ b/spacetemplate/assets/agile.yaml
@@ -150,6 +150,7 @@ work_item_types:
         base_type:
           kind: string
         values:
+        - None
         - Done
         - Duplicate
         - Incomplete Description

--- a/spacetemplate/importer/repository_blackbox_test.go
+++ b/spacetemplate/importer/repository_blackbox_test.go
@@ -141,6 +141,15 @@ func (s *repoSuite) TestImport() {
 					Kind: workitem.KindString,
 				},
 			}
+			// Test that new values are allowed in enum fields
+			stateField, ok := templ.WITs[0].Fields["state"]
+			require.True(t, ok, "failed to find 'state' field")
+			enumType, ok := stateField.Type.(workitem.EnumType)
+			require.True(t, ok, "failed to convert state field type to enum type")
+			enumType.Values = append(enumType.Values, "case closed")
+			stateField.Type = enumType
+			templ.WITs[0].Fields["state"] = stateField
+
 			templ.WITGs[0].Name = "Helmet"
 			templ.WIBs[0].Name = "Sword"
 			// when
@@ -167,6 +176,11 @@ func (s *repoSuite) TestImport() {
 					obj, ok := wit.Fields["flavor"]
 					require.True(t, ok, "flavor field not found in %+v", wit.Fields)
 					require.NotNil(t, obj)
+				})
+				t.Run("\"state\" field changed enum values", func(t *testing.T) {
+					enumType, ok := templ.WITs[0].Fields["state"].Type.(workitem.EnumType)
+					require.True(t, ok, "failed to convert state field to enum type")
+					require.Equal(t, []interface{}{"new", "closed", "case closed"}, enumType.Values)
 				})
 			})
 			t.Run("WILT name has changed", func(t *testing.T) {


### PR DESCRIPTION
Add `None` to a Defect's resolution in the Agile space template and make it the default resolution by putting it in first place.

See https://github.com/openshiftio/openshift.io/issues/3832