### PR TITLE
SDD Template is now legacy

### DIFF
--- a/spacetemplate/assets/legacy.yaml
+++ b/spacetemplate/assets/legacy.yaml
@@ -7,7 +7,7 @@ space_template:
     scenarios that are described in the language and from the viewpoint of the
     user. Scenarios deliver particular value propositions and are realized
     through experiences.
-  can_construct: yes
+  can_construct: no
 
 work_item_types:
 


### PR DESCRIPTION
This sets `can_create` to `no` for the SDD template, effectively making it unavailable for new Spaces.
