### PR TITLE
Do not run parallel integration test

### DIFF
--- a/.make/test.mk
+++ b/.make/test.mk
@@ -91,6 +91,10 @@ COVERAGE_MODE ?= set
 # But if you want you can enable that by setting GO_TEST_VERBOSITY_FLAG=-v
 GO_TEST_VERBOSITY_FLAG ?= 
 
+# Set the test binaries, that can be run in parallel.
+# The default is the number of CPUs available.
+GO_TEST_BINARIES_PARALLEL_FLAG ?= -p 1
+
 # By default use the "localhost" or specify manually during make invocation:
 #
 # 	F8_POSTGRES_HOST=somehost make test-integration
@@ -169,7 +173,7 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_BINARIES_PARALLEL_FLAG) $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 test-integration-benchmark: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running benchmarks: $@")


### PR DESCRIPTION
* Please describe what your change is about.
Test integration regularly failed with:
```
--- FAIL: TestJSONAPICompliance (0.70s)
    --- FAIL: TestJSONAPICompliance/TestListSpaces (0.11s)
```
https://github.com/fabric8-services/fabric8-wit/blob/master/controller/json_api_compliance_test.go#L67 
The failure is intermittent and seems to occurs bc the of the state of the DB
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
The proposal is to run integration test (only test requiring DB) forcing them to run on 1 program/test binaries.
```
> go help build
...
 -p n
                the number of programs, such as build commands or
                test binaries, that can be run in parallel.
                The default is the number of CPUs available.
...
```
* If you are still working on the change please prefix the pull request title with "WIP"
