### PR TITLE
Cleanup golden files comparison and generation by introducing compareOptions

### DIFF
--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -23,7 +23,8 @@ import (
 
 var updateGoldenFiles = flag.Bool("update", false, "when set, rewrite the golden files")
 
-// CompareOptions define how the comparison will take place
+// CompareOptions define how the comparison and golden file generation will take
+// place
 type CompareOptions struct {
 	// Whether or not to ignore UUIDs when comparing or writing the golden file
 	// to disk
@@ -50,11 +51,12 @@ func compareWithGolden(t *testing.T, goldenFile string, actualObj interface{}, o
 	}
 }
 
-// compareWithGoldenAgnostic does the same as compareWithGolden but it replaces UUIDs in both
-// strings (the golden file as well as in the actual object) before comparing
-// the two strings. This should make the comparison UUID agnostic without
-// loosing the locality comparison. In other words, that means we replace each
-// UUID with a more generic "00000000-0000-0000-0000-000000000001",
+// compareWithGoldenAgnostic does the same as compareWithGolden but it replaces
+// UUIDs in both strings (the golden file as well as in the actual object)
+// before comparing the two strings. This should make the comparison UUID
+// agnostic without loosing the locality comparison. In other words, that means
+// we replace each UUID with a more generic
+// "00000000-0000-0000-0000-000000000001",
 // "00000000-0000-0000-0000-000000000002", ...,
 // "00000000-0000-0000-0000-00000000000N" value.
 //

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -110,7 +110,7 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 			return errs.WithStack(err)
 		}
 	} else {
-		switch t := actual.(type) {
+		switch t := actualObj.(type) {
 		case []byte:
 			actual = t
 		case string:
@@ -133,7 +133,7 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 				return errs.Wrap(err, "failed to replace UUIDs with more generic ones")
 			}
 		}
-		if ots.DateTimeAgnostic {
+		if opts.DateTimeAgnostic {
 			tmp, err = replaceTimes(tmp)
 			if err != nil {
 				return errs.Wrap(err, "failed to replace RFC3339 times with default time")
@@ -431,14 +431,14 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 		{UUIDAgnostic: false, DateTimeAgnostic: false, MarshalInputAsJSON: true},
 		{UUIDAgnostic: false, DateTimeAgnostic: false, MarshalInputAsJSON: false},
 	}
-	for _, agnostic := range agnosticVals {
+	for _, opts := range agnosticOpts {
 		t.Run("file not found", func(t *testing.T) {
 			// given
 			f := "not_existing_file.golden.json"
 			// when
-			actualObj := dummy
+			var data interface{} = dummy
 			if !opts.MarshalInputAsJSON {
-				actualObj = dummyStr
+				data = dummyStr
 			}
 			err := testableCompareWithGolden(false, f, data, opts)
 			// then
@@ -450,7 +450,7 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 			// given
 			f := "not/existing/folder/file.golden.json"
 			// when
-			data := dummy
+			var data interface{} = dummy
 			if !opts.MarshalInputAsJSON {
 				data = dummyStr
 			}
@@ -466,7 +466,7 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 			// given
 			f := "test-files/codebase/show/ok_without_auth.golden.json"
 			// when
-			data := dummy
+			var data interface{} = dummy
 			if !opts.MarshalInputAsJSON {
 				data = dummyStr
 			}

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -24,9 +24,9 @@ import (
 
 var updateGoldenFiles = flag.Bool("update", false, "when set, rewrite the golden files")
 
-// CompareOptions define how the comparison and golden file generation will take
+// compareOptions define how the comparison and golden file generation will take
 // place
-type CompareOptions struct {
+type compareOptions struct {
 	// Whether or not to ignore UUIDs when comparing or writing the golden file
 	// to disk
 	UUIDAgnostic bool
@@ -46,7 +46,7 @@ type CompareOptions struct {
 // file is overwritten with the current actual object. When adding new tests you
 // first must run them with the -update flag in order to create an initial
 // golden version.
-func compareWithGoldenOpts(t *testing.T, goldenFile string, actualObj interface{}, opts CompareOptions) {
+func compareWithGoldenOpts(t *testing.T, goldenFile string, actualObj interface{}, opts compareOptions) {
 	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, opts))
 }
 
@@ -57,7 +57,7 @@ func compareWithGoldenOpts(t *testing.T, goldenFile string, actualObj interface{
 // actual object. When adding new tests you first must run them with the -update
 // flag in order to create an initial golden version.
 func compareWithGolden(t *testing.T, goldenFile string, actualObj interface{}) {
-	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, CompareOptions{MarshalInputAsJSON: true}))
+	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, compareOptions{MarshalInputAsJSON: true}))
 }
 
 // compareWithGoldenAgnostic does the same as compareWithGolden but after
@@ -72,7 +72,7 @@ func compareWithGolden(t *testing.T, goldenFile string, actualObj interface{}) {
 // In addition to UUID replacement, we also replace all RFC3339 time strings
 // with "0001-01-01T00:00:00Z".
 func compareWithGoldenAgnostic(t *testing.T, goldenFile string, actualObj interface{}) {
-	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, CompareOptions{
+	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, compareOptions{
 		UUIDAgnostic:       true,
 		DateTimeAgnostic:   true,
 		MarshalInputAsJSON: true,
@@ -82,7 +82,7 @@ func compareWithGoldenAgnostic(t *testing.T, goldenFile string, actualObj interf
 // compareWithGoldenAgnosticUUID is only agnostic to UUIDs apart from that it is
 // the same as compareWithGoldenAgnostic.
 func compareWithGoldenAgnosticUUID(t *testing.T, goldenFile string, actualObj interface{}) {
-	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, CompareOptions{
+	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, compareOptions{
 		UUIDAgnostic:       true,
 		MarshalInputAsJSON: true,
 	}))
@@ -91,13 +91,13 @@ func compareWithGoldenAgnosticUUID(t *testing.T, goldenFile string, actualObj in
 // compareWithGoldenAgnosticTime is only agnostic to times apart from that it is
 // the same as compareWithGoldenAgnostic.
 func compareWithGoldenAgnosticTime(t *testing.T, goldenFile string, actualObj interface{}) {
-	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, CompareOptions{
+	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, compareOptions{
 		DateTimeAgnostic:   true,
 		MarshalInputAsJSON: true,
 	}))
 }
 
-func testableCompareWithGolden(update bool, goldenFile string, actualObj interface{}, opts CompareOptions) error {
+func testableCompareWithGolden(update bool, goldenFile string, actualObj interface{}, opts compareOptions) error {
 	absPath, err := filepath.Abs(goldenFile)
 	if err != nil {
 		return errs.WithStack(err)
@@ -421,7 +421,7 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 	dummy := Foo{Bar: "hello world", ID: uuid.NewV4()}
 	dummyStr := uuid.NewV4().String()
 
-	agnosticOpts := []CompareOptions{
+	agnosticOpts := []compareOptions{
 		{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: true},
 		{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: false},
 		{UUIDAgnostic: true, DateTimeAgnostic: false, MarshalInputAsJSON: true},
@@ -494,13 +494,13 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 		t.Run("comparing with the same object", func(t *testing.T) {
 			t.Run("not agnostic", func(t *testing.T) {
 				// when
-				err = testableCompareWithGolden(false, f, dummy, CompareOptions{MarshalInputAsJSON: true})
+				err = testableCompareWithGolden(false, f, dummy, compareOptions{MarshalInputAsJSON: true})
 				// then
 				require.NoError(t, err)
 			})
 			t.Run("agnostic", func(t *testing.T) {
 				// when
-				err = testableCompareWithGolden(false, f, dummy, CompareOptions{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: true})
+				err = testableCompareWithGolden(false, f, dummy, compareOptions{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: true})
 				// then
 				require.NoError(t, err)
 			})
@@ -509,13 +509,13 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 			dummy.ID = uuid.NewV4()
 			t.Run("not agnostic", func(t *testing.T) {
 				// when
-				err = testableCompareWithGolden(false, f, dummy, CompareOptions{MarshalInputAsJSON: true})
+				err = testableCompareWithGolden(false, f, dummy, compareOptions{MarshalInputAsJSON: true})
 				// then
 				require.Error(t, err)
 			})
 			t.Run("agnostic", func(t *testing.T) {
 				// when
-				err = testableCompareWithGolden(false, f, dummy, CompareOptions{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: true})
+				err = testableCompareWithGolden(false, f, dummy, compareOptions{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: true})
 				// then
 				require.NoError(t, err)
 			})
@@ -524,13 +524,13 @@ func TestGoldenCompareWithGolden(t *testing.T) {
 			dummy.CreatedAt = time.Now()
 			t.Run("not agnostic", func(t *testing.T) {
 				// when
-				err = testableCompareWithGolden(false, f, dummy, CompareOptions{MarshalInputAsJSON: true})
+				err = testableCompareWithGolden(false, f, dummy, compareOptions{MarshalInputAsJSON: true})
 				// then
 				require.Error(t, err)
 			})
 			t.Run("agnostic", func(t *testing.T) {
 				// when
-				err = testableCompareWithGolden(false, f, dummy, CompareOptions{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: true})
+				err = testableCompareWithGolden(false, f, dummy, compareOptions{UUIDAgnostic: true, DateTimeAgnostic: true, MarshalInputAsJSON: true})
 				// then
 				require.NoError(t, err)
 			})

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -44,8 +44,8 @@ type CompareOptions struct {
 // is given, that golden file is overwritten with the current actual object.
 // When adding new tests you first must run them with the -update flag in order
 // to create an initial golden version.
-func compareWithGolden(t *testing.T, goldenFile string, actualObj interface{}, opts CompareOptions) {
-	err := testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, opts)
+func compareWithGolden(t *testing.T, goldenFile string, actualObj interface{}) {
+	err := testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, CompareOptions{MarshalInputAsJSON: true})
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/controller/golden_files_test.go
+++ b/controller/golden_files_test.go
@@ -110,7 +110,12 @@ func testableCompareWithGolden(update bool, goldenFile string, actualObj interfa
 			return errs.WithStack(err)
 		}
 	} else {
-		actual = []byte(actual)
+		switch t := actual.(type) {
+		case []byte:
+			actual = t
+		case string:
+			actual = []byte(t)
+		}
 	}
 	if update {
 		// Make sure the directory exists where to write the file to


### PR DESCRIPTION
Before we used to have a list of booleans in order to configure the comparison and generation of golden files. Now we have a defined set of comparison options:

```go
// compareOptions define how the comparison and golden file generation will take
// place
type compareOptions struct {
	// Whether or not to ignore UUIDs when comparing or writing the golden file
	// to disk
	UUIDAgnostic bool
	// Whether or not to ignore date/times when comparing or writing the golden
	// file to disk
	DateTimeAgnostic bool
	// Whether or not to call JSON marshall on the actual object before
	// comparing it against the content of the golden file or writing to the
	// golden file. If this is false, then we will treat the actual object as a
	// []byte or string.
	MarshalInputAsJSON bool
}
```

And a new compare function:

```go
// compareWithGoldenOpts compares the actual object against the one from a
// golden file and let's you specify the options to be used for comparison and
// golden file production by hand. If the -update flag is given, that golden
// file is overwritten with the current actual object. When adding new tests you
// first must run them with the -update flag in order to create an initial
// golden version.
func compareWithGoldenOpts(t *testing.T, goldenFile string, actualObj interface{}, opts compareOptions) {
	require.NoError(t, testableCompareWithGolden(*updateGoldenFiles, goldenFile, actualObj, opts))
}
```

The changes being made to the rest of the code are just to there to keep the old compare functions in tact.