### PR TITLE
Delete trackerquery

### DIFF
--- a/controller/trackerquery_blackbox_test.go
+++ b/controller/trackerquery_blackbox_test.go
@@ -20,6 +20,7 @@ import (
 	testsupport "github.com/fabric8-services/fabric8-wit/test"
 	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
 	testtoken "github.com/fabric8-services/fabric8-wit/test/token"
+	"github.com/fabric8-services/fabric8-wit/workitem"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 
@@ -30,9 +31,11 @@ import (
 
 type TestTrackerQueryREST struct {
 	gormtestsupport.DBTestSuite
-	RwiScheduler *remoteworkitem.Scheduler
-	db           *gormapplication.GormDB
-	authService  auth.AuthService
+	RwiScheduler  *remoteworkitem.Scheduler
+	db            *gormapplication.GormDB
+	authService   auth.AuthService
+	workitemCtrl  app.WorkitemController
+	workitemsCtrl app.WorkitemsController
 }
 
 func TestRunTrackerQueryREST(t *testing.T) {
@@ -43,17 +46,14 @@ func (s *TestTrackerQueryREST) SetupTest() {
 	s.DBTestSuite.SetupTest()
 	s.RwiScheduler = remoteworkitem.NewScheduler(s.DB)
 	s.db = gormapplication.NewGormDB(s.DB)
+	s.workitemCtrl = NewWorkitemController(s.svc, s.GormDB, s.Configuration)
+	s.workitemsCtrl = NewWorkitemsController(s.svc, s.GormDB, s.Configuration)
 }
 
 type testAuthService struct{}
 
 func (s *testAuthService) RequireScope(ctx context.Context, resourceID, requiredScope string) error {
 	return nil
-}
-
-func (s *TestTrackerQueryREST) SecuredController() (*goa.Service, *TrackerController, *TrackerqueryController) {
-	svc := testsupport.ServiceAsUser("TrackerQuery-Service", testsupport.TestIdentity)
-	return svc, NewTrackerController(svc, s.db, s.RwiScheduler, s.Configuration), NewTrackerqueryController(svc, s.db, s.RwiScheduler, s.Configuration, &testAuthService{})
 }
 
 func (s *TestTrackerQueryREST) UnSecuredController() (*goa.Service, *TrackerController, *TrackerqueryController) {
@@ -274,4 +274,75 @@ func (s *TestTrackerQueryREST) TestDeleteTrackerQuery() {
 		require.NotNil(t, err)
 		require.IsType(t, strconv.Itoa(http.StatusUnauthorized), *err.Errors[0].Status)
 	})
+
+	t.Run("delete remoteworkitems - true", func(t *testing.T) {
+		fxt := tf.NewTestFixture(s.T(), s.DB,
+			tf.Spaces(1),
+			tf.WorkItemTypes(1),
+			tf.Trackers(1),
+			tf.TrackerQueries(2),
+			tf.WorkItems(3, func(fxt *tf.TestFixture, idx int) error {
+				switch idx {
+				case 0, 1:
+					fxt.WorkItems[idx].Fields[workitem.SystemRemoteTrackerID] = fxt.TrackerQueries[0].ID
+				default:
+					fxt.WorkItems[idx].Fields[workitem.SystemRemoteTrackerID] = fxt.TrackerQueries[1].ID
+				}
+				return nil
+			}),
+		)
+		assert.NotNil(s.T(), fxt.Spaces, fxt.Trackers, fxt.WorkItemTypes, fxt.TrackerQueries, fxt.WorkItems)
+		s.svc = testsupport.ServiceAsUser("TestDeleteTrackerQuery-Service", *fxt.Identities[0])
+
+		_, result := test.ListWorkitemsOK(t, s.svc.Context, s.svc, s.workitemsCtrl, fxt.Spaces[0].ID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.Len(t, result.Data, 3)
+
+		err := test.DeleteTrackerqueryOK(t, s.svc.Context, s.svc, s.trackerqueryCtrl, fxt.TrackerQueries[0].ID, true)
+		require.NotNil(t, err)
+
+		_, result = test.ListWorkitemsOK(t, s.svc.Context, s.svc, s.workitemsCtrl, fxt.Spaces[0].ID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.Len(t, result.Data, 1)
+
+		_, jerr := test.ShowWorkitemNotFound(t, s.svc.Context, s.svc, s.workitemCtrl, fxt.WorkItems[0].ID, nil, nil)
+		require.NotNil(t, jerr)
+
+		_, jerr = test.ShowWorkitemNotFound(t, s.svc.Context, s.svc, s.workitemCtrl, fxt.WorkItems[1].ID, nil, nil)
+		require.NotNil(t, jerr)
+	})
+
+	t.Run("delete remoteworkitems - false", func(t *testing.T) {
+		fxt := tf.NewTestFixture(s.T(), s.DB,
+			tf.Spaces(1),
+			tf.WorkItemTypes(1),
+			tf.Trackers(1),
+			tf.TrackerQueries(2),
+			tf.WorkItems(3, func(fxt *tf.TestFixture, idx int) error {
+				switch idx {
+				case 0, 1:
+					fxt.WorkItems[idx].Fields[workitem.SystemRemoteTrackerID] = fxt.TrackerQueries[0].ID
+				default:
+					fxt.WorkItems[idx].Fields[workitem.SystemRemoteTrackerID] = fxt.TrackerQueries[1].ID
+				}
+				return nil
+			}),
+		)
+		assert.NotNil(s.T(), fxt.Spaces, fxt.Trackers, fxt.WorkItemTypes, fxt.TrackerQueries, fxt.WorkItems)
+		s.svc = testsupport.ServiceAsUser("TestDeleteTrackerQuery-Service", *fxt.Identities[0])
+
+		_, result := test.ListWorkitemsOK(t, s.svc.Context, s.svc, s.workitemsCtrl, fxt.Spaces[0].ID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.Len(t, result.Data, 3)
+
+		err := test.DeleteTrackerqueryOK(t, s.svc.Context, s.svc, s.trackerqueryCtrl, fxt.TrackerQueries[0].ID, false)
+		require.NotNil(t, err)
+
+		_, result = test.ListWorkitemsOK(t, s.svc.Context, s.svc, s.workitemsCtrl, fxt.Spaces[0].ID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.Len(t, result.Data, 3)
+
+		_, jerr := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workitemCtrl, fxt.WorkItems[0].ID, nil, nil)
+		require.NotNil(t, jerr)
+
+		_, jerr = test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workitemCtrl, fxt.WorkItems[1].ID, nil, nil)
+		require.NotNil(t, jerr)
+	})
+
 }

--- a/design/tracker_queries.go
+++ b/design/tracker_queries.go
@@ -96,8 +96,10 @@ var _ = a.Resource("trackerquery", func() {
 		a.Description("Delete tracker query.")
 		a.Params(func() {
 			a.Param("id", d.UUID, "id")
+			a.Param("delete-wi", d.Boolean, "delete workitems")
+			a.Required("id", "delete-wi")
 		})
-		a.Response(d.NoContent)
+		a.Response(d.OK)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)


### PR DESCRIPTION
https://openshift.io/openshiftio/Openshift_io/plan/detail/1103

[1] Provides a boolean flag option along with trackerquery deletion 

```
curl -X DELETE  <..>/api/trackerqueries/<trackerquery_id>?delete-wi=true -H "Authorization: Bearer $TOKEN"
```

[2] If `delete-wi` is true, all remoteworkitems in the system which were fetched through that trackerquery are deleted

[3] If `delete-wi` is false, only the trackerquery is deleted. 
remoteworkitems still remain in the system.