### PR TITLE
Enables searching of workitems by trackerquery id

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -2002,7 +2002,7 @@ func TestWorkItemInterfaceSliceSort(t *testing.T) {
 	})
 }
 
-func (s *searchControllerTestSuite) TestSearchByTrackerQuery(t *testing.T) {
+func (s *searchControllerTestSuite) TestSearchByTrackerQuery() {
 	fxt := tf.NewTestFixture(s.T(), s.DB,
 		tf.Spaces(1),
 		tf.WorkItemTypes(1),

--- a/workitem/expression_compiler.go
+++ b/workitem/expression_compiler.go
@@ -202,6 +202,13 @@ var DefaultTableJoins = func() TableJoinMap {
 			PrefixActivators: []string{"label."},
 			AllowedColumns:   []string{"name"},
 		},
+		"trackerquery": {
+			TableName:        "tracker_queries",
+			TableAlias:       "tq",
+			On:               JoinOnJSONField(SystemRemoteTrackerID, "tq.id") + " AND " + Column("tq", "space_id") + "=" + Column(WorkItemStorage{}.TableName(), "space_id"),
+			PrefixActivators: []string{"trackerquery."},
+			AllowedColumns:   []string{"id"},
+		},
 	}
 
 	res["typegroup_members"] = &TableJoin{


### PR DESCRIPTION
This PR enables searching workitems by trackerquery ID.

[1]  Adds Tracker Query table details, alias in expression compiler.
[2] Tests for the same