### PR TITLE
Add swagger_ui to macOS doker-compose

### DIFF
--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -37,3 +37,9 @@ services:
       - "8089:8089"
     depends_on:
       - db-auth
+  swagger_ui:
+    image: swaggerapi/swagger-ui:latest
+    ports:
+    - "8081:8080"
+    environment:
+      API_URL: "http://localhost:8080/api/swagger.json"


### PR DESCRIPTION
* Please describe what your change is about.

When running `make dev` on macOS, this error is reported:
```
ERROR: No such service: swagger_ui
make: *** [docker-compose-up] Error 1
```
this error was introduce by https://github.com/fabric8-services/fabric8-wit/pull/2217 in the PR the macOS file was missed.

* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))

Updating the macOs file fix the issue.

* If you are still working on the change please prefix the pull request title with "WIP"
