### PR TITLE
Fixup for bbd8f88c789943293680644ae8a49b5342a55575 #2334

### DIFF
--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -162,19 +162,20 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 
 					// When comparing the new and old field types we don't want
 					// to compare the default value. That is why we always
-					// overwrite the default value of the old type with the
-					// default value of the new type.
+					// overwrite the default value of the new type with the
+					// default value of the old type.
 
-					defVal := fd.Type.GetDefaultValue()
-					oldFieldType, err = oldFieldType.SetDefaultValue(defVal)
+					// remember new default value
+					oldDefVal := oldFieldType.GetDefaultValue()
+					newFieldType, err := fd.Type.SetDefaultValue(oldDefVal)
 					if err != nil {
-						return errs.Wrapf(err, "failed to overwrite default of old field type with %+v (%[1]T)", defVal)
+						return errs.Wrapf(err, "failed to temporarily overwrite default of new field type with %+v (%[1]T)", oldDefVal)
 					}
 
-					if equal := fd.Type.Equal(oldFieldType); !equal {
+					if equal := newFieldType.Equal(oldFieldType); !equal {
 						// Special treatment for EnumType
 						origEnum, ok1 := oldFieldType.(workitem.EnumType)
-						newEnum, ok2 := fd.Type.(workitem.EnumType)
+						newEnum, ok2 := newFieldType.(workitem.EnumType)
 						if ok1 && ok2 {
 							equal = newEnum.EqualEnclosing(origEnum)
 						}


### PR DESCRIPTION
Previously the [deployment failed](https://github.com/fabric8-services/fabric8-wit/pull/2334#issuecomment-433887438):

```
failed to overwrite default of old field type with None (string):
failed to set default value of enum type to None (string):
value: None (string) is not part of allowed enum values:
[Done Duplicate Incomplete Description Can not Reproduce Deferred Won't Fix Out of Date Verified]
file: spacetemplate/importer/repository.go
line: 91
```

We've updated the resolution enum to
have a new value and that is also the new default. That new value didn't
exist in the old enum type but we tried to make it the new default for
the old type anyways. That didn't work because the `FieldType.SetDefault()`
implementation for enums checks if the given value is part of the
allowed enum values.

The overall intention is to check if too enums are the same but ignore
the default value. That is why we temporarily make both defaults the
same before we call `FieldType.Equal()`.

With this change we simply reverse the assignment of the new default to
the old type. Instead we temporarily assign the old default to the new
type. The result is that a call to `FieldType.Equal()` will return true.