### PR TITLE
Delete workspaces: Don't rely on links in the list workspaces response

### DIFF
--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/fabric8-services/fabric8-wit/account"
 	"github.com/fabric8-services/fabric8-wit/app"
@@ -253,23 +252,20 @@ func (c *CodebaseController) Delete(ctx *app.DeleteCodebaseContext) error {
 	}
 	log.Info(ctx, nil, "Found %d workspaces to delete", len(workspaces))
 	for _, workspace := range workspaces {
-		for _, link := range workspace.Links {
-			if strings.ToLower(link.Method) == "delete" {
-				log.Info(ctx,
-					map[string]interface{}{"codebase_url": cb.URL,
-						"che_namespace": ns,
-						"workspace":     workspace.Config.Name,
-					}, "About to delete Che workspace")
-				err = cheClient.DeleteWorkspace(ctx.Context, workspace.Config.Name)
-				if err != nil {
-					log.Error(ctx,
-						map[string]interface{}{
-							"codebase_url":  cb.URL,
-							"che_namespace": ns,
-							"workspace":     workspace.Config.Name},
-						"failed to delete Che workspace: %s", err.Error())
-				}
-			}
+		log.Info(ctx,
+			map[string]interface{}{"codebase_url": cb.URL,
+				"che_namespace": ns,
+				"workspace":     workspace.Config.Name,
+			}, "About to delete Che workspace")
+		err = cheClient.DeleteWorkspace(ctx.Context, workspace.Config.Name)
+		if err != nil {
+			log.Error(ctx,
+				map[string]interface{}{
+					"codebase_url":  cb.URL,
+					"che_namespace": ns,
+					"workspace":     workspace.Config.Name},
+				"failed to delete Che workspace: %s", err.Error(),
+			)
 		}
 	}
 

--- a/test/data/che/che_delete_codebase_workspaces.ok.yaml
+++ b/test/data/che/che_delete_codebase_workspaces.ok.yaml
@@ -64,13 +64,7 @@ interactions:
       ]
     },
     "id": "string",
-    "links": [
-      {
-        "href": "che-server/workspace?masterUrl=https://tsrv.devshift.net:8443&namespace=foo&repository=git@github.com:bar/foo",
-        "method": "DELETE",
-        "rel": "delete"
-      }
-    ],
+    "links": [],
     "runtime": {
       "devMachine": {
         "runtime": {


### PR DESCRIPTION
The response for workspace list returned from che starter does not contain a delete link.
This PR removes the check for the delete link in the response payload.


Fixes https://github.com/openshiftio/openshift.io/issues/4559